### PR TITLE
fix(cli): force-exit after analyze to prevent KuzuDB hang

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -357,10 +357,8 @@ export const analyzeCommand = async (
 
   console.log('');
 
-  // ONNX Runtime registers native atexit hooks that segfault during process
-  // shutdown on macOS (#38) and some Linux configs (#40). Force-exit to
-  // bypass them when embeddings were loaded.
-  if (!embeddingSkipped) {
-    process.exit(0);
-  }
+  // KuzuDB's native module holds open handles that prevent Node from exiting.
+  // ONNX Runtime also registers native atexit hooks that segfault on some
+  // platforms (#38, #40). Force-exit to ensure clean termination.
+  process.exit(0);
 };


### PR DESCRIPTION
## Summary
- `npx gitnexus analyze` now exits immediately after completion instead of hanging for several seconds
- KuzuDB's native module holds open handles that prevent Node.js from draining the event loop
- Previously only force-exited when embeddings were used; now always force-exits

## Test plan
- [x] 749 unit tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)