### PR TITLE
fix(web): map API path field to repoPath in fetchRepoInfo

### DIFF
--- a/gitnexus-web/src/services/server-connection.ts
+++ b/gitnexus-web/src/services/server-connection.ts
@@ -69,7 +69,9 @@ export async function fetchRepoInfo(baseUrl: string, repoName?: string): Promise
   if (!response.ok) {
     throw new Error(`Server returned ${response.status}: ${response.statusText}`);
   }
-  return response.json();
+  const data = await response.json();
+  // npm gitnexus@1.3.3 returns "path"; git HEAD returns "repoPath"
+  return { ...data, repoPath: data.repoPath ?? data.path };
 }
 
 export async function fetchGraph(


### PR DESCRIPTION
## Problem

When connecting the web UI to a local `gitnexus serve` backend, clicking "Connect" crashes with:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'split')
    at App.tsx:138:34
```

**Root cause:** The npm-published backend (`gitnexus@1.3.3`) `GET /api/repo` returns `path`, but `ServerRepoInfo` expects `repoPath`. The `fetchRepoInfo` function passes the raw JSON through without field mapping, so `result.repoInfo.repoPath` is `undefined`, and `App.tsx:138` calls `.split('/')` on it.

## Fix

Use spread operator to preserve all API fields, only overriding `repoPath` with `data.repoPath ?? data.path` for backwards compatibility with both npm `1.3.3` (`path`) and git HEAD (`repoPath`).

## Testing

1. `gitnexus serve` → running on `http://localhost:4747`
2. `cd gitnexus-web && npm run dev` → running on `http://localhost:5173`
3. Enter `http://localhost:4747` in the connection field → graph loads successfully

Supersedes #98. Fixes #92