### PR TITLE
feat: add --mpc-only flag to skip AI context file generation

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -45,6 +45,7 @@ function ensureHeap(): boolean {
 export interface AnalyzeOptions {
   force?: boolean;
   embeddings?: boolean;
+  mpcOnly?: boolean;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -303,14 +304,17 @@ export const analyzeCommand = async (
     aggregatedClusterCount = Array.from(groups.values()).filter(count => count >= 5).length;
   }
 
-  const aiContext = await generateAIContextFiles(repoPath, storagePath, projectName, {
-    files: pipelineResult.totalFileCount,
-    nodes: stats.nodes,
-    edges: stats.edges,
-    communities: pipelineResult.communityResult?.stats.totalCommunities,
-    clusters: aggregatedClusterCount,
-    processes: pipelineResult.processResult?.stats.totalProcesses,
-  });
+  // Skip AI context file generation when --mcp-only is set
+  const aiContext = options.mpcOnly
+    ? { files: [], hooks: [] }
+    : await generateAIContextFiles(repoPath, storagePath, projectName, {
+        files: pipelineResult.totalFileCount,
+        nodes: stats.nodes,
+        edges: stats.edges,
+        communities: pipelineResult.communityResult?.stats.totalCommunities,
+        clusters: aggregatedClusterCount,
+        processes: pipelineResult.processResult?.stats.totalProcesses,
+      });
 
   await closeKuzu();
   // Note: we intentionally do NOT call disposeEmbedder() here.

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -35,6 +35,7 @@ program
   .description('Index a repository (full analysis)')
   .option('-f, --force', 'Force full re-index even if up to date')
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
+  .option('--mpc-only', 'Index only — skip writing CLAUDE.md, AGENTS.md, skills, and hooks')
   .action(analyzeCommand);
 
 program


### PR DESCRIPTION
## Problem

Running `gitnexus analyze` writes/overwrites CLAUDE.md, AGENTS.md, skills, and hooks on every reindex. When using GitNexus purely as an MCP server, this is unwanted — users have their own CLAUDE.md and don't want it modified.

Currently the only workaround is manually reverting the files after each analyze:
```bash
git checkout CLAUDE.md
rm -rf .claude/skills/gitnexus/
```

## Fix

Adds `--mpc-only` flag to the `analyze` command:

```bash
gitnexus analyze --mpc-only
```

When set, the analyzer indexes the repository and builds the full knowledge graph (KuzuDB, FTS, embeddings) but skips the `generateAIContextFiles()` call entirely.

## Implementation

- `analyze.ts`: Added `mpcOnly` to `AnalyzeOptions`, conditionally skips `generateAIContextFiles()`
- `index.ts`: Added `--mpc-only` option to commander

Minimal change — 5 lines modified across 2 files.