### PR TITLE
fix(ingestion): increase bufferSize from 256KB to 2MB for large files

### DIFF
--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -174,7 +174,7 @@ export const processCalls = async (
       // Cache Miss: Re-parse
       // Use larger bufferSize for files > 32KB
       try {
-        tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 256 });
+        tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 1024 * 2 });
       } catch (parseError) {
         // Skip files that can't be parsed
         continue;

--- a/gitnexus/src/core/ingestion/heritage-processor.ts
+++ b/gitnexus/src/core/ingestion/heritage-processor.ts
@@ -47,7 +47,7 @@ export const processHeritage = async (
     if (!tree) {
       // Use larger bufferSize for files > 32KB
       try {
-        tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 256 });
+        tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 1024 * 2 });
       } catch (parseError) {
         // Skip files that can't be parsed
         continue;

--- a/gitnexus/src/core/ingestion/import-processor.ts
+++ b/gitnexus/src/core/ingestion/import-processor.ts
@@ -794,7 +794,7 @@ export const processImports = async (
 
     if (!tree) {
       try {
-        tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 256 });
+        tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 1024 * 2 });
       } catch (parseError) {
         continue;
       }

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -297,7 +297,7 @@ const processParsingSequential = async (
 
     let tree;
     try {
-      tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 256 });
+      tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 1024 * 2 });
     } catch (parseError) {
       console.warn(`Skipping unparseable file: ${file.path}`);
       continue;

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -1109,7 +1109,7 @@ const processFileGroup = (
 
     let tree;
     try {
-      tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 256 });
+      tree = parser.parse(file.content, undefined, { bufferSize: 1024 * 1024 * 2 });
     } catch {
       continue;
     }


### PR DESCRIPTION
Fixes #198

## Problem
Files between 256KB-512KB crash tree-sitter with `Invalid argument` because bufferSize (256KB) is too small.

The file size filter (`MAX_FILE_SIZE = 512KB`) allows them through, but the parse buffer (`bufferSize: 256KB`) is too small.

## Fix
Increased bufferSize from `1024*256` (256KB) to `1024*1024*2` (2MB)

This allows parsing of files up to MAX_FILE_SIZE (512KB) without errors.

## Files Changed
- `call-processor.ts`
- `heritage-processor.ts`
- `import-processor.ts`
- `parsing-processor.ts`
- `workers/parse-worker.ts`