### PR TITLE
feat: add MiniMax as a first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ npm install
 npm run dev
 ```
 
-The web UI uses the same indexing pipeline as the CLI but runs entirely in WebAssembly (Tree-sitter WASM, KuzuDB WASM, in-browser embeddings). It's great for quick exploration but limited by browser memory for larger repos.
+The web UI uses the same indexing pipeline as the CLI but runs entirely in WebAssembly (Tree-sitter WASM, KuzuDB WASM, in-browser embeddings). It's great for quick exploration but limited by browser memory for larger repos. The built-in AI chat supports multiple LLM providers: OpenAI, Google Gemini, Anthropic, Azure OpenAI, Ollama, OpenRouter, and MiniMax.
 
 **Local Backend Mode:** Run `gitnexus serve` and open the web UI locally — it auto-detects the server and shows all your indexed repos, with full AI chat support. No need to re-upload or re-index. The agent's tools (Cypher queries, search, code navigation) route through the backend HTTP API automatically.
 
@@ -468,11 +468,14 @@ gitnexus wiki
 gitnexus wiki --model gpt-4o
 gitnexus wiki --base-url https://api.anthropic.com/v1
 
+# Use MiniMax
+gitnexus wiki --model MiniMax-M2.5 --base-url https://api.minimax.io/v1
+
 # Force full regeneration
 gitnexus wiki --force
 ```
 
-The wiki generator reads the indexed graph structure, groups files into modules via LLM, generates per-module documentation pages, and creates an overview page — all with cross-references to the knowledge graph.
+The wiki generator reads the indexed graph structure, groups files into modules via LLM, generates per-module documentation pages, and creates an overview page — all with cross-references to the knowledge graph. It supports any OpenAI-compatible provider including OpenAI, Anthropic, MiniMax, and others.
 
 ---
 

--- a/gitnexus-web/src/components/SettingsPanel.tsx
+++ b/gitnexus-web/src/components/SettingsPanel.tsx
@@ -281,7 +281,7 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
 
   if (!isOpen) return null;
 
-  const providers: LLMProvider[] = ['openai', 'gemini', 'anthropic', 'azure-openai', 'ollama', 'openrouter'];
+  const providers: LLMProvider[] = ['openai', 'gemini', 'anthropic', 'azure-openai', 'ollama', 'openrouter', 'minimax'];
 
 
   return (
@@ -366,7 +366,7 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
                     w-8 h-8 rounded-lg flex items-center justify-center text-lg
                     ${settings.activeProvider === provider ? 'bg-accent/20' : 'bg-surface'}
                   `}>
-                    {provider === 'openai' ? '🤖' : provider === 'gemini' ? '💎' : provider === 'anthropic' ? '🧠' : provider === 'ollama' ? '🦙' : provider === 'openrouter' ? '🌐' : '☁️'}
+                    {provider === 'openai' ? '🤖' : provider === 'gemini' ? '💎' : provider === 'anthropic' ? '🧠' : provider === 'ollama' ? '🦙' : provider === 'openrouter' ? '🌐' : provider === 'minimax' ? '⚡' : '☁️'}
                   </div>
                   <span className="font-medium">{getProviderDisplayName(provider)}</span>
                 </button>
@@ -814,7 +814,61 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
             </div>
           )}
 
+          {/* MiniMax Settings */}
+          {settings.activeProvider === 'minimax' && (
+            <div className="space-y-4 animate-fade-in">
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
+                  <Key className="w-4 h-4" />
+                  API Key
+                </label>
+                <div className="relative">
+                  <input
+                    type={showApiKey['minimax'] ? 'text' : 'password'}
+                    value={settings.minimax?.apiKey ?? ''}
+                    onChange={e => setSettings(prev => ({
+                      ...prev,
+                      minimax: { ...prev.minimax!, apiKey: e.target.value }
+                    }))}
+                    placeholder="Enter your MiniMax API key"
+                    className="w-full px-4 py-3 pr-12 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => toggleApiKeyVisibility('minimax')}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-text-muted hover:text-text-primary transition-colors"
+                  >
+                    {showApiKey['minimax'] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                </div>
+                <p className="text-xs text-text-muted">
+                  Get your API key from{' '}
+                  <a
+                    href="https://platform.minimax.io"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent hover:underline"
+                  >
+                    MiniMax Platform
+                  </a>
+                </p>
+              </div>
 
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-text-secondary">Model</label>
+                <input
+                  type="text"
+                  value={settings.minimax?.model ?? 'MiniMax-M2.5'}
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    minimax: { ...prev.minimax!, model: e.target.value }
+                  }))}
+                  placeholder="e.g., MiniMax-M2.5, MiniMax-M2.5-highspeed"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-sm"
+                />
+              </div>
+            </div>
+          )}
 
           {/* Privacy Note */}
           <div className="p-4 bg-elevated/50 border border-border-subtle rounded-xl">

--- a/gitnexus-web/src/core/llm/agent.ts
+++ b/gitnexus-web/src/core/llm/agent.ts
@@ -13,14 +13,15 @@ import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatOllama } from '@langchain/ollama';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { createGraphRAGTools } from './tools';
-import type { 
-  ProviderConfig, 
+import type {
+  ProviderConfig,
   OpenAIConfig,
-  AzureOpenAIConfig, 
+  AzureOpenAIConfig,
   GeminiConfig,
   AnthropicConfig,
   OllamaConfig,
   OpenRouterConfig,
+  MiniMaxConfig,
   AgentStreamChunk,
 } from './types';
 import { 
@@ -197,7 +198,7 @@ export const createChatModel = (config: ProviderConfig): BaseChatModel => {
     
     case 'openrouter': {
       const openRouterConfig = config as OpenRouterConfig;
-      
+
       // Debug logging
       if (import.meta.env.DEV) {
         console.log('🌐 OpenRouter config:', {
@@ -207,11 +208,11 @@ export const createChatModel = (config: ProviderConfig): BaseChatModel => {
           baseUrl: openRouterConfig.baseUrl,
         });
       }
-      
+
       if (!openRouterConfig.apiKey || openRouterConfig.apiKey.trim() === '') {
         throw new Error('OpenRouter API key is required but was not provided');
       }
-      
+
       return new ChatOpenAI({
         openAIApiKey: openRouterConfig.apiKey,
         apiKey: openRouterConfig.apiKey, // Fallback for some versions
@@ -225,7 +226,29 @@ export const createChatModel = (config: ProviderConfig): BaseChatModel => {
         streaming: true,
       });
     }
-    
+
+    case 'minimax': {
+      const minimaxConfig = config as MiniMaxConfig;
+
+      if (!minimaxConfig.apiKey || minimaxConfig.apiKey.trim() === '') {
+        throw new Error('MiniMax API key is required but was not provided');
+      }
+
+      // MiniMax provides an OpenAI-compatible API
+      return new ChatOpenAI({
+        apiKey: minimaxConfig.apiKey,
+        modelName: minimaxConfig.model,
+        // MiniMax requires temperature in (0.0, 1.0], avoid zero
+        temperature: Math.max(minimaxConfig.temperature ?? 0.1, 0.01),
+        maxTokens: minimaxConfig.maxTokens,
+        configuration: {
+          apiKey: minimaxConfig.apiKey,
+          baseURL: 'https://api.minimax.io/v1',
+        },
+        streaming: true,
+      });
+    }
+
     default:
       throw new Error(`Unsupported provider: ${(config as any).provider}`);
   }

--- a/gitnexus-web/src/core/llm/settings-service.ts
+++ b/gitnexus-web/src/core/llm/settings-service.ts
@@ -5,9 +5,9 @@
  * All API keys are stored locally - never sent to any server except the LLM provider.
  */
 
-import { 
-  LLMSettings, 
-  DEFAULT_LLM_SETTINGS, 
+import {
+  LLMSettings,
+  DEFAULT_LLM_SETTINGS,
   LLMProvider,
   OpenAIConfig,
   AzureOpenAIConfig,
@@ -15,6 +15,7 @@ import {
   AnthropicConfig,
   OllamaConfig,
   OpenRouterConfig,
+  MiniMaxConfig,
   ProviderConfig,
 } from './types';
 
@@ -59,6 +60,10 @@ export const loadSettings = (): LLMSettings => {
       openrouter: {
         ...DEFAULT_LLM_SETTINGS.openrouter,
         ...parsed.openrouter,
+      },
+      minimax: {
+        ...DEFAULT_LLM_SETTINGS.minimax,
+        ...parsed.minimax,
       },
     };
   } catch (error) {
@@ -162,6 +167,17 @@ export const updateProviderSettings = <T extends LLMProvider>(
       saveSettings(updated);
       return updated;
     }
+    case 'minimax': {
+      const updated: LLMSettings = {
+        ...current,
+        minimax: {
+          ...(current.minimax ?? {}),
+          ...(updates as Partial<Omit<MiniMaxConfig, 'provider'>>),
+        },
+      };
+      saveSettings(updated);
+      return updated;
+    }
     default: {
       // Should be unreachable due to T extends LLMProvider, but keep a safe fallback
       const updated: LLMSettings = { ...current };
@@ -245,7 +261,16 @@ export const getActiveProviderConfig = (): ProviderConfig | null => {
         temperature: settings.openrouter.temperature,
         maxTokens: settings.openrouter.maxTokens,
       } as OpenRouterConfig;
-      
+
+    case 'minimax':
+      if (!settings.minimax?.apiKey) {
+        return null;
+      }
+      return {
+        provider: 'minimax',
+        ...settings.minimax,
+      } as MiniMaxConfig;
+
     default:
       return null;
   }
@@ -282,6 +307,8 @@ export const getProviderDisplayName = (provider: LLMProvider): string => {
       return 'Ollama (Local)';
     case 'openrouter':
       return 'OpenRouter';
+    case 'minimax':
+      return 'MiniMax';
     default:
       return provider;
   }
@@ -303,6 +330,8 @@ export const getAvailableModels = (provider: LLMProvider): string[] => {
       return ['claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022', 'claude-3-5-haiku-20241022', 'claude-3-opus-20240229'];
     case 'ollama':
       return ['llama3.2', 'llama3.1', 'mistral', 'codellama', 'deepseek-coder'];
+    case 'minimax':
+      return ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed'];
     default:
       return [];
   }

--- a/gitnexus-web/src/core/llm/types.ts
+++ b/gitnexus-web/src/core/llm/types.ts
@@ -8,7 +8,7 @@
 /**
  * Supported LLM providers
  */
-export type LLMProvider = 'openai' | 'azure-openai' | 'gemini' | 'anthropic' | 'ollama' | 'openrouter';
+export type LLMProvider = 'openai' | 'azure-openai' | 'gemini' | 'anthropic' | 'ollama' | 'openrouter' | 'minimax';
 
 /**
  * Base configuration shared by all providers
@@ -79,9 +79,18 @@ export interface OpenRouterConfig extends BaseProviderConfig {
 }
 
 /**
+ * MiniMax configuration (OpenAI-compatible API)
+ */
+export interface MiniMaxConfig extends BaseProviderConfig {
+  provider: 'minimax';
+  apiKey: string;
+  model: string;  // e.g., 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'
+}
+
+/**
  * Union type for all provider configurations
  */
-export type ProviderConfig = OpenAIConfig | AzureOpenAIConfig | GeminiConfig | AnthropicConfig | OllamaConfig | OpenRouterConfig;
+export type ProviderConfig = OpenAIConfig | AzureOpenAIConfig | GeminiConfig | AnthropicConfig | OllamaConfig | OpenRouterConfig | MiniMaxConfig;
 
 /**
  * Stored settings (what goes to localStorage)
@@ -98,6 +107,7 @@ export interface LLMSettings {
   anthropic?: Partial<Omit<AnthropicConfig, 'provider'>>;
   ollama?: Partial<Omit<OllamaConfig, 'provider'>>;
   openrouter?: Partial<Omit<OpenRouterConfig, 'provider'>>;
+  minimax?: Partial<Omit<MiniMaxConfig, 'provider'>>;
 
   // Intelligent Clustering Settings
   intelligentClustering: boolean;
@@ -146,6 +156,11 @@ export const DEFAULT_LLM_SETTINGS: LLMSettings = {
     apiKey: '',
     model: '',
     baseUrl: 'https://openrouter.ai/api/v1',
+    temperature: 0.1,
+  },
+  minimax: {
+    apiKey: '',
+    model: 'MiniMax-M2.5',
     temperature: 0.1,
   },
 };


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimaxi.com) as a native LLM provider in the web UI, alongside the existing OpenAI, Gemini, Anthropic, Azure OpenAI, Ollama, and OpenRouter providers.

### Why

MiniMax offers powerful models (MiniMax-M2.5 with 204K context window) via an OpenAI-compatible API. While users can already access MiniMax through OpenRouter, adding direct support provides:

- **Lower latency** — direct API calls without the OpenRouter middleware
- **Simpler setup** — users just need a MiniMax API key, no OpenRouter account required
- **Better discoverability** — MiniMax appears as a first-class option in the provider selector

### Changes

- **`types.ts`** — Add `MiniMaxConfig` interface and `'minimax'` to the `LLMProvider` union type
- **`agent.ts`** — Add `'minimax'` case to `createChatModel()` using the OpenAI-compatible client pointed at `https://api.minimax.io/v1`
- **`settings-service.ts`** — Add MiniMax support to all settings functions (load, save, display name, available models)
- **`SettingsPanel.tsx`** — Add MiniMax provider button and configuration form (API key + model selection)
- **`README.md`** — Document MiniMax as a supported provider and add wiki generation example

### Supported Models

| Model | Context Window | Notes |
|-------|---------------|-------|
| `MiniMax-M2.5` | 204K tokens | Default, full capability |
| `MiniMax-M2.5-highspeed` | 204K tokens | Optimized for speed |

### Note

MiniMax API requires temperature in `(0.0, 1.0]` (zero is rejected), so the implementation clamps temperature to a minimum of `0.01`.

## Test Plan

- [ ] Verify MiniMax appears in the provider selector grid
- [ ] Verify MiniMax settings form shows API key and model fields
- [ ] Verify settings persist correctly in localStorage
- [ ] Verify `createChatModel` creates a valid ChatOpenAI instance with MiniMax base URL
- [ ] Verify existing providers are unaffected