### PR TITLE
feat(web): add built-in Novita provider support

### DIFF
--- a/gitnexus-web/src/components/SettingsPanel.tsx
+++ b/gitnexus-web/src/components/SettingsPanel.tsx
@@ -281,7 +281,7 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
 
   if (!isOpen) return null;
 
-  const providers: LLMProvider[] = ['openai', 'gemini', 'anthropic', 'azure-openai', 'ollama', 'openrouter'];
+  const providers: LLMProvider[] = ['openai', 'novita', 'gemini', 'anthropic', 'azure-openai', 'ollama', 'openrouter'];
 
 
   return (
@@ -366,7 +366,7 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
                     w-8 h-8 rounded-lg flex items-center justify-center text-lg
                     ${settings.activeProvider === provider ? 'bg-accent/20' : 'bg-surface'}
                   `}>
-                    {provider === 'openai' ? '🤖' : provider === 'gemini' ? '💎' : provider === 'anthropic' ? '🧠' : provider === 'ollama' ? '🦙' : provider === 'openrouter' ? '🌐' : '☁️'}
+                    {provider === 'openai' ? '🤖' : provider === 'novita' ? '🚀' : provider === 'gemini' ? '💎' : provider === 'anthropic' ? '🧠' : provider === 'ollama' ? '🦙' : provider === 'openrouter' ? '🌐' : '☁️'}
                   </div>
                   <span className="font-medium">{getProviderDisplayName(provider)}</span>
                 </button>
@@ -445,6 +445,71 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
                 />
                 <p className="text-xs text-text-muted">
                   Leave empty to use the default OpenAI API. Set a custom URL for proxies or compatible APIs.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Novita Settings */}
+          {settings.activeProvider === 'novita' && (
+            <div className="space-y-4 animate-fade-in">
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
+                  <Key className="w-4 h-4" />
+                  API Key
+                </label>
+                <div className="relative">
+                  <input
+                    type={showApiKey['novita'] ? 'text' : 'password'}
+                    value={settings.novita?.apiKey ?? ''}
+                    onChange={e => setSettings(prev => ({
+                      ...prev,
+                      novita: { ...prev.novita!, apiKey: e.target.value }
+                    }))}
+                    placeholder="Enter your Novita API key"
+                    className="w-full px-4 py-3 pr-12 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => toggleApiKeyVisibility('novita')}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-text-muted hover:text-text-primary transition-colors"
+                  >
+                    {showApiKey['novita'] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-text-secondary">Model</label>
+                <input
+                  type="text"
+                  value={settings.novita?.model ?? 'meta-llama/llama-3.1-8b-instruct'}
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    novita: { ...prev.novita!, model: e.target.value }
+                  }))}
+                  placeholder="e.g., deepseek/deepseek-v3, qwen/qwen2.5-72b-instruct"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-sm"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
+                  <Server className="w-4 h-4" />
+                  Base URL
+                </label>
+                <input
+                  type="url"
+                  value={settings.novita?.baseUrl ?? 'https://api.novita.ai/openai'}
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    novita: { ...prev.novita!, baseUrl: e.target.value }
+                  }))}
+                  placeholder="https://api.novita.ai/openai"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
+                />
+                <p className="text-xs text-text-muted">
+                  Novita OpenAI-compatible endpoint default: <code className="px-1 py-0.5 bg-elevated rounded">https://api.novita.ai/openai</code>
                 </p>
               </div>
             </div>
@@ -865,4 +930,3 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
     </div>
   );
 };
-

--- a/gitnexus-web/src/core/llm/agent.ts
+++ b/gitnexus-web/src/core/llm/agent.ts
@@ -16,6 +16,7 @@ import { createGraphRAGTools } from './tools';
 import type { 
   ProviderConfig, 
   OpenAIConfig,
+  NovitaConfig,
   AzureOpenAIConfig, 
   GeminiConfig,
   AnthropicConfig,
@@ -141,6 +142,26 @@ export const createChatModel = (config: ProviderConfig): BaseChatModel => {
         configuration: {
           apiKey: openaiConfig.apiKey,
           ...(openaiConfig.baseUrl ? { baseURL: openaiConfig.baseUrl } : {}),
+        },
+        streaming: true,
+      });
+    }
+
+    case 'novita': {
+      const novitaConfig = config as NovitaConfig;
+
+      if (!novitaConfig.apiKey || novitaConfig.apiKey.trim() === '') {
+        throw new Error('Novita API key is required but was not provided');
+      }
+
+      return new ChatOpenAI({
+        apiKey: novitaConfig.apiKey,
+        modelName: novitaConfig.model,
+        temperature: novitaConfig.temperature ?? 0.1,
+        maxTokens: novitaConfig.maxTokens,
+        configuration: {
+          apiKey: novitaConfig.apiKey,
+          baseURL: novitaConfig.baseUrl ?? 'https://api.novita.ai/openai',
         },
         streaming: true,
       });
@@ -543,4 +564,3 @@ export const invokeAgent = async (
   const lastMessage = result.messages[result.messages.length - 1];
   return lastMessage?.content?.toString() ?? 'No response generated.';
 };
-

--- a/gitnexus-web/src/core/llm/settings-service.ts
+++ b/gitnexus-web/src/core/llm/settings-service.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_LLM_SETTINGS, 
   LLMProvider,
   OpenAIConfig,
+  NovitaConfig,
   AzureOpenAIConfig,
   GeminiConfig,
   AnthropicConfig,
@@ -39,6 +40,10 @@ export const loadSettings = (): LLMSettings => {
       openai: {
         ...DEFAULT_LLM_SETTINGS.openai,
         ...parsed.openai,
+      },
+      novita: {
+        ...DEFAULT_LLM_SETTINGS.novita,
+        ...parsed.novita,
       },
       azureOpenAI: {
         ...DEFAULT_LLM_SETTINGS.azureOpenAI,
@@ -85,10 +90,12 @@ export const updateProviderSettings = <T extends LLMProvider>(
   provider: T,
   updates: Partial<
     T extends 'openai' ? Partial<Omit<OpenAIConfig, 'provider'>> :
+    T extends 'novita' ? Partial<Omit<NovitaConfig, 'provider'>> :
     T extends 'azure-openai' ? Partial<Omit<AzureOpenAIConfig, 'provider'>> :
     T extends 'gemini' ? Partial<Omit<GeminiConfig, 'provider'>> :
     T extends 'anthropic' ? Partial<Omit<AnthropicConfig, 'provider'>> :
     T extends 'ollama' ? Partial<Omit<OllamaConfig, 'provider'>> :
+    T extends 'openrouter' ? Partial<Omit<OpenRouterConfig, 'provider'>> :
     never
   >
 ): LLMSettings => {
@@ -102,6 +109,17 @@ export const updateProviderSettings = <T extends LLMProvider>(
         openai: {
           ...(current.openai ?? {}),
           ...(updates as Partial<Omit<OpenAIConfig, 'provider'>>),
+        },
+      };
+      saveSettings(updated);
+      return updated;
+    }
+    case 'novita': {
+      const updated: LLMSettings = {
+        ...current,
+        novita: {
+          ...(current.novita ?? {}),
+          ...(updates as Partial<Omit<NovitaConfig, 'provider'>>),
         },
       };
       saveSettings(updated);
@@ -199,6 +217,18 @@ export const getActiveProviderConfig = (): ProviderConfig | null => {
         provider: 'openai',
         ...settings.openai,
       } as OpenAIConfig;
+    case 'novita':
+      if (!settings.novita?.apiKey || settings.novita.apiKey.trim() === '') {
+        return null;
+      }
+      return {
+        provider: 'novita',
+        apiKey: settings.novita.apiKey,
+        model: settings.novita.model || 'meta-llama/llama-3.1-8b-instruct',
+        baseUrl: settings.novita.baseUrl || 'https://api.novita.ai/openai',
+        temperature: settings.novita.temperature,
+        maxTokens: settings.novita.maxTokens,
+      } as NovitaConfig;
       
     case 'azure-openai':
       if (!settings.azureOpenAI?.apiKey || !settings.azureOpenAI?.endpoint) {
@@ -272,6 +302,8 @@ export const getProviderDisplayName = (provider: LLMProvider): string => {
   switch (provider) {
     case 'openai':
       return 'OpenAI';
+    case 'novita':
+      return 'Novita AI';
     case 'azure-openai':
       return 'Azure OpenAI';
     case 'gemini':
@@ -294,6 +326,8 @@ export const getAvailableModels = (provider: LLMProvider): string[] => {
   switch (provider) {
     case 'openai':
       return ['gpt-4.5-preview', 'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo'];
+    case 'novita':
+      return ['meta-llama/llama-3.1-8b-instruct', 'deepseek/deepseek-v3', 'qwen/qwen2.5-72b-instruct'];
     case 'azure-openai':
       // Azure models depend on deployment, so we show common ones
       return ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', 'gpt-35-turbo'];
@@ -325,4 +359,3 @@ export const fetchOpenRouterModels = async (): Promise<Array<{ id: string; name:
     return [];
   }
 };
-

--- a/gitnexus-web/src/core/llm/types.ts
+++ b/gitnexus-web/src/core/llm/types.ts
@@ -8,7 +8,7 @@
 /**
  * Supported LLM providers
  */
-export type LLMProvider = 'openai' | 'azure-openai' | 'gemini' | 'anthropic' | 'ollama' | 'openrouter';
+export type LLMProvider = 'openai' | 'novita' | 'azure-openai' | 'gemini' | 'anthropic' | 'ollama' | 'openrouter';
 
 /**
  * Base configuration shared by all providers
@@ -28,6 +28,16 @@ export interface OpenAIConfig extends BaseProviderConfig {
   apiKey: string;
   model: string;  // e.g., 'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo'
   baseUrl?: string;  // optional, for custom endpoints or proxies
+}
+
+/**
+ * Novita configuration (OpenAI-compatible endpoint)
+ */
+export interface NovitaConfig extends BaseProviderConfig {
+  provider: 'novita';
+  apiKey: string;
+  model: string;
+  baseUrl?: string;  // defaults to https://api.novita.ai/openai
 }
 
 /**
@@ -81,7 +91,7 @@ export interface OpenRouterConfig extends BaseProviderConfig {
 /**
  * Union type for all provider configurations
  */
-export type ProviderConfig = OpenAIConfig | AzureOpenAIConfig | GeminiConfig | AnthropicConfig | OllamaConfig | OpenRouterConfig;
+export type ProviderConfig = OpenAIConfig | NovitaConfig | AzureOpenAIConfig | GeminiConfig | AnthropicConfig | OllamaConfig | OpenRouterConfig;
 
 /**
  * Stored settings (what goes to localStorage)
@@ -93,6 +103,7 @@ export interface LLMSettings {
    * We validate required fields at runtime before creating a ProviderConfig.
    */
   openai?: Partial<Omit<OpenAIConfig, 'provider'>>;
+  novita?: Partial<Omit<NovitaConfig, 'provider'>>;
   azureOpenAI?: Partial<Omit<AzureOpenAIConfig, 'provider'>>;
   gemini?: Partial<Omit<GeminiConfig, 'provider'>>;
   anthropic?: Partial<Omit<AnthropicConfig, 'provider'>>;
@@ -117,6 +128,12 @@ export const DEFAULT_LLM_SETTINGS: LLMSettings = {
   openai: {
     apiKey: '',
     model: 'gpt-4o',
+    temperature: 0.1,
+  },
+  novita: {
+    apiKey: '',
+    model: 'meta-llama/llama-3.1-8b-instruct',
+    baseUrl: 'https://api.novita.ai/openai',
     temperature: 0.1,
   },
   gemini: {
@@ -347,4 +364,3 @@ NOTES:
 - For vector search, join CodeEmbedding.nodeId to the appropriate table's id
 - Use LIMIT to avoid returning too many results
 `;
-


### PR DESCRIPTION
## Summary\n- add novita as a first-class LLM provider in GitNexus Web\n- preconfigure Novita endpoint default to https://api.novita.ai/openai\n- wire provider through settings storage and chat model factory\n- add Novita settings UI (API key/model/base URL)\n\n## Notes\n- this keeps Novita integration explicit instead of requiring OpenAI custom base URL setup each time\n\n## Verification\n- attempted to run npm run build in gitnexus-web, but local environment lacked tsc due missing dependencies\n- dependency install attempt was interrupted due long-running/hung install in this environment