### PR TITLE
fix(cli): sync version number between package.json and CLI

### DIFF
--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -37,7 +37,7 @@ const program = new Command();
 program
   .name('gitnexus')
   .description('GitNexus local CLI and MCP server')
-  .version('1.2.0');
+  .version('1.3.3');
 
 program
   .command('setup')


### PR DESCRIPTION
The CLI was displaying version 1.2.0 while package.json was at 1.3.3. This fixes the inconsistency to avoid user confusion.