### PR TITLE
feat(analyze): add .gitnexusignore support with --no-user-ignore override

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ gitnexus analyze [path]           # Index a repository (or update stale index)
 gitnexus analyze --force          # Force full re-index
 gitnexus analyze --embeddings     # Enable embedding generation (slower, better search)
 gitnexus analyze --verbose        # Log skipped files when parsers are unavailable
+gitnexus analyze --no-user-ignore # Ignore .gitnexusignore and use built-in ignore rules only
 gitnexus mcp                     # Start MCP server (stdio) — serves all indexed repos
 gitnexus serve                   # Start local HTTP server (multi-repo) for web UI connection
 gitnexus list                    # List all indexed repositories
@@ -237,6 +238,33 @@ flowchart TD
 ```
 
 **How it works:** Each `gitnexus analyze` stores the index in `.gitnexus/` inside the repo (portable, gitignored) and registers a pointer in `~/.gitnexus/registry.json`. When an AI agent starts, the MCP server reads the registry and can serve any indexed repo. KuzuDB connections are opened lazily on first query and evicted after 5 minutes of inactivity (max 5 concurrent). If only one repo is indexed, the `repo` parameter is optional on all tools — agents don't need to change anything.
+
+### Index Scope Control (`.gitnexusignore`)
+
+By default, `gitnexus analyze` applies:
+
+1. Built-in ignore rules (for example `node_modules`, build artifacts, binary formats)
+2. Your repo's optional `.gitnexusignore` file (if present)
+
+Use `.gitnexusignore` to exclude non-core paths from indexing without changing GitNexus defaults.
+
+Example:
+
+```gitignore
+# Ignore domain data / artifacts
+data/
+exports/
+**/*.json
+
+# Keep a specific JSON config indexed
+!src/config/critical-schema.json
+```
+
+If you want to temporarily ignore `.gitnexusignore` and index using built-in rules only:
+
+```bash
+gitnexus analyze --no-user-ignore
+```
 
 ---
 

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -141,6 +141,7 @@ gitnexus analyze [path]           # Index a repository (or update stale index)
 gitnexus analyze --force          # Force full re-index
 gitnexus analyze --embeddings     # Enable embedding generation (slower, better search)
 gitnexus analyze --verbose        # Log skipped files when parsers are unavailable
+gitnexus analyze --no-user-ignore # Ignore .gitnexusignore and use built-in ignore rules only
 gitnexus mcp                     # Start MCP server (stdio) — serves all indexed repos
 gitnexus serve                   # Start local HTTP server (multi-repo) for web UI
 gitnexus list                    # List all indexed repositories
@@ -154,6 +155,30 @@ gitnexus wiki --model <model>    # Wiki with custom LLM model (default: gpt-4o-m
 ## Multi-Repo Support
 
 GitNexus supports indexing multiple repositories. Each `gitnexus analyze` registers the repo in a global registry (`~/.gitnexus/registry.json`). The MCP server serves all indexed repos automatically.
+
+## Index Scope Control (`.gitnexusignore`)
+
+By default, `gitnexus analyze` applies:
+
+1. Built-in ignore rules (for example `node_modules`, build artifacts, binary formats)
+2. Your repo's optional `.gitnexusignore` file (if present)
+
+Use `.gitnexusignore` to exclude non-core paths from indexing without changing GitNexus defaults.
+
+Example:
+
+```gitignore
+data/
+exports/
+**/*.json
+!src/config/critical-schema.json
+```
+
+To bypass `.gitnexusignore` and index using built-in rules only:
+
+```bash
+gitnexus analyze --no-user-ignore
+```
 
 ## Supported Languages
 

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -46,6 +46,7 @@ export interface AnalyzeOptions {
   force?: boolean;
   embeddings?: boolean;
   verbose?: boolean;
+  userIgnore?: boolean;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -189,11 +190,17 @@ export const analyzeCommand = async (
   }
 
   // ── Phase 1: Full Pipeline (0–60%) ─────────────────────────────────
-  const pipelineResult = await runPipelineFromRepo(repoPath, (progress) => {
-    const phaseLabel = PHASE_LABELS[progress.phase] || progress.phase;
-    const scaled = Math.round(progress.percent * 0.6);
-    updateBar(scaled, phaseLabel);
-  });
+  const pipelineResult = await runPipelineFromRepo(
+    repoPath,
+    (progress) => {
+      const phaseLabel = PHASE_LABELS[progress.phase] || progress.phase;
+      const scaled = Math.round(progress.percent * 0.6);
+      updateBar(scaled, phaseLabel);
+    },
+    {
+      useUserIgnoreFile: options?.userIgnore ?? true,
+    },
+  );
 
   // ── Phase 2: KuzuDB (60–85%) ──────────────────────────────────────
   updateBar(60, 'Loading into KuzuDB...');

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -27,6 +27,7 @@ program
   .option('-f, --force', 'Force full re-index even if up to date')
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
+  .option('--no-user-ignore', 'Ignore .gitnexusignore and use built-in ignore rules only')
   .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 
 program

--- a/gitnexus/src/config/ignore-service.ts
+++ b/gitnexus/src/config/ignore-service.ts
@@ -1,3 +1,7 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { minimatch } from 'minimatch';
+
 const DEFAULT_IGNORE_LIST = new Set([
     // Version Control
     '.git',
@@ -147,6 +151,8 @@ const IGNORED_EXTENSIONS = new Set([
     '.iso', '.img', '.dmg',
 ]);
 
+export const USER_IGNORE_FILE = '.gitnexusignore';
+
 // Files to ignore by exact name
 const IGNORED_FILES = new Set([
     'package-lock.json',
@@ -166,6 +172,7 @@ const IGNORED_FILES = new Set([
     '.prettierignore',
     '.eslintignore',
     '.dockerignore',
+    USER_IGNORE_FILE,
     'Thumbs.db',
     '.DS_Store',
     'LICENSE',
@@ -184,6 +191,102 @@ const IGNORED_FILES = new Set([
     '.env.example',
 ]);
 
+interface UserIgnoreRule {
+  negated: boolean;
+  patterns: string[];
+}
+
+const USER_IGNORE_MATCH_OPTIONS = {
+  dot: true,
+  nocase: process.platform === 'win32',
+};
+
+const normalizeGlobPath = (value: string): string =>
+  value.replace(/\\/g, '/').replace(/^\.\/+/, '');
+
+const parseUserIgnoreRule = (line: string): UserIgnoreRule | null => {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+
+  const negated = trimmed.startsWith('!');
+  let pattern = negated ? trimmed.slice(1).trim() : trimmed;
+  if (!pattern) return null;
+
+  const anchored = pattern.startsWith('/');
+  pattern = normalizeGlobPath(pattern.replace(/^\/+/, ''));
+  if (!pattern) return null;
+
+  const patterns = new Set<string>();
+  const addPattern = (candidate: string) => {
+    if (!candidate) return;
+    patterns.add(candidate);
+    if (!anchored && !candidate.startsWith('**/')) {
+      patterns.add(`**/${candidate}`);
+    }
+  };
+
+  if (pattern.endsWith('/')) {
+    const base = pattern.replace(/\/+$/, '');
+    if (!base) return null;
+    addPattern(base);
+    addPattern(`${base}/**`);
+  } else {
+    addPattern(pattern);
+
+    // For non-glob patterns, also match directory descendants.
+    const hasGlobMagic = /[*?[\]{}()!+@]/.test(pattern);
+    if (!hasGlobMagic) {
+      addPattern(`${pattern}/**`);
+    }
+  }
+
+  return {
+    negated,
+    patterns: Array.from(patterns),
+  };
+};
+
+export const parseUserIgnoreRules = (content: string): UserIgnoreRule[] =>
+  content
+    .split(/\r?\n/)
+    .map(parseUserIgnoreRule)
+    .filter((rule): rule is UserIgnoreRule => rule !== null);
+
+export const loadUserIgnoreRules = async (
+  repoPath: string,
+  opts?: { enabled?: boolean; fileName?: string },
+): Promise<UserIgnoreRule[]> => {
+  if (opts?.enabled === false) return [];
+
+  const fileName = opts?.fileName || USER_IGNORE_FILE;
+  const filePath = path.join(repoPath, fileName);
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return parseUserIgnoreRules(content);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return [];
+    }
+    throw error;
+  }
+};
+
+export const shouldIgnorePathByUserRules = (filePath: string, rules: UserIgnoreRule[]): boolean => {
+  if (rules.length === 0) return false;
+
+  const normalizedPath = normalizeGlobPath(filePath);
+  let ignored = false;
+
+  for (const rule of rules) {
+    const matched = rule.patterns.some(pattern => minimatch(normalizedPath, pattern, USER_IGNORE_MATCH_OPTIONS));
+    if (matched) {
+      ignored = !rule.negated;
+    }
+  }
+
+  return ignored;
+};
 
 
 export const shouldIgnorePath = (filePath: string): boolean => {
@@ -236,4 +339,3 @@ export const shouldIgnorePath = (filePath: string): boolean => {
 
   return false;
 }
-

--- a/gitnexus/src/core/ingestion/filesystem-walker.ts
+++ b/gitnexus/src/core/ingestion/filesystem-walker.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
-import { shouldIgnorePath } from '../../config/ignore-service.js';
+import { loadUserIgnoreRules, shouldIgnorePath, shouldIgnorePathByUserRules, USER_IGNORE_FILE } from '../../config/ignore-service.js';
 
 export interface FileEntry {
   path: string;
@@ -19,6 +19,11 @@ export interface FilePath {
   path: string;
 }
 
+export interface WalkRepositoryOptions {
+  useUserIgnoreFile?: boolean;
+  userIgnoreFileName?: string;
+}
+
 const READ_CONCURRENCY = 32;
 
 /** Skip files larger than 512KB — they're usually generated/vendored and crash tree-sitter */
@@ -30,15 +35,24 @@ const MAX_FILE_SIZE = 512 * 1024;
  */
 export const walkRepositoryPaths = async (
   repoPath: string,
-  onProgress?: (current: number, total: number, filePath: string) => void
+  onProgress?: (current: number, total: number, filePath: string) => void,
+  options?: WalkRepositoryOptions,
 ): Promise<ScannedFile[]> => {
+  const userIgnoreRules = await loadUserIgnoreRules(repoPath, {
+    enabled: options?.useUserIgnoreFile ?? true,
+    fileName: options?.userIgnoreFileName || USER_IGNORE_FILE,
+  });
+
   const files = await glob('**/*', {
     cwd: repoPath,
     nodir: true,
     dot: false,
   });
 
-  const filtered = files.filter(file => !shouldIgnorePath(file));
+  const filtered = files.filter(file =>
+    !shouldIgnorePath(file) &&
+    !shouldIgnorePathByUserRules(file, userIgnoreRules),
+  );
   const entries: ScannedFile[] = [];
   let processed = 0;
   let skippedLarge = 0;

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -28,9 +28,15 @@ const CHUNK_BYTE_BUDGET = 20 * 1024 * 1024; // 20MB
 /** Max AST trees to keep in LRU cache */
 const AST_CACHE_CAP = 50;
 
+export interface PipelineOptions {
+  useUserIgnoreFile?: boolean;
+  userIgnoreFileName?: string;
+}
+
 export const runPipelineFromRepo = async (
   repoPath: string,
-  onProgress: (progress: PipelineProgress) => void
+  onProgress: (progress: PipelineProgress) => void,
+  options?: PipelineOptions,
 ): Promise<PipelineResult> => {
   const graph = createKnowledgeGraph();
   const symbolTable = createSymbolTable();
@@ -50,16 +56,23 @@ export const runPipelineFromRepo = async (
       message: 'Scanning repository...',
     });
 
-    const scannedFiles = await walkRepositoryPaths(repoPath, (current, total, filePath) => {
-      const scanProgress = Math.round((current / total) * 15);
-      onProgress({
-        phase: 'extracting',
-        percent: scanProgress,
-        message: 'Scanning repository...',
-        detail: filePath,
-        stats: { filesProcessed: current, totalFiles: total, nodesCreated: graph.nodeCount },
-      });
-    });
+    const scannedFiles = await walkRepositoryPaths(
+      repoPath,
+      (current, total, filePath) => {
+        const scanProgress = Math.round((current / total) * 15);
+        onProgress({
+          phase: 'extracting',
+          percent: scanProgress,
+          message: 'Scanning repository...',
+          detail: filePath,
+          stats: { filesProcessed: current, totalFiles: total, nodesCreated: graph.nodeCount },
+        });
+      },
+      {
+        useUserIgnoreFile: options?.useUserIgnoreFile ?? true,
+        userIgnoreFileName: options?.userIgnoreFileName,
+      },
+    );
 
     const totalFiles = scannedFiles.length;
 

--- a/gitnexus/test/integration/filesystem-walker.test.ts
+++ b/gitnexus/test/integration/filesystem-walker.test.ts
@@ -13,12 +13,15 @@ describe('filesystem-walker', () => {
     // Create test directory structure
     await fs.mkdir(path.join(tmpDir, 'src'), { recursive: true });
     await fs.mkdir(path.join(tmpDir, 'src', 'components'), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, 'data'), { recursive: true });
     await fs.mkdir(path.join(tmpDir, 'node_modules', 'lodash'), { recursive: true });
     await fs.mkdir(path.join(tmpDir, '.git'), { recursive: true });
 
     await fs.writeFile(path.join(tmpDir, 'src', 'index.ts'), 'export const main = () => {}');
     await fs.writeFile(path.join(tmpDir, 'src', 'utils.ts'), 'export const helper = () => {}');
     await fs.writeFile(path.join(tmpDir, 'src', 'components', 'Button.tsx'), 'export const Button = () => <div/>');
+    await fs.writeFile(path.join(tmpDir, 'src', 'keep.json'), '{"keep": true}');
+    await fs.writeFile(path.join(tmpDir, 'data', 'sample.json'), '{"sample": true}');
     await fs.writeFile(path.join(tmpDir, 'node_modules', 'lodash', 'index.js'), 'module.exports = {}');
     await fs.writeFile(path.join(tmpDir, '.git', 'HEAD'), 'ref: refs/heads/main');
     await fs.writeFile(path.join(tmpDir, 'package.json'), '{}');
@@ -104,6 +107,26 @@ describe('filesystem-walker', () => {
       } finally {
         await fs.rm(emptyDir, { recursive: true, force: true });
       }
+    });
+
+    it('applies .gitnexusignore rules by default', async () => {
+      await fs.writeFile(path.join(tmpDir, '.gitnexusignore'), 'data/\n**/*.json\n!src/keep.json\n');
+
+      const files = await walkRepositoryPaths(tmpDir);
+      const paths = files.map(f => f.path.replace(/\\/g, '/'));
+
+      expect(paths).not.toContain('data/sample.json');
+      expect(paths).toContain('src/keep.json');
+    });
+
+    it('can disable user ignore file rules', async () => {
+      await fs.writeFile(path.join(tmpDir, '.gitnexusignore'), 'data/\n**/*.json\n');
+
+      const files = await walkRepositoryPaths(tmpDir, undefined, { useUserIgnoreFile: false });
+      const paths = files.map(f => f.path.replace(/\\/g, '/'));
+
+      expect(paths).toContain('data/sample.json');
+      expect(paths).toContain('src/keep.json');
     });
   });
 

--- a/gitnexus/test/unit/ignore-service.test.ts
+++ b/gitnexus/test/unit/ignore-service.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { shouldIgnorePath } from '../../src/config/ignore-service.js';
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs/promises';
+import { loadUserIgnoreRules, parseUserIgnoreRules, shouldIgnorePath, shouldIgnorePathByUserRules } from '../../src/config/ignore-service.js';
 
 describe('shouldIgnorePath', () => {
   describe('version control directories', () => {
@@ -74,6 +75,7 @@ describe('shouldIgnorePath', () => {
       'composer.lock', 'Cargo.lock', 'go.sum',
       '.gitignore', '.gitattributes', '.npmrc', '.editorconfig',
       '.prettierrc', '.eslintignore', '.dockerignore',
+      '.gitnexusignore',
       'LICENSE', 'LICENSE.md', 'CHANGELOG.md',
       '.env', '.env.local', '.env.production',
     ])('ignores %s', (fileName) => {
@@ -133,5 +135,62 @@ describe('shouldIgnorePath', () => {
     ])('does not ignore source file %s', (filePath) => {
       expect(shouldIgnorePath(filePath)).toBe(false);
     });
+  });
+});
+
+describe('user ignore rules', () => {
+  it('supports comments, blank lines, directory patterns and glob patterns', () => {
+    const rules = parseUserIgnoreRules(`
+# comment
+data/
+**/*.json
+`);
+
+    expect(shouldIgnorePathByUserRules('data/sample.txt', rules)).toBe(true);
+    expect(shouldIgnorePathByUserRules('nested/data/sample.txt', rules)).toBe(true);
+    expect(shouldIgnorePathByUserRules('src/config.json', rules)).toBe(true);
+    expect(shouldIgnorePathByUserRules('src/index.ts', rules)).toBe(false);
+  });
+
+  it('supports negation rules', () => {
+    const rules = parseUserIgnoreRules(`
+**/*.json
+!src/keep.json
+`);
+
+    expect(shouldIgnorePathByUserRules('src/skip.json', rules)).toBe(true);
+    expect(shouldIgnorePathByUserRules('src/keep.json', rules)).toBe(false);
+  });
+
+  it('supports root anchored rules with leading slash', () => {
+    const rules = parseUserIgnoreRules('/root-only/**');
+
+    expect(shouldIgnorePathByUserRules('root-only/file.txt', rules)).toBe(true);
+    expect(shouldIgnorePathByUserRules('nested/root-only/file.txt', rules)).toBe(false);
+  });
+
+  it('treats bare patterns as matching both the target and descendants', () => {
+    const rules = parseUserIgnoreRules('data');
+
+    expect(shouldIgnorePathByUserRules('data', rules)).toBe(true);
+    expect(shouldIgnorePathByUserRules('data/sample.json', rules)).toBe(true);
+    expect(shouldIgnorePathByUserRules('nested/data/sample.json', rules)).toBe(true);
+  });
+});
+
+describe('loadUserIgnoreRules', () => {
+  it('returns empty rules when ignore file does not exist', async () => {
+    const rules = await loadUserIgnoreRules('/definitely/does-not-exist');
+    expect(rules).toEqual([]);
+  });
+
+  it('rethrows non-missing file system errors', async () => {
+    const readFileSpy = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(
+      Object.assign(new Error('permission denied'), { code: 'EACCES' }),
+    );
+
+    await expect(loadUserIgnoreRules('/tmp/repo')).rejects.toThrow('permission denied');
+
+    readFileSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

This PR adds repository-level user ignore support for `gitnexus analyze` via a new `.gitnexusignore` file.

By default, when `.gitnexusignore` exists in the analyzed repository root, its patterns are applied during file scanning in addition to GitNexus's built-in hardcoded ignore rules. A new CLI escape hatch, `--no-user-ignore`, allows users to disable this behavior and keep current built-in ignore logic only.

## Why

Many repositories include large non-core areas (for example: `data/`, generated snapshots, imported datasets, domain artifacts) that are useful for the repo but noisy for code intelligence indexing.

Today, users cannot control this in a repo-specific way without changing GitNexus source itself. This PR makes indexing more practical and intentional for real-world repos by giving users a simple, local ignore file.

## What Changed

### 1. User ignore parsing + matching

Implemented `.gitnexusignore` support in the ignore service layer.

- Added `USER_IGNORE_FILE = '.gitnexusignore'`
- Added loader and parser:
  - `loadUserIgnoreRules(...)`
  - `parseUserIgnoreRules(...)`
- Added matcher:
  - `shouldIgnorePathByUserRules(...)`

Supported rule behavior:

- blank lines and comments (`# ...`)
- glob patterns (`*`, `**`)
- directory rules with trailing slash (e.g. `data/`)
- anchored root-style patterns with leading `/`
- negation rules with `!` (later rules override earlier rules)

### 2. Scan pipeline integration

Threaded user-ignore options through ingestion scan path:

- `walkRepositoryPaths(...)` now accepts options and applies user rules during filtering
- `runPipelineFromRepo(...)` now accepts pipeline options and forwards them to the walker

This keeps all existing hardcoded ignore behavior intact and adds user ignore as an additive layer.

### 3. Analyze CLI override flag

Added new analyze option:

- `--no-user-ignore`

Behavior:

- default: `.gitnexusignore` is used if present
- with `--no-user-ignore`: `.gitnexusignore` is ignored, built-in rules only

## How It Works

1. Analyzer starts pipeline.
2. Filesystem walker loads `.gitnexusignore` rules (if enabled and file exists).
3. During scan filtering, each path is excluded if:
   - built-in ignore rules match, OR
   - user ignore rules match.
4. Remaining files proceed through existing structure/parse/index pipeline unchanged.

## Examples

Example `.gitnexusignore`:

```gitignore
# ignore non-code data
/data/

# ignore json files globally
**/*.json

# but keep one config file
!src/config/keep.json
```

Default run:

```bash
gitnexus analyze
```

Bypass user ignore file:

```bash
gitnexus analyze --no-user-ignore
```

## Testing

Added tests for both parsing/matching and end-to-end scan behavior:

- Unit tests (`ignore-service.test.ts`)
  - comments/blanks
  - glob patterns
  - negation
  - root-anchored patterns
- Integration tests (`filesystem-walker.test.ts`)
  - `.gitnexusignore` applied by default
  - `useUserIgnoreFile: false` bypass path

Validation performed:

- `npm run build` ✅
- `npm run test` ✅
- `npm run test:integration` ✅ for test assertions; existing unrelated worker-module warnings/errors in integration environment remain unchanged by this PR.

## Backward Compatibility

- No breaking change.
- Existing built-in ignore behavior is preserved.
- New behavior is opt-in by file presence and opt-out via flag.

## Notes

This implementation intentionally focuses on practical glob-based repo-level control for indexing scope and avoids introducing a heavier full gitignore engine. It is designed to solve the high-value use case (excluding non-core directories/files from indexing) with minimal complexity.
