### PR TITLE
fix: handle stream errors during CSV writer flush cycles

### DIFF
--- a/gitnexus/src/core/kuzu/csv-generator.ts
+++ b/gitnexus/src/core/kuzu/csv-generator.ts
@@ -140,12 +140,16 @@ const extractContent = async (
 class BufferedCSVWriter {
   private ws: WriteStream;
   private buffer: string[] = [];
+  private streamError: Error | null = null;
   rows = 0;
 
   constructor(filePath: string, header: string) {
     this.ws = createWriteStream(filePath, 'utf-8');
     // Large repos flush many times — raise listener cap to avoid MaxListenersExceededWarning
     this.ws.setMaxListeners(50);
+    this.ws.on('error', (err) => {
+      this.streamError = err;
+    });
     this.buffer.push(header);
   }
 
@@ -159,13 +163,25 @@ class BufferedCSVWriter {
   }
 
   flush(): Promise<void> {
+    if (this.streamError) return Promise.reject(this.streamError);
     if (this.buffer.length === 0) return Promise.resolve();
     const chunk = this.buffer.join('\n') + '\n';
     this.buffer.length = 0;
     return new Promise((resolve, reject) => {
       const ok = this.ws.write(chunk);
       if (ok) resolve();
-      else this.ws.once('drain', resolve);
+      else {
+        const onError = (err: Error) => {
+          this.ws.removeListener('drain', onDrain);
+          reject(err);
+        };
+        const onDrain = () => {
+          this.ws.removeListener('error', onError);
+          resolve();
+        };
+        this.ws.once('drain', onDrain);
+        this.ws.once('error', onError);
+      }
     });
   }
 


### PR DESCRIPTION
BufferedCSVWriter registers its error handler only inside finish(). During intermediate addRow/flush cycles, write errors are unhandled — in Node.js this crashes the process. Also, flush() waits on drain but never rejects on error, so the promise hangs indefinitely if a write fails.

Changes:
- Register error handler in constructor to capture errors during all writes
- Check for prior stream errors at start of flush()
- Add error listener alongside drain listener so flush() rejects on failure