### PR TITLE
fix(impact): run DB queries sequentially to prevent segfault

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1412,27 +1412,28 @@ export class LocalBackend {
       const d1Ids = (grouped[1] || []).map((i: any) => `'${i.id.replace(/'/g, "''")}'`).join(', ');
 
       // Affected processes: which execution flows are broken and at which step
-      const [processRows, moduleRows, directModuleRows] = await Promise.all([
-        executeQuery(repo.id, `
+      // NOTE: queries are run sequentially to avoid concurrent access to the
+      // native DB addon (LadybugDB/KuzuDB C++ bindings are not thread-safe).
+      // Running them via Promise.all caused non-deterministic segfaults (#292).
+      const processRows = await executeQuery(repo.id, `
           MATCH (s)-[r:CodeRelation {type: 'STEP_IN_PROCESS'}]->(p:Process)
           WHERE s.id IN [${allIds}]
           RETURN p.heuristicLabel AS name, COUNT(DISTINCT s.id) AS hits, MIN(r.step) AS minStep, p.stepCount AS stepCount
           ORDER BY hits DESC
           LIMIT 20
-        `).catch(() => []),
-        executeQuery(repo.id, `
+        `).catch(() => []);
+      const moduleRows = await executeQuery(repo.id, `
           MATCH (s)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
           WHERE s.id IN [${allIds}]
           RETURN c.heuristicLabel AS name, COUNT(DISTINCT s.id) AS hits
           ORDER BY hits DESC
           LIMIT 20
-        `).catch(() => []),
-        d1Ids ? executeQuery(repo.id, `
+        `).catch(() => []);
+      const directModuleRows = await (d1Ids ? executeQuery(repo.id, `
           MATCH (s)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
           WHERE s.id IN [${d1Ids}]
           RETURN DISTINCT c.heuristicLabel AS name
-        `).catch(() => []) : Promise.resolve([]),
-      ]);
+        `).catch(() => []) : Promise.resolve([]));
 
       affectedProcesses = processRows.map((r: any) => ({
         name: r.name || r[0],


### PR DESCRIPTION
## Problem

`gitnexus impact <symbol>` crashes with a **segfault** on any symbol that has non-trivial results (i.e. the knowledge graph actually has process/community data for it).

Root cause: the impact-enrichment block at `src/mcp/local/local-backend.ts` fires three Cypher queries **concurrently** via `Promise.all`:

```typescript
const [processRows, moduleRows, directModuleRows] = await Promise.all([
  executeQuery(repo.id, `...processRows...`).catch(() => []),
  executeQuery(repo.id, `...moduleRows...`).catch(() => []),
  d1Ids ? executeQuery(repo.id, `...directModuleRows...`).catch(() => []) : Promise.resolve([]),
]);
```

LadybugDB / KuzuDB's native C++ addon is **not thread-safe** — concurrent calls from the same process corrupt internal state and segfault.  This is confirmed by the upstream issue tracker for both libraries.

Closes #292.

## Fix

Replace `Promise.all` with three sequential `await` calls.  Each query retains its own `.catch(() => [])` guard so a failing query cannot abort the whole report:

```typescript
const processRows    = await executeQuery(repo.id, `...`).catch(() => []);
const moduleRows     = await executeQuery(repo.id, `...`).catch(() => []);
const directModuleRows = await (d1Ids
  ? executeQuery(repo.id, `...`).catch(() => [])
  : Promise.resolve([]));
```

The three queries are short graph lookups (LIMIT 20) so the latency difference is negligible.

## Test plan

- [ ] Run `npx gitnexus impact <any-symbol>` on an indexed repo — no segfault
- [ ] Verify `affectedProcesses` and `affectedModules` are still populated correctly in the output
- [ ] `npm run build` passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)