### PR TITLE
fix(ast-cache): guard against zero maxSize crashing LRUCache

### DIFF
--- a/gitnexus/src/core/ingestion/ast-cache.ts
+++ b/gitnexus/src/core/ingestion/ast-cache.ts
@@ -10,10 +10,13 @@ export interface ASTCache {
 }
 
 export const createASTCache = (maxSize: number = 50): ASTCache => {
+  // Ensure max is at least 1 — LRUCache throws if max/maxSize/ttl are all 0 or unset.
+  // This happens when the pipeline has no parseable files (e.g., unsupported languages only).
+  const safeMax = Math.max(maxSize, 1);
   // Initialize the cache with a 'dispose' handler
   // This is the magic: When an item is evicted (dropped), this runs automatically.
   const cache = new LRUCache<string, Parser.Tree>({
-    max: maxSize,
+    max: safeMax,
     dispose: (tree) => {
       try {
         // NOTE: web-tree-sitter has tree.delete(); native tree-sitter trees are GC-managed.

--- a/gitnexus/test/unit/ast-cache.test.ts
+++ b/gitnexus/test/unit/ast-cache.test.ts
@@ -83,4 +83,23 @@ describe('ASTCache', () => {
       expect(defaultCache.stats().maxSize).toBe(50);
     });
   });
+
+  describe('edge cases', () => {
+    it('does not throw when maxSize is 0', () => {
+      expect(() => createASTCache(0)).not.toThrow();
+      const zeroCache = createASTCache(0);
+      expect(zeroCache.stats().maxSize).toBe(0);
+    });
+
+    it('does not throw when maxSize is negative', () => {
+      expect(() => createASTCache(-5)).not.toThrow();
+    });
+
+    it('still functions with maxSize 0 (clamped to 1 internally)', () => {
+      const zeroCache = createASTCache(0);
+      const tree = mockTree('test');
+      zeroCache.set('a.ts', tree);
+      expect(zeroCache.get('a.ts')).toBe(tree);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `createASTCache(0)` passes `max: 0` to `LRUCache`, which throws `TypeError: At least one of max, maxSize, or ttl is required`
- This happens when a repo has **no parseable files** (e.g., only Kotlin files before Kotlin support was published to npm), causing `chunks` to be empty and `maxChunkFiles` to evaluate to `0`
- Fix: clamp `maxSize` to a minimum of `1` inside `createASTCache` so the cache is always valid regardless of the caller's input

## Reproduction

```bash
# On a Kotlin-only repo with gitnexus@latest from npm (Kotlin not yet published)
npx gitnexus analyze
# TypeError: At least one of max, maxSize, or ttl is required
#   at createASTCache (ast-cache.js:5:19)
#   at runPipelineFromRepo (pipeline.js:113:20)
```

## Changes

| File | Change |
|------|--------|
| `gitnexus/src/core/ingestion/ast-cache.ts` | Clamp `maxSize` to `Math.max(maxSize, 1)` before passing to `LRUCache` |
| `gitnexus/test/unit/ast-cache.test.ts` | Add 3 edge-case tests for `maxSize=0` and negative values |

## Test plan

- [x] All 11 AST cache tests pass (8 existing + 3 new)
- [x] `npx vitest run test/unit/ast-cache.test.ts` — green
- [x] Verified `gitnexus analyze` no longer crashes on a Kotlin-only repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)