### PR TITLE
feat: add .gitnexusignore support

### DIFF
--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -20,6 +20,7 @@
         "graphology": "^0.25.4",
         "graphology-indices": "^0.17.0",
         "graphology-utils": "^2.3.0",
+        "ignore": "^7.0.5",
         "kuzu": "^0.11.3",
         "lru-cache": "^11.0.0",
         "mnemonist": "^0.39.0",
@@ -3698,6 +3699,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/inherits": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -58,6 +58,7 @@
     "graphology": "^0.25.4",
     "graphology-indices": "^0.17.0",
     "graphology-utils": "^2.3.0",
+    "ignore": "^7.0.5",
     "kuzu": "^0.11.3",
     "lru-cache": "^11.0.0",
     "mnemonist": "^0.39.0",

--- a/gitnexus/src/config/ignore-service.ts
+++ b/gitnexus/src/config/ignore-service.ts
@@ -1,3 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import ignore, { Ignore } from 'ignore';
+
+/**
+ * Load a .gitnexusignore file from the repository root.
+ * Returns an `ignore` instance that can test paths against the patterns.
+ * If no .gitnexusignore exists, returns null (graceful fallback).
+ */
+export const loadGitNexusIgnore = (repoPath: string): Ignore | null => {
+  const ignorePath = path.join(repoPath, '.gitnexusignore');
+  try {
+    const content = fs.readFileSync(ignorePath, 'utf-8');
+    const ig = ignore();
+    ig.add(content);
+    return ig;
+  } catch {
+    // No .gitnexusignore file — that's fine, return null
+    return null;
+  }
+};
+
 const DEFAULT_IGNORE_LIST = new Set([
     // Version Control
     '.git',

--- a/gitnexus/src/core/ingestion/filesystem-walker.ts
+++ b/gitnexus/src/core/ingestion/filesystem-walker.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
-import { shouldIgnorePath } from '../../config/ignore-service.js';
+import { shouldIgnorePath, loadGitNexusIgnore } from '../../config/ignore-service.js';
 
 export interface FileEntry {
   path: string;
@@ -38,7 +38,14 @@ export const walkRepositoryPaths = async (
     dot: false,
   });
 
-  const filtered = files.filter(file => !shouldIgnorePath(file));
+  // Load .gitnexusignore patterns (null if file doesn't exist)
+  const nexusIgnore = loadGitNexusIgnore(repoPath);
+
+  const filtered = files.filter(file => {
+    if (shouldIgnorePath(file)) return false;
+    if (nexusIgnore && nexusIgnore.ignores(file)) return false;
+    return true;
+  });
   const entries: ScannedFile[] = [];
   let processed = 0;
   let skippedLarge = 0;


### PR DESCRIPTION
## Summary
- Adds `.gitnexusignore` file support (standard `.gitignore` syntax) to exclude files/directories from indexing
- Uses the `ignore` npm package for pattern matching (glob, `#` comments, `!` negation)
- Patterns applied early in `walkRepositoryPaths()` before stat/read, for performance
- Graceful fallback when no `.gitnexusignore` exists

Closes #228

## Files changed
- `gitnexus/src/config/ignore-service.ts` — new `loadGitNexusIgnore()` function
- `gitnexus/src/core/ingestion/filesystem-walker.ts` — integrated ignore patterns into file discovery
- `gitnexus/package.json` — added `ignore` dependency

## Test plan
- [ ] Create `.gitnexusignore` with patterns like `node_modules/`, `*.generated.ts`
- [ ] Run `gitnexus analyze` and verify excluded files are not indexed
- [ ] Verify no `.gitnexusignore` = no change in behavior
- [ ] Verify `!` negation patterns work

🤖 Generated with [Claude Code](https://claude.com/claude-code)