### PR TITLE
feat(ingestion): add AST decorator-based entrypoint hints

### DIFF
--- a/gitnexus/src/core/graph/types.ts
+++ b/gitnexus/src/core/graph/types.ts
@@ -42,6 +42,9 @@ export type NodeProperties = {
   endLine?: number,
   language?: string,
   isExported?: boolean,
+  // Optional AST-derived framework hint (e.g. @Controller, @GetMapping)
+  astFrameworkMultiplier?: number,
+  astFrameworkReason?: string,
   // Community-specific properties
   heuristicLabel?: string,
   cohesion?: number,

--- a/gitnexus/src/core/ingestion/process-processor.ts
+++ b/gitnexus/src/core/ingestion/process-processor.ts
@@ -285,7 +285,7 @@ const findEntryPoints = (
     if (callees.length === 0) continue;
 
     // Calculate entry point score using new scoring system
-    const { score, reasons } = calculateEntryPointScore(
+    const { score: baseScore, reasons } = calculateEntryPointScore(
       node.properties.name,
       node.properties.language || 'javascript',
       node.properties.isExported ?? false,
@@ -293,6 +293,13 @@ const findEntryPoints = (
       callees.length,
       filePath  // Pass filePath for framework detection
     );
+
+    let score = baseScore;
+    const astFrameworkMultiplier = node.properties.astFrameworkMultiplier ?? 1.0;
+    if (astFrameworkMultiplier > 1.0) {
+      score *= astFrameworkMultiplier;
+      reasons.push(`framework-ast:${node.properties.astFrameworkReason || 'decorator'}`);
+    }
 
     if (score > 0) {
       entryPointCandidates.push({ id: node.id, score, reasons });


### PR DESCRIPTION
## Description

This PR implements AST-based framework hint detection for decorator/annotation-driven entrypoints and wires it into process entrypoint scoring.

Before this change, framework awareness was path-only (e.g. `/controllers/`, `views.py`, `*Controller.java`).  
Now we also detect framework signals from definition text (decorators/annotations/attributes), so entrypoint ranking is less dependent on folder naming conventions.

## What Changed

- Added AST framework detection:
  - `detectFrameworkFromAST(language, definitionText)`
  - File: `gitnexus/src/core/ingestion/framework-detection.ts`
- Extended node properties with AST hint metadata:
  - `astFrameworkMultiplier`
  - `astFrameworkReason`
  - File: `gitnexus/src/core/graph/types.ts`
- Integrated AST detection into parsing (both paths):
  - Sequential parser: `gitnexus/src/core/ingestion/parsing-processor.ts`
  - Worker parser: `gitnexus/src/core/ingestion/workers/parse-worker.ts`
- Applied AST hint multiplier in process entrypoint scoring:
  - File: `gitnexus/src/core/ingestion/process-processor.ts`

## Supported AST Hints (this PR)

- TypeScript/JavaScript: NestJS decorators (`@Controller`, `@Get`, `@Post`, etc.)
- Python: FastAPI / Flask decorators (`@app.get`, `@router.get`, `@app.route`, etc.)
- Java: Spring / JAX-RS annotations (`@RestController`, `@GetMapping`, `@GET`, etc.)
- C#: ASP.NET attributes (`[ApiController]`, `[HttpGet]`, `[HttpPost]`, etc.)
- PHP: Laravel/PHP route patterns (`Route::get`, `#[Route(...)]`, etc.)

## Why Not Full Semantic Decorator Parsing (in this PR)

This PR intentionally uses AST-text pattern hints instead of full framework-specific semantic parsing because:

- **Cross-language cost**: full semantic parsing must be implemented and maintained separately per framework/language.
- **Grammar/version fragility**: strict decorator AST handling is more sensitive to parser/grammar evolution.
- **Performance target**: ingestion is optimized for broad, fast indexing; full semantic extraction would increase complexity and parse overhead.
- **Incremental delivery**: this change provides immediate entrypoint-quality gains with low risk, while keeping room for language-by-language semantic upgrades.

In short: this is a pragmatic step that improves signal now, without overfitting the ingestion pipeline to a few frameworks.

## Scope / Non-Goals

- No full semantic route/decorator model in this PR.
- Detection is currently pattern-based on AST definition text.
- No new CLI flags/options introduced.

## Validation

- `npm run build` passed in `gitnexus/`.
- Spot checks of `detectFrameworkFromAST(...)` returned expected hints for:
  - NestJS (TS)
  - Spring (Java)
  - ASP.NET (C#)
