### PR TITLE
fix: use 1-based ranks in RRF score calculation

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -346,7 +346,7 @@ export class LocalBackend {
     for (let i = 0; i < bm25Results.length; i++) {
       const result = bm25Results[i];
       const key = result.nodeId || result.filePath;
-      const rrfScore = 1 / (60 + i);
+      const rrfScore = 1 / (60 + i + 1);  // i+1 because rank starts at 1
       const existing = scoreMap.get(key);
       if (existing) {
         existing.score += rrfScore;
@@ -358,7 +358,7 @@ export class LocalBackend {
     for (let i = 0; i < semanticResults.length; i++) {
       const result = semanticResults[i];
       const key = result.nodeId || result.filePath;
-      const rrfScore = 1 / (60 + i);
+      const rrfScore = 1 / (60 + i + 1);  // i+1 because rank starts at 1
       const existing = scoreMap.get(key);
       if (existing) {
         existing.score += rrfScore;


### PR DESCRIPTION
## Problem

The RRF (Reciprocal Rank Fusion) formula in local-backend.ts uses 0-based array index directly: 1/(60+i). This gives the rank-0 item a score of 1/60 instead of the correct 1/61.

The same project already has the correct implementation in hybrid-search.ts: 1/(RRF_K+i+1) with the comment "i+1 because rank starts at 1".

## Fix

Changed both RRF loops in local-backend.ts from 1/(60+i) to 1/(60+i+1) to match the standard RRF formula where ranks are 1-indexed.

## Impact

Without this fix, the first item in each result set gets a slightly inflated score (1/60 vs 1/61), which can subtly alter merge ordering when BM25 and semantic search return different top results.
