### PR TITLE
fix(ingestion): align CALLS edge sourceId with node ID format

### DIFF
--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -291,7 +291,8 @@ const findEnclosingFunctionId = (node: any, filePath: string): string | null => 
       if (current.type === 'init_declaration' || current.type === 'deinit_declaration') {
         const funcName = current.type === 'init_declaration' ? 'init' : 'deinit';
         const label = 'Constructor';
-        return generateId(label, `${filePath}:${funcName}`);
+        const startLine = current.startPosition?.row ?? 0;
+        return generateId(label, `${filePath}:${funcName}:${startLine}`);
       }
 
       if (['function_declaration', 'function_definition', 'async_function_declaration',
@@ -327,7 +328,8 @@ const findEnclosingFunctionId = (node: any, filePath: string): string | null => 
       }
 
       if (funcName) {
-        return generateId(label, `${filePath}:${funcName}`);
+        const startLine = current.startPosition?.row ?? 0;
+        return generateId(label, `${filePath}:${funcName}:${startLine}`);
       }
     }
     current = current.parent;


### PR DESCRIPTION
## Summary
- `findEnclosingFunctionId` generated IDs as `generateId(label, 'path:name')` but node creation uses `generateId(label, 'path:name:startLine')`
- This mismatch meant every CALLS edge had a sourceId pointing to a non-existent node
- The process detector found 0 entry points with outgoing calls → 0 execution flows
- Fix: include `:startLine` in `findEnclosingFunctionId` to match node ID format

## Test plan
- [x] 749 unit tests pass
- [ ] Re-run `npx gitnexus analyze` on a repo and verify flows > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)