### PR TITLE
feat(models): add DeepSeek model configurations

### DIFF
--- a/eval/configs/models/deepseek-chat.yaml
+++ b/eval/configs/models/deepseek-chat.yaml
@@ -1,0 +1,13 @@
+model: deepseek-ai/deepseek-chat
+provider: openrouter
+cost:
+  input: 0.14  # per 1M tokens
+  output: 0.28  # per 1M tokens
+  
+# Native DeepSeek API (direct)
+api_key: null
+base_url: null
+
+# For OpenRouter, uncomment below and comment out direct config above
+# api_key: \${OPENROUTER_API_KEY}
+# base_url: https://openrouter.ai/api/v1

--- a/eval/configs/models/deepseek-v3.yaml
+++ b/eval/configs/models/deepseek-v3.yaml
@@ -1,0 +1,15 @@
+model: deepseek-ai/DeepSeek-V3
+provider: openrouter
+cost:
+  input: 0.27  # per 1M tokens
+  output: 1.10  # per 1M tokens
+  
+# Native DeepSeek API (direct)
+# Get your API key at: https://platform.deepseek.com/
+# Or use OpenRouter with: OPENROUTER_API_KEY
+api_key: null
+base_url: null
+
+# For OpenRouter, uncomment below and comment out direct config above
+# api_key: \${OPENROUTER_API_KEY}
+# base_url: https://openrouter.ai/api/v1


### PR DESCRIPTION
Fixes #215

Add configurations for DeepSeek-V3 and DeepSeek-Chat models via OpenRouter integration.

## Models Added
- **DeepSeek-V3**: Reasoning model (input: $0.27/1M, output: $1.10/1M)
- **DeepSeek-Chat**: Chat model (input: $0.14/1M, output: $0.28/1M)

## Usage
Set `OPENROUTER_API_KEY` in `.env` and use:
```bash
python eval/swe_bench/evaluate.py --model deepseek-v3
```

Alternative: Use native DeepSeek API with `api_key` and `base_url` config.