### PR TITLE
fix: reject write operations in Cypher query endpoints

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -652,8 +652,15 @@ export class LocalBackend {
     return this.cypher(repo, { query });
   }
 
+  /** Reject Cypher queries that attempt to mutate the graph. */
+  private static readonly WRITE_PATTERN = /\b(CREATE|DELETE|SET|REMOVE|MERGE|DROP|ALTER|DETACH|COPY|CALL)\b/i;
+
   private async cypher(repo: RepoHandle, params: { query: string }): Promise<any> {
     await this.ensureInitialized(repo.id);
+
+    if (LocalBackend.WRITE_PATTERN.test(params.query)) {
+      return { error: 'Write operations are not allowed. Only read-only MATCH/RETURN queries are permitted.' };
+    }
 
     if (!isKuzuReady(repo.id)) {
       return { error: 'KuzuDB not ready. Index may be corrupted.' };

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -187,12 +187,20 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
     }
   });
 
+  // Reject Cypher queries that attempt to mutate the graph
+  const WRITE_PATTERN = /\b(CREATE|DELETE|SET|REMOVE|MERGE|DROP|ALTER|DETACH|COPY|CALL)\b/i;
+
   // Execute Cypher query
   app.post('/api/query', async (req, res) => {
     try {
       const cypher = req.body.cypher as string;
       if (!cypher) {
         res.status(400).json({ error: 'Missing "cypher" in request body' });
+        return;
+      }
+
+      if (WRITE_PATTERN.test(cypher)) {
+        res.status(403).json({ error: 'Write operations are not allowed. Only read-only MATCH/RETURN queries are permitted.' });
         return;
       }
 


### PR DESCRIPTION
## Summary

Adds a read-only guard to both the MCP `cypher` tool and the HTTP `/api/query` endpoint.

Queries containing write keywords (`CREATE`, `DELETE`, `SET`, `REMOVE`, `MERGE`, `DROP`, `ALTER`, `DETACH`, `COPY`, `CALL`) are rejected before execution.

## Motivation

The `cypher` tool is exposed to AI assistants and HTTP clients. Without validation, a crafted query could mutate or destroy the knowledge graph. This guard ensures only read-only `MATCH`/`RETURN` queries are permitted.

## Changes

- `gitnexus/src/mcp/local/local-backend.ts`: Added `WRITE_PATTERN` static regex and early rejection in `cypher()` method
- `gitnexus/src/server/api.ts`: Added same pattern check in `/api/query` handler, returns 403

## Risk

Low — only adds a pre-execution check. No changes to query execution or result formatting.
