### PR TITLE
fix: use cross-platform npx command in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "gitnexus": {
       "type": "stdio",
-      "command": "cmd",
-      "args": ["/c", "npx", "-y", "gitnexus@latest", "mcp"]
+      "command": "npx",
+      "args": ["-y", "gitnexus@latest", "mcp"]
     }
   }
 }


### PR DESCRIPTION
Replace Windows-specific `cmd /c npx` invocation with portable `npx` command that works on macOS, Linux, and Windows.

Fixes #47

Generated with [Claude Code](https://claude.ai/code)