### PR TITLE
fix: add symbol-level IMPORTS edges for named imports

### DIFF
--- a/gitnexus/src/core/ingestion/import-processor.ts
+++ b/gitnexus/src/core/ingestion/import-processor.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { KnowledgeGraph } from '../graph/types.js';
 import { ASTCache } from './ast-cache.js';
+import { SymbolTable } from './symbol-table.js';
 import Parser from 'tree-sitter';
 import { loadParser, loadLanguage } from '../tree-sitter/parser-loader.js';
 import { LANGUAGE_QUERIES } from './tree-sitter-queries.js';
@@ -728,6 +729,7 @@ export const processImports = async (
   onProgress?: (current: number, total: number) => void,
   repoRoot?: string,
   allPaths?: string[],
+  symbolTable?: SymbolTable,
 ) => {
   // Use allPaths (full repo) when available for cross-chunk resolution, else fall back to chunk files
   const allFileList = allPaths ?? files.map(f => f.path);
@@ -771,6 +773,57 @@ export const processImports = async (
       importMap.set(filePath, new Set());
     }
     importMap.get(filePath)!.add(resolvedPath);
+  };
+
+  // Helper: add symbol-level IMPORTS edges for named imports
+  const addSymbolImportEdges = (filePath: string, resolvedPath: string, symbolNames?: string[]) => {
+    if (!symbolNames || !symbolTable) return;
+    const sourceId = generateId('File', filePath);
+    for (const name of symbolNames) {
+      const targetNodeId = symbolTable.lookupExact(resolvedPath, name);
+      if (!targetNodeId) continue;
+      const relId = generateId('IMPORTS', `${filePath}:${name}->${resolvedPath}`);
+      graph.addRelationship({
+        id: relId,
+        sourceId,
+        targetId: targetNodeId,
+        type: 'IMPORTS',
+        confidence: 1.0,
+        reason: '',
+      });
+    }
+  };
+
+  // Helper: extract imported symbol names from AST node (for sequential path)
+  const extractSymbolNames = (importNode: any, language: string): string[] => {
+    const names: string[] = [];
+    if (language === SupportedLanguages.Python) {
+      for (const child of importNode.namedChildren) {
+        if (child.type === 'module_name') continue;
+        if (child.type === 'wildcard_import') continue;
+        if (child.type === 'dotted_name' || child.type === 'identifier') {
+          names.push(child.text);
+        } else if (child.type === 'aliased_import') {
+          const nameNode = child.childForFieldName?.('name') || child.namedChildren?.[0];
+          if (nameNode) names.push(nameNode.text);
+        }
+      }
+      return names;
+    }
+    if (language === SupportedLanguages.TypeScript || language === SupportedLanguages.JavaScript) {
+      const importClause = importNode.namedChildren?.find((c: any) => c.type === 'import_clause');
+      const namedImports = importClause?.namedChildren?.find((c: any) => c.type === 'named_imports');
+      if (namedImports) {
+        for (const spec of namedImports.namedChildren) {
+          if (spec.type === 'import_specifier') {
+            const nameNode = spec.childForFieldName?.('name');
+            if (nameNode) names.push(nameNode.text);
+          }
+        }
+      }
+      return names;
+    }
+    return names;
   };
 
   for (let i = 0; i < files.length; i++) {
@@ -843,6 +896,9 @@ export const processImports = async (
           ? appendKotlinWildcard(sourceNode.text.replace(/['"<>]/g, ''), captureMap['import'])
           : sourceNode.text.replace(/['"<>]/g, '');
         totalImportsFound++;
+
+        // Extract imported symbol names for symbol-level edges
+        const symbolNames = extractSymbolNames(captureMap['import'], language);
 
         // ---- JVM languages (Java + Kotlin): handle wildcards and member imports ----
         if (language === SupportedLanguages.Java || language === SupportedLanguages.Kotlin) {
@@ -932,6 +988,7 @@ export const processImports = async (
 
         if (resolvedPath) {
           addImportEdge(file.path, resolvedPath);
+          addSymbolImportEdges(file.path, resolvedPath, symbolNames);
         }
       }
     });
@@ -956,6 +1013,7 @@ export const processImportsFromExtracted = async (
   onProgress?: (current: number, total: number) => void,
   repoRoot?: string,
   prebuiltCtx?: ImportResolutionContext,
+  symbolTable?: SymbolTable,
 ) => {
   const ctx = prebuiltCtx ?? buildImportResolutionContext(files.map(f => f.path));
   const { allFilePaths, allFileList, normalizedFileList, suffixIndex: index, resolveCache } = ctx;
@@ -989,6 +1047,25 @@ export const processImportsFromExtracted = async (
       importMap.set(filePath, new Set());
     }
     importMap.get(filePath)!.add(resolvedPath);
+  };
+
+  // Helper: add symbol-level IMPORTS edges for named imports
+  const addSymbolImportEdges = (filePath: string, resolvedPath: string, symbolNames?: string[]) => {
+    if (!symbolNames || !symbolTable) return;
+    const sourceId = generateId('File', filePath);
+    for (const name of symbolNames) {
+      const targetNodeId = symbolTable.lookupExact(resolvedPath, name);
+      if (!targetNodeId) continue;
+      const relId = generateId('IMPORTS', `${filePath}:${name}->${resolvedPath}`);
+      graph.addRelationship({
+        id: relId,
+        sourceId,
+        targetId: targetNodeId,
+        type: 'IMPORTS',
+        confidence: 1.0,
+        reason: '',
+      });
+    }
   };
 
   // Group by file for progress reporting (users see file count, not import count)
@@ -1027,7 +1104,7 @@ export const processImportsFromExtracted = async (
       await yieldToEventLoop();
     }
 
-    for (const { rawImportPath, language } of fileImports) {
+    for (const { rawImportPath, language, symbolNames } of fileImports) {
       totalImportsFound++;
 
       // Check resolve cache first
@@ -1120,6 +1197,7 @@ export const processImportsFromExtracted = async (
 
       if (resolvedPath) {
         addImportEdge(filePath, resolvedPath);
+        addSymbolImportEdges(filePath, resolvedPath, symbolNames);
       }
     }
   }

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -175,7 +175,7 @@ export const runPipelineFromRepo = async (
 
         if (chunkWorkerData) {
           // Imports
-          await processImportsFromExtracted(graph, allPathObjects, chunkWorkerData.imports, importMap, undefined, repoPath, importCtx);
+          await processImportsFromExtracted(graph, allPathObjects, chunkWorkerData.imports, importMap, undefined, repoPath, importCtx, symbolTable);
           // Calls — resolve immediately, then free the array
           if (chunkWorkerData.calls.length > 0) {
             await processCallsFromExtracted(graph, chunkWorkerData.calls, symbolTable, importMap);
@@ -185,7 +185,7 @@ export const runPipelineFromRepo = async (
             await processHeritageFromExtracted(graph, chunkWorkerData.heritage, symbolTable);
           }
         } else {
-          await processImports(graph, chunkFiles, astCache, importMap, undefined, repoPath, allPaths);
+          await processImports(graph, chunkFiles, astCache, importMap, undefined, repoPath, allPaths, symbolTable);
           sequentialChunkPaths.push(chunkPaths);
         }
 

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -63,6 +63,7 @@ export interface ExtractedImport {
   filePath: string;
   rawImportPath: string;
   language: string;
+  symbolNames?: string[];
 }
 
 export interface ExtractedCall {
@@ -267,6 +268,47 @@ const FUNCTION_NODE_TYPES = new Set([
   // Swift initializers/deinitializers
   'init_declaration', 'deinit_declaration',
 ]);
+
+/** Extract the specific symbol names from an import AST node.
+ *  Python:  `from X import foo, bar`  → ['foo', 'bar']
+ *  JS/TS:   `import { foo, bar } from 'X'`  → ['foo', 'bar']
+ *  Returns empty array for bare module imports or unsupported patterns. */
+const extractImportedSymbolNames = (importNode: any, language: string): string[] => {
+  const names: string[] = [];
+
+  if (language === SupportedLanguages.Python) {
+    // import_from_statement children: module_name (dotted_name) + name fields (dotted_name | aliased_import)
+    for (const child of importNode.namedChildren) {
+      if (child.type === 'module_name') continue;
+      if (child.type === 'wildcard_import') continue;
+      if (child.type === 'dotted_name' || child.type === 'identifier') {
+        names.push(child.text);
+      } else if (child.type === 'aliased_import') {
+        // from X import foo as bar — use original name 'foo'
+        const nameNode = child.childForFieldName?.('name') || child.namedChildren?.[0];
+        if (nameNode) names.push(nameNode.text);
+      }
+    }
+    return names;
+  }
+
+  if (language === SupportedLanguages.TypeScript || language === SupportedLanguages.JavaScript) {
+    // import_statement > import_clause > named_imports > import_specifier*
+    const importClause = importNode.namedChildren?.find((c: any) => c.type === 'import_clause');
+    const namedImports = importClause?.namedChildren?.find((c: any) => c.type === 'named_imports');
+    if (namedImports) {
+      for (const spec of namedImports.namedChildren) {
+        if (spec.type === 'import_specifier') {
+          const nameNode = spec.childForFieldName?.('name');
+          if (nameNode) names.push(nameNode.text);
+        }
+      }
+    }
+    return names;
+  }
+
+  return names;
+};
 
 /** Walk up AST to find enclosing function, return its generateId or null for top-level */
 const findEnclosingFunctionId = (node: any, filePath: string): string | null => {
@@ -740,10 +782,15 @@ const processFileGroup = (
         const rawImportPath = language === SupportedLanguages.Kotlin
           ? appendKotlinWildcard(captureMap['import.source'].text.replace(/['"<>]/g, ''), captureMap['import'])
           : captureMap['import.source'].text.replace(/['"<>]/g, '');
+
+        // Extract imported symbol names from the AST node
+        const symbolNames = extractImportedSymbolNames(captureMap['import'], language);
+
         result.imports.push({
           filePath: file.path,
           rawImportPath,
           language: language,
+          symbolNames: symbolNames.length > 0 ? symbolNames : undefined,
         });
         continue;
       }


### PR DESCRIPTION
#### NOTE: This was fixed by AI and I am by no means a programmer. Please let me know if you have any issues with this.
---
### Problem

The ingestion pipeline only creates **file-to-file** IMPORTS edges. When a file uses a named import like:

```python
from myapp.auth import validate_user
```

The graph only records:

```
auth_controller.py (File) --IMPORTS--> auth.py (File)
```

The specific symbol (`validate_user` function) being imported is lost. This means:

- `impact("validate_user")` can't trace what depends on this function via imports
- `context("validate_user")` doesn't show importing files in its incoming references
- Blast radius analysis falls back to file-level granularity, overstating impact for files that export many symbols

### Solution

Add **symbol-level IMPORTS edges** alongside existing file-level ones by leveraging the `SymbolTable` (already populated during parsing) to resolve named imports to their target nodes.

After this fix, the graph contains both:

```
auth_controller.py (File) --IMPORTS--> auth.py (File)              ← unchanged
auth_controller.py (File) --IMPORTS--> validate_user (Function)     ← NEW
```

### What's affected

| Import pattern | Before | After |
|---|---|---|
| `from X import foo, bar` (Python) | File → File only | File → File + File → Function/Class |
| `import { foo, bar } from 'X'` (JS/TS) | File → File only | File → File + File → Function/Class |
| `from X import foo as alias` (Python) | File → File only | File → File + File → Function (original name) |
| `import X` (Python bare import) | File → File | No change (correct — no specific symbol imported) |
| `import X from 'Y'` (JS default import) | File → File | No change (default imports don't target named symbols) |
| `from X import *` (Python wildcard) | File → File | No change (wildcard doesn't target specific symbols) |

### Changes

**`src/core/ingestion/workers/parse-worker.ts`**

- Add `extractImportedSymbolNames()` — walks the import AST node to extract named symbols from Python `import_from_statement` and JS/TS `named_imports` nodes
- Attach extracted `symbolNames` array to the `ExtractedImport` interface for the worker data path

**`src/core/ingestion/import-processor.ts`**

- Add `addSymbolImportEdges()` helper in both `processImports` (sequential path) and `processImportsFromExtracted` (worker path)
- For each extracted symbol name, calls `symbolTable.lookupExact(resolvedPath, name)` to find the target Function/Class node
- Creates a high-confidence IMPORTS edge from the source File to the target symbol node
- Accept optional `symbolTable` parameter (no breaking change — undefined falls through gracefully)

**`src/core/ingestion/pipeline.ts`**

- Pass the existing `symbolTable` as a new argument to `processImports()` and `processImportsFromExtracted()`

### Design decisions

- **Additive, not replacing** — file-level edges are preserved. Symbol-level edges are additional. No existing behavior changes.
- **Graceful degradation** — if `symbolTable` is undefined or a symbol isn't found, the code silently skips. No errors for unresolved symbols.
- **Source is File, target is Symbol** — the `sourceId` is the importing File node (not a symbol within it), since Python/JS import statements are module-level, not scoped to a function.
- **Uses `lookupExact` only** — matches symbol by (filePath, name) pair. No fuzzy matching, keeping confidence at 1.0.

### Testing

Verified on a Python LangGraph project (84 nodes). Before: 179 edges (all file-level). After: 179 file-level edges + ~40 new symbol-level IMPORTS edges correctly linking files to the specific Function/Class nodes they import.

Example results from `impact("supervisor")` targeting a Function node:

- **Before**: no upstream edges (function node was unreachable via IMPORTS)
- **After**: `graph.py (File) --IMPORTS--> supervisor (Function)` at depth 1, with correct transitive trace through files that import `graph.py` at depth 2
