### PR TITLE
feat: add --mpc-only flag to analyze command

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -45,6 +45,7 @@ function ensureHeap(): boolean {
 export interface AnalyzeOptions {
   force?: boolean;
   embeddings?: boolean;
+  mpcOnly?: boolean;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -311,14 +312,17 @@ export const analyzeCommand = async (
     aggregatedClusterCount = Array.from(groups.values()).filter(count => count >= 5).length;
   }
 
-  const aiContext = await generateAIContextFiles(repoPath, storagePath, projectName, {
-    files: pipelineResult.totalFileCount,
-    nodes: stats.nodes,
-    edges: stats.edges,
-    communities: pipelineResult.communityResult?.stats.totalCommunities,
-    clusters: aggregatedClusterCount,
-    processes: pipelineResult.processResult?.stats.totalProcesses,
-  });
+  // Skip AI context file generation when --mcp-only is set
+  const aiContext = options.mpcOnly
+    ? { files: [], hooks: [] }
+    : await generateAIContextFiles(repoPath, storagePath, projectName, {
+        files: pipelineResult.totalFileCount,
+        nodes: stats.nodes,
+        edges: stats.edges,
+        communities: pipelineResult.communityResult?.stats.totalCommunities,
+        clusters: aggregatedClusterCount,
+        processes: pipelineResult.processResult?.stats.totalProcesses,
+      });
 
   await closeKuzu();
   // Note: we intentionally do NOT call disposeEmbedder() here.

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -26,6 +26,7 @@ program
   .description('Index a repository (full analysis)')
   .option('-f, --force', 'Force full re-index even if up to date')
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
+  .option('--mpc-only', 'Index only — skip writing CLAUDE.md, AGENTS.md, skills, and hooks')
   .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 
 program


### PR DESCRIPTION
Adds `--mpc-only` flag to `gitnexus analyze` that runs indexing without generating CLAUDE.md, AGENTS.md, skills, or hooks.

Useful when you only need the graph index updated (e.g. for MCP queries) and don't want AI context files overwritten.