### PR TITLE
Fix TypeError: bar.log is not a function in analyze command

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -93,7 +93,14 @@ export const analyzeCommand = async (
   const origLog = console.log.bind(console);
   const origWarn = console.warn.bind(console);
   const origError = console.error.bind(console);
-  const barLog = (...args: any[]) => (bar as any).log(args.map(a => (typeof a === 'string' ? a : String(a))).join(' '));
+  const barLog = (...args: any[]) => {
+        const msg = args.map(a => (typeof a === 'string' ? a : String(a))).join(' ');
+        if ((bar as any).log) {
+            (bar as any).log(msg);
+        } else {
+            origLog(msg);
+        }
+    };
   console.log = barLog;
   console.warn = barLog;
   console.error = barLog;


### PR DESCRIPTION
This PR adds a safety check for the bar.log method in the analyze command. In some environments or versions of cli-progress, the log method might not be available on the SingleBar instance, causing a TypeError. This fix falls back to the original console.log if bar.log is missing, ensuring the tool doesn't crash during the scanning phase.

---

```cmd
npx gitnexus analyze

  GitNexus Analyzer

  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   1% | Scanning filesfile:///C:/Users/***/AppData/Local/nvm/v22.14.0/node_modules/gitnexus/dist/cli/analyze.js:78
    const barLog = (...args) => bar.log(args.map(a => (typeof a === 'string' ? a : String(a))).join(' '));
                                    ^

TypeError: bar.log is not a function
    at console.barLog (file:///C:/Users/***/AppData/Local/nvm/v22.14.0/node_modules/gitnexus/dist/cli/analyze.js:78:37)
    at walkRepository (file:///C:/Users/***/AppData/Local/nvm/v22.14.0/node_modules/gitnexus/dist/core/ingestion/filesystem-walker.js:42:17)
    at async runPipelineFromRepo (file:///C:/Users/***/AppData/Local/nvm/v22.14.0/node_modules/gitnexus/dist/core/ingestion/pipeline.js:31:23)
    at async Command.analyzeCommand (file:///C:/Users/***/AppData/Local/nvm/v22.14.0/node_modules/gitnexus/dist/cli/analyze.js:112:28)   

Node.js v22.14.0
```