### PR TITLE
fix(embeddings): check CUDA availability before loading ONNX provider

### DIFF
--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -14,8 +14,29 @@ if (!process.env.ORT_LOG_LEVEL) {
   process.env.ORT_LOG_LEVEL = '3';
 }
 
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
 import { DEFAULT_EMBEDDING_CONFIG, type EmbeddingConfig, type ModelProgress } from './types.js';
+
+/**
+ * Check if CUDA is actually available on this system.
+ * onnxruntime-node crashes with a native fatal error (not catchable by JS)
+ * when attempting to load the CUDA provider without CUDA libraries installed.
+ */
+const isCudaAvailable = (): boolean => {
+  try {
+    execSync('nvidia-smi', { stdio: 'ignore', timeout: 3000 });
+    const commonPaths = [
+      '/usr/lib/x86_64-linux-gnu/libcuda.so',
+      '/usr/lib/x86_64-linux-gnu/libcuda.so.1',
+      '/usr/local/cuda/lib64/libcudart.so',
+    ];
+    return commonPaths.some(p => existsSync(p));
+  } catch {
+    return false;
+  }
+};
 
 // Module-level state for singleton pattern
 let embedderInstance: FeatureExtractionPipeline | null = null;
@@ -62,8 +83,11 @@ export const initEmbedder = async (
   const finalConfig = { ...DEFAULT_EMBEDDING_CONFIG, ...config };
   // On Windows, use DirectML for GPU acceleration (via DirectX12)
   // CUDA is only available on Linux x64 with onnxruntime-node
+  // IMPORTANT: Must verify CUDA availability before attempting it — onnxruntime-node
+  // crashes with a native fatal error (not a JS exception) if CUDA libs are missing.
   const isWindows = process.platform === 'win32';
-  const gpuDevice = isWindows ? 'dml' : 'cuda';
+  const cudaAvailable = !isWindows && isCudaAvailable();
+  const gpuDevice = isWindows ? 'dml' : (cudaAvailable ? 'cuda' : 'cpu');
   let requestedDevice = forceDevice || (finalConfig.device === 'auto' ? gpuDevice : finalConfig.device);
 
   initPromise = (async () => {

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -5,7 +5,28 @@
  * For MCP, we only need to compute query embeddings, not batch embed.
  */
 
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
+
+/**
+ * Check if CUDA is actually available on this system.
+ * onnxruntime-node crashes with a native fatal error (not catchable by JS)
+ * when attempting to load the CUDA provider without CUDA libraries installed.
+ */
+const isCudaAvailable = (): boolean => {
+  try {
+    execSync('nvidia-smi', { stdio: 'ignore', timeout: 3000 });
+    const commonPaths = [
+      '/usr/lib/x86_64-linux-gnu/libcuda.so',
+      '/usr/lib/x86_64-linux-gnu/libcuda.so.1',
+      '/usr/local/cuda/lib64/libcudart.so',
+    ];
+    return commonPaths.some(p => existsSync(p));
+  } catch {
+    return false;
+  }
+};
 
 // Model config
 const MODEL_ID = 'Snowflake/snowflake-arctic-embed-xs';
@@ -37,9 +58,12 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
       console.error('GitNexus: Loading embedding model (first search may take a moment)...');
 
       // Try GPU first (DirectML on Windows, CUDA on Linux), fall back to CPU
+      // IMPORTANT: Must verify CUDA before attempting — native crash if libs missing.
       const isWindows = process.platform === 'win32';
-      const gpuDevice = isWindows ? 'dml' : 'cuda';
-      const devicesToTry: Array<'dml' | 'cuda' | 'cpu'> = [gpuDevice, 'cpu'];
+      const cudaAvailable = !isWindows && isCudaAvailable();
+      const gpuDevice = isWindows ? 'dml' : (cudaAvailable ? 'cuda' : 'cpu');
+      const devicesToTry: Array<'dml' | 'cuda' | 'cpu'> =
+        gpuDevice === 'cpu' ? ['cpu'] : [gpuDevice, 'cpu'];
       
       for (const device of devicesToTry) {
         try {


### PR DESCRIPTION
## Summary

- **onnxruntime-node crashes with a native fatal error** (`provider_bridge_ort.cc`) when attempting to load the CUDA execution provider on systems without CUDA libraries (e.g. WSL2, Linux without GPU). This crash happens at the C++ level and **cannot be caught by JavaScript try/catch**, so the existing GPU-to-CPU fallback never triggers.
- Adds `isCudaAvailable()` pre-check that verifies `nvidia-smi` and `libcuda.so` presence before attempting the CUDA backend. Systems without CUDA now go directly to CPU without crashing.
- Fixes both CLI embedder and MCP embedder.

## Reproduction

```bash
# On WSL2 or Linux without CUDA:
gitnexus analyze --embeddings
# → native crash in provider_bridge_ort.cc, process exits
```

## Test plan

- [ ] Run `gitnexus analyze --embeddings` on Linux/WSL2 without CUDA — should use CPU backend successfully
- [ ] Run `gitnexus analyze --embeddings` on a system with CUDA — should still use CUDA
- [ ] Run `gitnexus analyze` (without `--embeddings`) — no change in behavior
- [ ] Verify MCP semantic search works on non-CUDA systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)