### PR TITLE
fix: add call_expression matching to tree-sitter queries

### DIFF
--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -32,6 +32,11 @@ export const TYPESCRIPT_QUERIES = `
     name: (identifier) @name
     value: (function_expression))) @definition.function
 
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression))) @definition.function
+
 (export_statement
   declaration: (lexical_declaration
     (variable_declarator
@@ -43,6 +48,12 @@ export const TYPESCRIPT_QUERIES = `
     (variable_declarator
       name: (identifier) @name
       value: (function_expression)))) @definition.function
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (call_expression)))) @definition.function
 
 (import_statement
   source: (string) @import.source) @import
@@ -69,7 +80,7 @@ export const TYPESCRIPT_QUERIES = `
       (type_identifier) @heritage.implements))) @heritage.impl
 `;
 
-// JavaScript queries - works with tree-sitter-javascript  
+// JavaScript queries - works with tree-sitter-javascript
 export const JAVASCRIPT_QUERIES = `
 (class_declaration
   name: (identifier) @name) @definition.class
@@ -90,6 +101,11 @@ export const JAVASCRIPT_QUERIES = `
     name: (identifier) @name
     value: (function_expression))) @definition.function
 
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression))) @definition.function
+
 (export_statement
   declaration: (lexical_declaration
     (variable_declarator
@@ -101,6 +117,12 @@ export const JAVASCRIPT_QUERIES = `
     (variable_declarator
       name: (identifier) @name
       value: (function_expression)))) @definition.function
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (call_expression)))) @definition.function
 
 (import_statement
   source: (string) @import.source) @import


### PR DESCRIPTION
## Problem

Exported `const` declarations initialized with call expressions are invisible to the knowledge graph. For example:

```ts
export const useThemeStore = create<ThemeState>()(devtools(...))
export const router = createBrowserRouter([...])
export const api = createApi({...})
```

The tree-sitter queries only match `arrow_function` and `function_expression` values, so any `const X = someCall(...)` pattern — which is extremely common in modern TS/JS — is silently dropped.

This affects **Zustand stores, factory functions, HOCs, RTK Query APIs, routers**, and many other patterns.

## Fix

Adds `call_expression` value matching for both exported and non-exported `const` declarations in the TypeScript and JavaScript query sets.

## Testing

Tested against a 218-component React codebase with 8 Zustand stores. Before: 0 stores in graph. After: all 8 found correctly.

```cypher
MATCH (f:Function) WHERE f.name STARTS WITH 'use' AND f.name ENDS WITH 'Store'
RETURN f.name, f.filePath
-- Returns 8 rows (was 0)
```