### PR TITLE
fix: run impact enrichment queries sequentially to prevent KuzuDB segfault

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1412,27 +1412,27 @@ export class LocalBackend {
       const d1Ids = (grouped[1] || []).map((i: any) => `'${i.id.replace(/'/g, "''")}'`).join(', ');
 
       // Affected processes: which execution flows are broken and at which step
-      const [processRows, moduleRows, directModuleRows] = await Promise.all([
-        executeQuery(repo.id, `
+      // NOTE: KuzuDB's native addon is not thread-safe — concurrent executeQuery calls
+      // via Promise.all cause a segfault (SIGSEGV, exit 139). Run queries sequentially.
+      const processRows = await executeQuery(repo.id, `
           MATCH (s)-[r:CodeRelation {type: 'STEP_IN_PROCESS'}]->(p:Process)
           WHERE s.id IN [${allIds}]
           RETURN p.heuristicLabel AS name, COUNT(DISTINCT s.id) AS hits, MIN(r.step) AS minStep, p.stepCount AS stepCount
           ORDER BY hits DESC
           LIMIT 20
-        `).catch(() => []),
-        executeQuery(repo.id, `
+        `).catch(() => []);
+      const moduleRows = await executeQuery(repo.id, `
           MATCH (s)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
           WHERE s.id IN [${allIds}]
           RETURN c.heuristicLabel AS name, COUNT(DISTINCT s.id) AS hits
           ORDER BY hits DESC
           LIMIT 20
-        `).catch(() => []),
-        d1Ids ? executeQuery(repo.id, `
+        `).catch(() => []);
+      const directModuleRows = await (d1Ids ? executeQuery(repo.id, `
           MATCH (s)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
           WHERE s.id IN [${d1Ids}]
           RETURN DISTINCT c.heuristicLabel AS name
-        `).catch(() => []) : Promise.resolve([]),
-      ]);
+        `).catch(() => []) : Promise.resolve([]));
 
       affectedProcesses = processRows.map((r: any) => ({
         name: r.name || r[0],


### PR DESCRIPTION
## Problem

`npx gitnexus impact <symbol>` crashes with **exit code 139 (SIGSEGV)** on macOS arm64 (and likely other platforms).

### Root cause

The `impact()` enrichment phase fires three `executeQuery` calls concurrently via `Promise.all`:

```ts
const [processRows, moduleRows, directModuleRows] = await Promise.all([
  executeQuery(repo.id, `...processRows...`).catch(() => []),
  executeQuery(repo.id, `...moduleRows...`).catch(() => []),
  executeQuery(repo.id, `...directModuleRows...`).catch(() => []),
]);
```

KuzuDB's native addon (`kuzujs-darwin-arm64.node` / platform equivalents) is **not thread-safe**. Issuing concurrent queries against the same database connection causes a memory conflict in the native layer → segfault.

### Verification

```bash
# Sequential — OK (exit 0)
await executeQuery(repoId, query1);
await executeQuery(repoId, query2);
await executeQuery(repoId, query3);

# Concurrent — CRASH (exit 139)
await Promise.all([
  executeQuery(repoId, query1),
  executeQuery(repoId, query2),
  executeQuery(repoId, query3),
]);
```

Note: `gitnexus context` and `gitnexus query` are unaffected because they never issue concurrent `executeQuery` calls.

## Fix

Replace the three-way `Promise.all` with sequential `await` calls so only one KuzuDB query is in-flight at a time. The performance impact is negligible — these are three lightweight graph traversal queries on a local embedded database.

## Test plan

- [ ] `npx gitnexus impact <any-symbol>` completes without crash on macOS arm64
- [ ] Returned result includes `affected_processes`, `affected_modules`, and `byDepth` as before
- [ ] `gitnexus context` and `gitnexus query` still work correctly (no regression)