### PR TITLE
fix: add explicit radix to parseInt calls

### DIFF
--- a/gitnexus-web/src/core/kuzu/kuzu-adapter.ts
+++ b/gitnexus-web/src/core/kuzu/kuzu-adapter.ts
@@ -149,7 +149,7 @@ export const loadGraphToKuzu = async (
         }
 
         const confidence = parseFloat(confidenceStr) || 1.0;
-        const step = parseInt(stepStr) || 0;
+        const step = parseInt(stepStr, 10) || 0;
         
         const insertQuery = `
           MATCH (a:${escapeLabel(fromLabel)} {id: '${fromId.replace(/'/g, "''")}'}),

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -350,7 +350,7 @@ export const analyzeCommand = async (
   if (kuzuWarnings.length > 0) {
     const totalFallback = kuzuWarnings.reduce((sum, w) => {
       const m = w.match(/\((\d+) edges\)/);
-      return sum + (m ? parseInt(m[1]) : 0);
+      return sum + (m ? parseInt(m[1], 10) : 0);
     }, 0);
     console.log(`  Note: ${totalFallback} edges across ${kuzuWarnings.length} types inserted via fallback (schema will be updated in next release)`);
   }

--- a/gitnexus/src/cli/eval-server.ts
+++ b/gitnexus/src/cli/eval-server.ts
@@ -297,8 +297,8 @@ function getNextStepHint(toolName: string): string {
 // ─── Server ───────────────────────────────────────────────────────────
 
 export async function evalServerCommand(options?: EvalServerOptions): Promise<void> {
-  const port = parseInt(options?.port || '4848');
-  const idleTimeoutSec = parseInt(options?.idleTimeout || '0');
+  const port = parseInt(options?.port || '4848', 10);
+  const idleTimeoutSec = parseInt(options?.idleTimeout || '0', 10);
 
   const backend = new LocalBackend();
   const ok = await backend.init();

--- a/gitnexus/src/cli/tool.ts
+++ b/gitnexus/src/cli/tool.ts
@@ -52,7 +52,7 @@ export async function queryCommand(queryText: string, options?: {
     query: queryText,
     task_context: options?.context,
     goal: options?.goal,
-    limit: options?.limit ? parseInt(options.limit) : undefined,
+    limit: options?.limit ? parseInt(options.limit, 10) : undefined,
     include_content: options?.content ?? false,
     repo: options?.repo,
   });
@@ -96,7 +96,7 @@ export async function impactCommand(target: string, options?: {
   const result = await backend.callTool('impact', {
     target,
     direction: options?.direction || 'upstream',
-    maxDepth: options?.depth ? parseInt(options.depth) : undefined,
+    maxDepth: options?.depth ? parseInt(options.depth, 10) : undefined,
     includeTests: options?.includeTests ?? false,
     repo: options?.repo,
   });

--- a/gitnexus/src/core/kuzu/kuzu-adapter.ts
+++ b/gitnexus/src/core/kuzu/kuzu-adapter.ts
@@ -298,7 +298,7 @@ const fallbackRelationshipInserts = async (
       if (!validTables.has(fromLabel) || !validTables.has(toLabel)) continue;
 
       const confidence = parseFloat(confidenceStr) || 1.0;
-      const step = parseInt(stepStr) || 0;
+      const step = parseInt(stepStr, 10) || 0;
 
       await conn.query(`
         MATCH (a:${escapeLabel(fromLabel)} {id: '${fromId.replace(/'/g, "''")}' }),


### PR DESCRIPTION
## Summary

Add explicit radix parameter (`10`) to all `parseInt()` calls that were missing it.

## Problem

Without an explicit radix, `parseInt` defaults to base 10 for decimal strings but can misparse strings with leading zeros as octal in older engines. Additionally, missing the radix parameter violates ESLint's `radix` rule, which exists to prevent subtle numeric parsing bugs.

## Changes

7 `parseInt()` calls updated across 5 files:

| File | Context |
|------|---------|
| `gitnexus/src/core/kuzu/kuzu-adapter.ts` | Step number parsing in edge insertion |
| `gitnexus/src/cli/analyze.ts` | Edge count extraction from warning messages |
| `gitnexus/src/cli/tool.ts` | CLI `--limit` and `--depth` option parsing (2 calls) |
| `gitnexus/src/cli/eval-server.ts` | Port and idle timeout option parsing (2 calls) |
| `gitnexus-web/src/core/kuzu/kuzu-adapter.ts` | Step number parsing (web version) |

## Testing

Pure mechanical change — adds `, 10` to each call. No behavioral difference for valid decimal inputs. Prevents potential misparse of zero-prefixed strings.
