### PR TITLE
feat: Adds Elixir Language Support

### DIFF
--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -157,7 +157,7 @@ GitNexus supports indexing multiple repositories. Each `gitnexus analyze` regist
 
 ## Supported Languages
 
-TypeScript, JavaScript, Python, Java, C, C++, C#, Go, Rust, PHP, Kotlin, Swift, Ruby
+TypeScript, JavaScript, Python, Java, C, C++, C#, Go, Rust, PHP, Kotlin, Swift, Ruby, Elixir
 
 ### Language Feature Matrix
 
@@ -176,6 +176,7 @@ TypeScript, JavaScript, Python, Java, C, C++, C#, Go, Rust, PHP, Kotlin, Swift, 
 | Swift | — | — | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | C | — | — | ✓ | — | ✓ | ✓ | — | ✓ | ✓ |
 | C++ | — | — | ✓ | ✓ | ✓ | ✓ | — | ✓ | ✓ |
+| Elixir | ✓ | — | ✓ | ✓ | ✓ | ✓ | — | ✓ | ✓ |
 
 **Imports** — cross-file import resolution · **Named Bindings** — `import { X as Y }` / re-export tracking · **Exports** — public/exported symbol detection · **Heritage** — class inheritance, interfaces, mixins · **Type Annotations** — explicit type extraction for receiver resolution · **Constructor Inference** — infer receiver type from constructor calls (`self`/`this` resolution included for all languages) · **Config** — language toolchain config parsing (tsconfig, go.mod, etc.) · **Frameworks** — AST-based framework pattern detection · **Entry Points** — entry point scoring heuristics
 

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -57,6 +57,7 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
+        "tree-sitter-elixir": "^0.3.5",
         "tree-sitter-kotlin": "^0.3.8",
         "tree-sitter-swift": "^0.6.0"
       }
@@ -5084,6 +5085,28 @@
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
+    },
+    "node_modules/tree-sitter-elixir": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-elixir/-/tree-sitter-elixir-0.3.5.tgz",
+      "integrity": "sha512-xozQMvYK0aSolcQZAx2d84Xe/YMWFuRPYFlLVxO01bM2GITh5jyiIp0TqPCQa8754UzRAI7A83hZmfiYub5TZQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      }
+    },
+    "node_modules/tree-sitter-elixir/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/tree-sitter-go": {
       "version": "0.21.2",

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.0.0",
+    "@ladybugdb/core": "^0.15.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "cli-progress": "^3.12.0",
     "commander": "^12.0.0",
@@ -59,7 +60,6 @@
     "graphology": "^0.25.4",
     "graphology-indices": "^0.17.0",
     "graphology-utils": "^2.3.0",
-    "@ladybugdb/core": "^0.15.2",
     "ignore": "^7.0.5",
     "lru-cache": "^11.0.0",
     "mnemonist": "^0.39.0",
@@ -79,6 +79,7 @@
     "uuid": "^13.0.0"
   },
   "optionalDependencies": {
+    "tree-sitter-elixir": "^0.3.5",
     "tree-sitter-kotlin": "^0.3.8",
     "tree-sitter-swift": "^0.6.0"
   },

--- a/gitnexus/src/config/supported-languages.ts
+++ b/gitnexus/src/config/supported-languages.ts
@@ -12,4 +12,5 @@ export enum SupportedLanguages {
     PHP = 'php',
     Kotlin = 'kotlin',
     Swift = 'swift',
+    Elixir = 'elixir',
 }

--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -22,10 +22,12 @@ import {
   CALL_EXPRESSION_TYPES,
   extractMixedChain,
   type MixedChainStep,
+  isElixirFunctionDef,
 } from './utils.js';
 import { buildTypeEnv } from './type-env.js';
 import type { ConstructorBinding } from './type-env.js';
 import { getTreeSitterBufferSize } from './constants.js';
+import { SupportedLanguages } from '../../config/supported-languages.js';
 import type { ExtractedCall, ExtractedAssignment, ExtractedHeritage, ExtractedRoute, FileConstructorBindings } from './workers/parse-worker.js';
 import { callRouters } from './call-routing.js';
 import { extractReturnTypeName, stripNullable } from './type-extractors/shared.js';
@@ -63,6 +65,15 @@ const findEnclosingFunction = (
 
         return generateId(label, `${filePath}:${funcName}`);
       }
+    }
+    // Elixir: call nodes with def/defp/defmacro target are function definitions
+    const elixirName = isElixirFunctionDef(current);
+    if (elixirName) {
+      const resolved = ctx.resolve(elixirName, filePath);
+      if (resolved?.tier === 'same-file' && resolved.candidates.length > 0) {
+        return resolved.candidates[0].nodeId;
+      }
+      return generateId('Function', `${filePath}:${elixirName}`);
     }
     current = current.parent;
   }
@@ -319,10 +330,12 @@ export const processCalls = async (
         }
       }
 
-      if (isBuiltInOrNoise(calledName)) return;
-
       const callNode = captureMap['call'];
       const callForm = inferCallForm(callNode, nameNode);
+      // Skip built-in/noise names for free and constructor calls.
+      // Elixir member calls (e.g. Repo.insert) have explicit module receiver context
+      // that disambiguates common names — skip the filter for those only.
+      if (isBuiltInOrNoise(calledName) && (callForm !== 'member' || language !== SupportedLanguages.Elixir)) return;
       const receiverName = callForm === 'member' ? extractReceiverName(nameNode) : undefined;
       let receiverTypeName = receiverName && typeEnv ? typeEnv.lookup(receiverName, callNode) : undefined;
       // Fall back to verified constructor bindings for return type inference

--- a/gitnexus/src/core/ingestion/call-routing.ts
+++ b/gitnexus/src/core/ingestion/call-routing.ts
@@ -11,7 +11,7 @@
  * Keep both copies in sync until a shared package is introduced.
  */
 
-import { SupportedLanguages } from '../../config/supported-languages.js';
+import { SupportedLanguages } from "../../config/supported-languages.js";
 
 // ── Call routing dispatch table ─────────────────────────────────────────────
 
@@ -41,24 +41,28 @@ export const callRouters = {
   [SupportedLanguages.CPlusPlus]: noRouting,
   [SupportedLanguages.C]: noRouting,
   [SupportedLanguages.Ruby]: routeRubyCall,
+  [SupportedLanguages.Elixir]: routeElixirCall,
 } satisfies Record<SupportedLanguages, CallRouter>;
 
 // ── Result types ────────────────────────────────────────────────────────────
 
 export type RubyCallRouting =
-  | { kind: 'import'; importPath: string; isRelative: boolean }
-  | { kind: 'heritage'; items: RubyHeritageItem[] }
-  | { kind: 'properties'; items: RubyPropertyItem[] }
-  | { kind: 'call' }
-  | { kind: 'skip' };
+  | { kind: "import"; importPath: string; isRelative: boolean }
+  | { kind: "heritage"; items: HeritageItem[] }
+  | { kind: "properties"; items: RubyPropertyItem[] }
+  | { kind: "call" }
+  | { kind: "skip" };
 
-export interface RubyHeritageItem {
+export interface HeritageItem {
   enclosingClass: string;
   mixinName: string;
-  heritageKind: 'include' | 'extend' | 'prepend';
+  heritageKind: "include" | "extend" | "prepend" | "use" | "behaviour";
 }
 
-export type RubyAccessorType = 'attr_accessor' | 'attr_reader' | 'attr_writer';
+/** @deprecated Use HeritageItem instead */
+export type RubyHeritageItem = HeritageItem;
+
+export type RubyAccessorType = "attr_accessor" | "attr_reader" | "attr_writer";
 
 export interface RubyPropertyItem {
   propName: string;
@@ -70,8 +74,8 @@ export interface RubyPropertyItem {
 }
 
 // ── Pre-allocated singletons for common return values ────────────────────────
-const CALL_RESULT: RubyCallRouting = { kind: 'call' };
-const SKIP_RESULT: RubyCallRouting = { kind: 'skip' };
+const CALL_RESULT: RubyCallRouting = { kind: "call" };
+const SKIP_RESULT: RubyCallRouting = { kind: "skip" };
 
 /** Max depth for parent-walking loops to prevent pathological AST traversals */
 const MAX_PARENT_DEPTH = 50;
@@ -85,48 +89,68 @@ const MAX_PARENT_DEPTH = 50;
  * @param callNode   - The tree-sitter `call` AST node
  * @returns A discriminated union describing the call's semantic role
  */
-export function routeRubyCall(calledName: string, callNode: any): RubyCallRouting {
+export function routeRubyCall(
+  calledName: string,
+  callNode: any,
+): RubyCallRouting {
   // ── require / require_relative → import ─────────────────────────────────
-  if (calledName === 'require' || calledName === 'require_relative') {
-    const argList = callNode.childForFieldName?.('arguments');
-    const stringNode = argList?.children?.find((c: any) => c.type === 'string');
-    const contentNode = stringNode?.children?.find((c: any) => c.type === 'string_content');
+  if (calledName === "require" || calledName === "require_relative") {
+    const argList = callNode.childForFieldName?.("arguments");
+    const stringNode = argList?.children?.find((c: any) => c.type === "string");
+    const contentNode = stringNode?.children?.find(
+      (c: any) => c.type === "string_content",
+    );
     if (!contentNode) return SKIP_RESULT;
 
     let importPath: string = contentNode.text;
     // Validate: reject null bytes, control chars, excessively long paths
-    if (!importPath || importPath.length > 1024 || /[\x00-\x1f]/.test(importPath)) {
+    if (
+      !importPath ||
+      importPath.length > 1024 ||
+      /[\x00-\x1f]/.test(importPath)
+    ) {
       return SKIP_RESULT;
     }
-    const isRelative = calledName === 'require_relative';
-    if (isRelative && !importPath.startsWith('.')) {
-      importPath = './' + importPath;
+    const isRelative = calledName === "require_relative";
+    if (isRelative && !importPath.startsWith(".")) {
+      importPath = "./" + importPath;
     }
-    return { kind: 'import', importPath, isRelative };
+    return { kind: "import", importPath, isRelative };
   }
 
   // ── include / extend / prepend → heritage (mixin) ──────────────────────
-  if (calledName === 'include' || calledName === 'extend' || calledName === 'prepend') {
+  if (
+    calledName === "include" ||
+    calledName === "extend" ||
+    calledName === "prepend"
+  ) {
     let enclosingClass: string | null = null;
     let current = callNode.parent;
     let depth = 0;
     while (current && ++depth <= MAX_PARENT_DEPTH) {
-      if (current.type === 'class' || current.type === 'module') {
-        const nameNode = current.childForFieldName?.('name');
-        if (nameNode) { enclosingClass = nameNode.text; break; }
+      if (current.type === "class" || current.type === "module") {
+        const nameNode = current.childForFieldName?.("name");
+        if (nameNode) {
+          enclosingClass = nameNode.text;
+          break;
+        }
       }
       current = current.parent;
     }
     if (!enclosingClass) return SKIP_RESULT;
 
-    const items: RubyHeritageItem[] = [];
-    const argList = callNode.childForFieldName?.('arguments');
-    for (const arg of (argList?.children ?? [])) {
-      if (arg.type === 'constant' || arg.type === 'scope_resolution') {
-        items.push({ enclosingClass, mixinName: arg.text, heritageKind: calledName as 'include' | 'extend' | 'prepend' });
+    const items: HeritageItem[] = [];
+    const argList = callNode.childForFieldName?.("arguments");
+    for (const arg of argList?.children ?? []) {
+      if (arg.type === "constant" || arg.type === "scope_resolution") {
+        items.push({
+          enclosingClass,
+          mixinName: arg.text,
+          heritageKind: calledName as "include" | "extend" | "prepend",
+        });
       }
     }
-    return items.length > 0 ? { kind: 'heritage', items } : SKIP_RESULT;
+    return items.length > 0 ? { kind: "heritage", items } : SKIP_RESULT;
   }
 
   // ── attr_accessor / attr_reader / attr_writer → property definitions ───
@@ -151,11 +175,11 @@ export function routeRubyCall(calledName: string, callNode: any): RubyCallRoutin
     }
 
     const items: RubyPropertyItem[] = [];
-    const argList = callNode.childForFieldName?.('arguments');
-    for (const arg of (argList?.children ?? [])) {
-      if (arg.type === 'simple_symbol') {
+    const argList = callNode.childForFieldName?.("arguments");
+    for (const arg of argList?.children ?? []) {
+      if (arg.type === "simple_symbol") {
         items.push({
-          propName: arg.text.startsWith(':') ? arg.text.slice(1) : arg.text,
+          propName: arg.text.startsWith(":") ? arg.text.slice(1) : arg.text,
           accessorType: calledName as RubyAccessorType,
           startLine: arg.startPosition.row,
           endLine: arg.endPosition.row,
@@ -163,9 +187,44 @@ export function routeRubyCall(calledName: string, callNode: any): RubyCallRoutin
         });
       }
     }
-    return items.length > 0 ? { kind: 'properties', items } : SKIP_RESULT;
+    return items.length > 0 ? { kind: "properties", items } : SKIP_RESULT;
   }
 
   // ── Everything else → regular call ─────────────────────────────────────
+  return CALL_RESULT;
+}
+
+// ── Elixir call routing ──────────────────────────────────────────────────────
+
+/** Elixir call routing reuses the shared RubyCallRouting type with extended heritage kinds. */
+export type ElixirCallRouting = RubyCallRouting;
+
+/** Names that produce definition nodes rather than call edges */
+const ELIXIR_DEF_KEYWORDS = new Set([
+  "defmodule",
+  "def",
+  "defp",
+  "defmacro",
+  "defmacrop",
+  "defstruct",
+  "defprotocol",
+  "defimpl",
+  "defguard",
+  "defguardp",
+  "defdelegate",
+]);
+
+/**
+ * Classify an Elixir call node and extract its semantic payload.
+ *
+ * Import keywords (alias/import/require/use) are excluded by #not-eq? in
+ * the tree-sitter queries and handled by dedicated @import/@heritage captures,
+ * so this function only needs to filter definition keywords.
+ */
+export function routeElixirCall(
+  calledName: string,
+  _callNode: any,
+): ElixirCallRouting {
+  if (ELIXIR_DEF_KEYWORDS.has(calledName)) return SKIP_RESULT;
   return CALL_RESULT;
 }

--- a/gitnexus/src/core/ingestion/export-detection.ts
+++ b/gitnexus/src/core/ingestion/export-detection.ts
@@ -205,6 +205,31 @@ const swiftExportChecker: ExportChecker = (node, _name) => {
   return false;
 };
 
+/**
+ * Elixir: `def`/`defmacro`/`defguard`/`defdelegate`/`defmodule`/`defstruct`/`defprotocol`/`defimpl` = public.
+ * `defp`/`defmacrop`/`defguardp` = private.
+ * Walk up from the name node to find the enclosing `call` node whose target
+ * identifier tells us if it's a public or private definition.
+ */
+const elixirExportChecker: ExportChecker = (node, _name) => {
+  let current: SyntaxNode | null = node;
+  while (current) {
+    if (current.type === 'call') {
+      const target = current.childForFieldName?.('target');
+      if (target?.type === 'identifier') {
+        const text = target.text;
+        if (text === 'defp' || text === 'defmacrop' || text === 'defguardp') return false;
+        if (text === 'def' || text === 'defmacro' || text === 'defguard' ||
+            text === 'defdelegate' || text === 'defmodule' || text === 'defstruct' ||
+            text === 'defprotocol' || text === 'defimpl') return true;
+      }
+    }
+    current = current.parent;
+  }
+  // Top-level module definitions are public by default
+  return true;
+};
+
 // ============================================================================
 // Exhaustive dispatch table — satisfies enforces all SupportedLanguages are covered
 // ============================================================================
@@ -223,6 +248,7 @@ const exportCheckers = {
   [SupportedLanguages.PHP]: phpExportChecker,
   [SupportedLanguages.Swift]: swiftExportChecker,
   [SupportedLanguages.Ruby]: (_node, _name) => true,
+  [SupportedLanguages.Elixir]: elixirExportChecker,
 } satisfies Record<SupportedLanguages, ExportChecker>;
 
 // ============================================================================

--- a/gitnexus/src/core/ingestion/framework-detection.ts
+++ b/gitnexus/src/core/ingestion/framework-detection.ts
@@ -330,6 +330,55 @@ export function detectFrameworkFromPath(filePath: string): FrameworkHint | null 
     return { framework: 'laravel', entryPointMultiplier: 1.5, reason: 'laravel-repository' };
   }
 
+  // ========== ELIXIR / PHOENIX ==========
+
+  // Phoenix controllers (highest — HTTP entry points)
+  if (p.includes('/controllers/') && (p.endsWith('.ex') || p.endsWith('.exs'))) {
+    return { framework: 'phoenix', entryPointMultiplier: 3.0, reason: 'phoenix-controller' };
+  }
+  if (p.endsWith('_controller.ex')) {
+    return { framework: 'phoenix', entryPointMultiplier: 3.0, reason: 'phoenix-controller-file' };
+  }
+
+  // Phoenix LiveView (high — real-time entry points)
+  if (p.includes('/live/') && (p.endsWith('.ex') || p.endsWith('.exs'))) {
+    return { framework: 'phoenix-liveview', entryPointMultiplier: 3.0, reason: 'phoenix-liveview' };
+  }
+  if (p.endsWith('_live.ex')) {
+    return { framework: 'phoenix-liveview', entryPointMultiplier: 3.0, reason: 'phoenix-liveview-file' };
+  }
+
+  // Phoenix channels
+  if (p.includes('/channels/') && p.endsWith('.ex')) {
+    return { framework: 'phoenix-channel', entryPointMultiplier: 2.5, reason: 'phoenix-channel' };
+  }
+  if (p.endsWith('_channel.ex')) {
+    return { framework: 'phoenix-channel', entryPointMultiplier: 2.5, reason: 'phoenix-channel-file' };
+  }
+
+  // Phoenix router and endpoint
+  if (p.endsWith('/router.ex') && p.includes('_web')) {
+    return { framework: 'phoenix', entryPointMultiplier: 3.0, reason: 'phoenix-router' };
+  }
+  if (p.endsWith('/endpoint.ex') && p.includes('_web')) {
+    return { framework: 'phoenix', entryPointMultiplier: 3.0, reason: 'phoenix-endpoint' };
+  }
+
+  // Phoenix views and components
+  if ((p.includes('/views/') || p.includes('/components/')) && p.includes('_web') && p.endsWith('.ex')) {
+    return { framework: 'phoenix', entryPointMultiplier: 2.0, reason: 'phoenix-view' };
+  }
+
+  // Elixir OTP application entry point
+  if (p.endsWith('/application.ex')) {
+    return { framework: 'elixir-otp', entryPointMultiplier: 3.0, reason: 'elixir-otp-application' };
+  }
+
+  // mix.exs project definition
+  if (p.endsWith('/mix.exs')) {
+    return { framework: 'elixir', entryPointMultiplier: 1.5, reason: 'elixir-mix' };
+  }
+
   // ========== RUBY ==========
 
   // Ruby: bin/ or exe/ (CLI entry points)
@@ -447,6 +496,15 @@ export const FRAMEWORK_AST_PATTERNS = {
   'uikit': ['viewDidLoad', 'viewWillAppear', 'viewDidAppear', 'UIViewController'],
   'swiftui': ['@main', 'WindowGroup', 'ContentView', '@StateObject', '@ObservedObject'],
   'combine': ['sink', 'assign', 'Publisher', 'Subscriber'],
+
+  // Elixir/Phoenix
+  'phoenix': ['use Phoenix.Router', 'use Phoenix.Controller', 'use Phoenix.LiveView',
+              'use Phoenix.Channel', 'use Phoenix.Component', 'plug ', 'pipe_through',
+              'live ', 'resources '],
+  'phoenix-liveview': ['use Phoenix.LiveView', 'use Phoenix.LiveComponent',
+                       'handle_event', 'handle_params', 'mount'],
+  'elixir-otp': ['use GenServer', 'use Supervisor', 'use Agent', 'use Task',
+                 'handle_call', 'handle_cast', 'handle_info'],
 };
 
 import { SupportedLanguages } from '../../config/supported-languages.js';
@@ -487,6 +545,11 @@ const AST_FRAMEWORK_PATTERNS_BY_LANGUAGE: Record<string, AstFrameworkPatternConf
   ],
   [SupportedLanguages.PHP]: [
     { framework: 'laravel', entryPointMultiplier: 3.0, reason: 'php-route-attribute', patterns: FRAMEWORK_AST_PATTERNS.laravel },
+  ],
+  [SupportedLanguages.Elixir]: [
+    { framework: 'phoenix', entryPointMultiplier: 3.0, reason: 'phoenix-pattern', patterns: FRAMEWORK_AST_PATTERNS.phoenix },
+    { framework: 'phoenix-liveview', entryPointMultiplier: 3.0, reason: 'phoenix-liveview-pattern', patterns: FRAMEWORK_AST_PATTERNS['phoenix-liveview'] },
+    { framework: 'elixir-otp', entryPointMultiplier: 2.5, reason: 'elixir-otp-pattern', patterns: FRAMEWORK_AST_PATTERNS['elixir-otp'] },
   ],
 };
 

--- a/gitnexus/src/core/ingestion/import-processor.ts
+++ b/gitnexus/src/core/ingestion/import-processor.ts
@@ -32,6 +32,7 @@ import {
   resolveRustImport,
   resolveRubyImport,
   resolvePythonImport,
+  resolveElixirImports,
 } from './resolvers/index.js';
 import { callRouters } from './call-routing.js';
 import type { ResolutionContext } from './resolution-context.js';
@@ -232,6 +233,13 @@ function resolveLanguageImport(
   if (language === SupportedLanguages.Ruby) {
     const resolved = resolveRubyImport(rawImportPath, normalizedFileList, allFileList, index);
     return resolved ? { kind: 'files', files: [resolved] } : null;
+  }
+
+  // Elixir: alias / import / require / use (module dot paths)
+  // resolveElixirImports handles multi-alias expansion (MyApp.{User, Admin} → both files)
+  if (language === SupportedLanguages.Elixir) {
+    const resolved = resolveElixirImports(rawImportPath, normalizedFileList, allFileList, index);
+    return resolved.length > 0 ? { kind: 'files', files: resolved } : null;
   }
 
   // Rust: expand top-level grouped imports: use {crate::a, crate::b}

--- a/gitnexus/src/core/ingestion/resolvers/elixir.ts
+++ b/gitnexus/src/core/ingestion/resolvers/elixir.ts
@@ -1,0 +1,78 @@
+/**
+ * Elixir module import resolution.
+ * Converts Elixir module paths (e.g., MyApp.Accounts.User) to file paths
+ * using the standard Elixir convention: CamelCase module segments → snake_case directories.
+ */
+
+import type { SuffixIndex } from './utils.js';
+import { suffixResolve } from './utils.js';
+
+/**
+ * Convert a CamelCase Elixir module segment to snake_case.
+ * Examples: "MyApp" → "my_app", "HTTPClient" → "http_client", "UserService" → "user_service"
+ */
+function toSnakeCase(segment: string): string {
+  return segment
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z\d])([A-Z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+/**
+ * Resolve an Elixir module path to matching .ex or .exs file(s).
+ *
+ * Module paths use dots: MyApp.Accounts.User → lib/my_app/accounts/user.ex
+ * Convention: each CamelCase segment becomes a snake_case directory/file.
+ *
+ * Also handles multi-alias syntax captured as a single string:
+ * "MyApp.{User, Admin}" → expands to ["MyApp.User", "MyApp.Admin"]
+ */
+export function resolveElixirImport(
+  importPath: string,
+  normalizedFileList: string[],
+  allFileList: string[],
+  index?: SuffixIndex,
+): string | null {
+  const results = resolveElixirImports(importPath, normalizedFileList, allFileList, index);
+  return results.length > 0 ? results[0] : null;
+}
+
+/**
+ * Resolve an Elixir module path to all matching .ex or .exs file paths.
+ * For multi-alias syntax (MyApp.{User, Admin}), returns one path per resolved module.
+ */
+export function resolveElixirImports(
+  importPath: string,
+  normalizedFileList: string[],
+  allFileList: string[],
+  index?: SuffixIndex,
+): string[] {
+  // Handle multi-alias: MyApp.{User, Admin} — resolve all matches
+  const multiMatch = importPath.match(/^(.+)\.\{(.+)\}$/);
+  if (multiMatch) {
+    const prefix = multiMatch[1];
+    const names = multiMatch[2].split(',').map(s => s.trim());
+    const results: string[] = [];
+    for (const name of names) {
+      const resolved = resolveElixirSingleImport(`${prefix}.${name}`, normalizedFileList, allFileList, index);
+      if (resolved) results.push(resolved);
+    }
+    return results;
+  }
+
+  const resolved = resolveElixirSingleImport(importPath, normalizedFileList, allFileList, index);
+  return resolved ? [resolved] : [];
+}
+
+function resolveElixirSingleImport(
+  importPath: string,
+  normalizedFileList: string[],
+  allFileList: string[],
+  index?: SuffixIndex,
+): string | null {
+  // Convert MyApp.Accounts.User → my_app/accounts/user
+  const segments = importPath.split('.');
+  const snakeParts = segments.map(toSnakeCase);
+
+  return suffixResolve(snakeParts, normalizedFileList, allFileList, index);
+}

--- a/gitnexus/src/core/ingestion/resolvers/index.ts
+++ b/gitnexus/src/core/ingestion/resolvers/index.ts
@@ -23,5 +23,7 @@ export { resolveRubyImport } from './ruby.js';
 
 export { resolvePythonImport } from './python.js';
 
+export { resolveElixirImport, resolveElixirImports } from './elixir.js';
+
 export { resolveImportPath, RESOLVE_CACHE_CAP } from './standard.js';
 export type { TsconfigPaths } from './standard.js';

--- a/gitnexus/src/core/ingestion/resolvers/utils.ts
+++ b/gitnexus/src/core/ingestion/resolvers/utils.ts
@@ -28,6 +28,8 @@ export const EXTENSIONS = [
   '.swift',
   // Ruby
   '.rb',
+  // Elixir
+  '.ex', '.exs',
 ];
 
 /**

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -896,6 +896,211 @@ export const SWIFT_QUERIES = `
 
 `;
 
+// Elixir queries - works with tree-sitter-elixir
+// NOTE: Elixir's macro-based syntax means defmodule, def, alias, etc. are all `call` nodes.
+// We use #eq? predicates on target identifiers to distinguish definition keywords from
+// regular function calls. Module attributes (@spec, @behaviour) are `unary_operator` nodes.
+// Pipe operator `|>` chains produce nested `binary_operator` nodes whose RHS calls are
+// captured by the regular call queries below.
+export const ELIXIR_QUERIES = `
+; ── Definitions ───────────────────────────────────────────────────────────────
+
+; defmodule MyApp.User do ... end
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @name)
+  (#eq? @_kw "defmodule")) @definition.module
+
+; def func(args) do ... end
+(call
+  target: (identifier) @_kw
+  (arguments
+    (call
+      target: (identifier) @name))
+  (#eq? @_kw "def")) @definition.function
+
+; defp func(args) do ... end (private)
+(call
+  target: (identifier) @_kw
+  (arguments
+    (call
+      target: (identifier) @name))
+  (#eq? @_kw "defp")) @definition.function
+
+; defmacro name(args) do ... end
+(call
+  target: (identifier) @_kw
+  (arguments
+    (call
+      target: (identifier) @name))
+  (#eq? @_kw "defmacro")) @definition.macro
+
+; defmacrop name(args) do ... end (private macro)
+(call
+  target: (identifier) @_kw
+  (arguments
+    (call
+      target: (identifier) @name))
+  (#eq? @_kw "defmacrop")) @definition.macro
+
+; defguard name(args) when ... (public guard)
+(call
+  target: (identifier) @_kw
+  (arguments
+    (call
+      target: (identifier) @name))
+  (#eq? @_kw "defguard")) @definition.macro
+
+; defguardp name(args) when ... (private guard)
+(call
+  target: (identifier) @_kw
+  (arguments
+    (call
+      target: (identifier) @name))
+  (#eq? @_kw "defguardp")) @definition.macro
+
+; defguard with when clause (binary_operator wraps the call)
+(call
+  target: (identifier) @_kw
+  (arguments
+    (binary_operator
+      left: (call
+        target: (identifier) @name)))
+  (#eq? @_kw "defguard")) @definition.macro
+
+; defguardp with when clause (binary_operator wraps the call)
+(call
+  target: (identifier) @_kw
+  (arguments
+    (binary_operator
+      left: (call
+        target: (identifier) @name)))
+  (#eq? @_kw "defguardp")) @definition.macro
+
+; defdelegate func(arg), to: OtherModule
+(call
+  target: (identifier) @_kw
+  (arguments
+    (call
+      target: (identifier) @name))
+  (#eq? @_kw "defdelegate")) @definition.function
+
+; defstruct — excluded from @call captures; the enclosing defmodule provides the struct name.
+
+; defprotocol Printable do ... end
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @name)
+  (#eq? @_kw "defprotocol")) @definition.interface
+
+; defimpl Printable, for: MyApp.User do ... end
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @name)
+  (#eq? @_kw "defimpl")) @definition.impl
+
+; ── Imports ───────────────────────────────────────────────────────────────────
+
+; alias MyApp.Repo / alias MyApp.{User, Admin}
+(call
+  target: (identifier) @_kw
+  (arguments [(alias) (dot)] @import.source)
+  (#eq? @_kw "alias")) @import
+
+; import Ecto.Query
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @import.source)
+  (#eq? @_kw "import")) @import
+
+; require Logger
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @import.source)
+  (#eq? @_kw "require")) @import
+
+; use Phoenix.Controller (also captured as heritage below)
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @import.source)
+  (#eq? @_kw "use")) @import
+
+; ── Calls (excluding definition/import keywords) ─────────────────────────────
+
+; Regular function calls
+(call
+  target: (identifier) @call.name
+  (#not-eq? @call.name "defmodule")
+  (#not-eq? @call.name "def")
+  (#not-eq? @call.name "defp")
+  (#not-eq? @call.name "defmacro")
+  (#not-eq? @call.name "defmacrop")
+  (#not-eq? @call.name "defstruct")
+  (#not-eq? @call.name "defprotocol")
+  (#not-eq? @call.name "defimpl")
+  (#not-eq? @call.name "defguard")
+  (#not-eq? @call.name "defguardp")
+  (#not-eq? @call.name "defdelegate")
+  (#not-eq? @call.name "alias")
+  (#not-eq? @call.name "import")
+  (#not-eq? @call.name "require")
+  (#not-eq? @call.name "use")) @call
+
+; Qualified calls: Module.func()
+(call
+  target: (dot
+    right: (identifier) @call.name)) @call
+
+; ── Heritage ──────────────────────────────────────────────────────────────────
+
+; use Module inside defmodule → heritage extends
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @heritage.class)
+  (do_block
+    (call
+      target: (identifier) @_use
+      (arguments (alias) @heritage.extends)
+      (#eq? @_use "use")))
+  (#eq? @_kw "defmodule")) @heritage
+
+; @behaviour Module inside defmodule → heritage implements
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @heritage.class)
+  (do_block
+    (unary_operator
+      operand: (call
+        target: (identifier) @_attr
+        (arguments (alias) @heritage.implements)
+        (#eq? @_attr "behaviour"))))
+  (#eq? @_kw "defmodule")) @heritage
+
+; @behaviour :atom_module inside defmodule → heritage implements (OTP atom form)
+(call
+  target: (identifier) @_kw
+  (arguments (alias) @heritage.class)
+  (do_block
+    (unary_operator
+      operand: (call
+        target: (identifier) @_attr
+        (arguments (atom) @heritage.implements)
+        (#eq? @_attr "behaviour"))))
+  (#eq? @_kw "defmodule")) @heritage
+
+; defimpl Protocol, for: Module → IMPLEMENTS edge
+(call
+  target: (identifier) @_kw
+  (arguments
+    (alias) @heritage.implements
+    (keywords
+      (pair
+        (keyword) @_for_kw
+        (alias) @heritage.class)))
+  (#eq? @_kw "defimpl")
+  (#match? @_for_kw "^for")) @heritage
+`;
+
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.TypeScript]: TYPESCRIPT_QUERIES,
   [SupportedLanguages.JavaScript]: JAVASCRIPT_QUERIES,
@@ -910,5 +1115,6 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.PHP]: PHP_QUERIES,
   [SupportedLanguages.Kotlin]: KOTLIN_QUERIES,
   [SupportedLanguages.Swift]: SWIFT_QUERIES,
+  [SupportedLanguages.Elixir]: ELIXIR_QUERIES,
 };
  

--- a/gitnexus/src/core/ingestion/type-env.ts
+++ b/gitnexus/src/core/ingestion/type-env.ts
@@ -1,5 +1,5 @@
 import type { SyntaxNode } from './utils.js';
-import { FUNCTION_NODE_TYPES, extractFunctionName, CLASS_CONTAINER_TYPES, isBuiltInOrNoise } from './utils.js';
+import { FUNCTION_NODE_TYPES, extractFunctionName, CLASS_CONTAINER_TYPES, isBuiltInOrNoise, isElixirFunctionDef } from './utils.js';
 import { SupportedLanguages } from '../../config/supported-languages.js';
 import { typeConfigs, TYPED_PARAMETER_TYPES } from './type-extractors/index.js';
 import type { ClassNameLookup, ReturnTypeLookup, ForLoopExtractorContext, PendingAssignment } from './type-extractors/types.js';
@@ -84,7 +84,13 @@ const findNarrowingBranchScope = (node: SyntaxNode): SyntaxNode | undefined => {
 };
 
 /** Bare nullable keywords that fastStripNullable must reject. */
-const FAST_NULLABLE_KEYWORDS = new Set(['null', 'undefined', 'void', 'None', 'nil']);
+const FAST_NULLABLE_KEYWORDS = new Set([
+  'null',
+  'undefined',
+  'void',
+  'None',
+  'nil',
+]);
 
 /**
  * Fast-path nullable check: 90%+ of type names are simple identifiers (e.g. "User")
@@ -93,7 +99,7 @@ const FAST_NULLABLE_KEYWORDS = new Set(['null', 'undefined', 'void', 'None', 'ni
  */
 const fastStripNullable = (typeName: string): string | undefined => {
   if (FAST_NULLABLE_KEYWORDS.has(typeName)) return undefined;
-  return (typeName.indexOf('|') === -1 && typeName.indexOf('?') === -1)
+  return typeName.indexOf('|') === -1 && typeName.indexOf('?') === -1
     ? typeName
     : stripNullable(typeName);
 };
@@ -106,7 +112,12 @@ const lookupInEnv = (
   patternOverrides?: PatternOverrides,
 ): string | undefined => {
   // Self/this receiver: resolve to enclosing class name via AST walk
-  if (varName === 'self' || varName === 'this' || varName === '$this') {
+  if (
+    varName === 'self' ||
+    varName === 'this' ||
+    varName === '$this' ||
+    varName === '__MODULE__'
+  ) {
     return findEnclosingClassName(callNode);
   }
 
@@ -148,7 +159,6 @@ const lookupInEnv = (
   return raw ? fastStripNullable(raw) : undefined;
 };
 
-
 /**
  * Walk up the AST from a node to find the enclosing class/module name.
  * Used to resolve `self`/`this` receivers to their containing type.
@@ -156,9 +166,18 @@ const lookupInEnv = (
 const findEnclosingClassName = (node: SyntaxNode): string | undefined => {
   let current = node.parent;
   while (current) {
+    // Elixir: defmodule is a call node with target "defmodule"
+    if (current.type === 'call') {
+      const target = current.childForFieldName('target');
+      if (target?.type === 'identifier' && target.text === 'defmodule') {
+        const args = current.children?.find((c: any) => c.type === 'arguments');
+        const aliasNode = args?.children?.find((c: any) => c.type === 'alias');
+        if (aliasNode) return aliasNode.text;
+      }
+    }
     if (CLASS_CONTAINER_TYPES.has(current.type)) {
-      const nameNode = current.childForFieldName('name')
-        ?? findTypeIdentifierChild(current);
+      const nameNode =
+        current.childForFieldName('name') ?? findTypeIdentifierChild(current);
       if (nameNode) return nameNode.text;
     }
     current = current.parent;
@@ -209,14 +228,17 @@ const findEnclosingParentClassName = (node: SyntaxNode): string | undefined => {
 };
 
 /** Extract the parent/superclass name from a class declaration AST node. */
-const extractParentClassFromNode = (classNode: SyntaxNode): string | undefined => {
+const extractParentClassFromNode = (
+  classNode: SyntaxNode,
+): string | undefined => {
   // 1. Named fields: Java (superclass), Ruby (superclass), Python (superclasses)
   const superclassNode = classNode.childForFieldName('superclass');
   if (superclassNode) {
     // Java: superclass > type_identifier or generic_type, Ruby: superclass > constant
-    const inner = superclassNode.childForFieldName('type')
-      ?? superclassNode.firstNamedChild
-      ?? superclassNode;
+    const inner =
+      superclassNode.childForFieldName('type') ??
+      superclassNode.firstNamedChild ??
+      superclassNode;
     return extractSimpleTypeName(inner) ?? inner.text;
   }
 
@@ -240,10 +262,14 @@ const extractParentClassFromNode = (classNode: SyntaxNode): string | undefined =
           const clause = child.child(j);
           if (clause?.type === 'extends_clause') {
             const typeNode = clause.firstNamedChild;
-            if (typeNode) return extractSimpleTypeName(typeNode) ?? typeNode.text;
+            if (typeNode)
+              return extractSimpleTypeName(typeNode) ?? typeNode.text;
           }
           // JS: direct identifier child (no extends_clause wrapper)
-          if (clause?.type === 'identifier' || clause?.type === 'type_identifier') {
+          if (
+            clause?.type === 'identifier' ||
+            clause?.type === 'type_identifier'
+          ) {
             return clause.text;
           }
         }
@@ -256,7 +282,8 @@ const extractParentClassFromNode = (classNode: SyntaxNode): string | undefined =
         if (first) {
           // generic_name wraps the identifier: BaseClass<T>
           if (first.type === 'generic_name') {
-            const inner = first.childForFieldName('name') ?? first.firstNamedChild;
+            const inner =
+              first.childForFieldName('name') ?? first.firstNamedChild;
             if (inner) return inner.text;
           }
           return first.text;
@@ -300,7 +327,8 @@ const extractParentClassFromNode = (classNode: SyntaxNode): string | undefined =
 
       // Swift: inheritance_specifier > user_type > type_identifier
       case 'inheritance_specifier': {
-        const userType = child.childForFieldName('inherits_from') ?? child.firstNamedChild;
+        const userType =
+          child.childForFieldName('inherits_from') ?? child.firstNamedChild;
         if (userType?.type === 'user_type') {
           const typeId = userType.firstNamedChild;
           if (typeId) return typeId.text;
@@ -321,6 +349,8 @@ const findEnclosingScopeKey = (node: SyntaxNode): string | undefined => {
       const { funcName } = extractFunctionName(current);
       if (funcName) return `${funcName}@${current.startIndex}`;
     }
+    const elixirName = isElixirFunctionDef(current);
+    if (elixirName) return `${elixirName}@${current.startIndex}`;
     current = current.parent;
   }
   return undefined;
@@ -347,9 +377,14 @@ const createClassNameLookup = (
       if (localNames.has(name)) return true;
       const cached = memo.get(name);
       if (cached !== undefined) return cached;
-      const result = symbolTable.lookupFuzzy(name).some(def =>
-        def.type === 'Class' || def.type === 'Enum' || def.type === 'Struct',
-      );
+      const result = symbolTable
+        .lookupFuzzy(name)
+        .some(
+          (def) =>
+            def.type === 'Class' ||
+            def.type === 'Enum' ||
+            def.type === 'Struct',
+        );
       memo.set(name, result);
       return result;
     },
@@ -375,15 +410,25 @@ const createClassNameLookup = (
 const SKIP_SUBTREE_TYPES = new Set([
   // Plain string literals (NOT template_string — it contains interpolated expressions
   // that can hold arrow functions with typed parameters, e.g. `${(x: T) => x}`)
-  'string',              'string_literal',
-  'string_content',      'string_fragment',      'heredoc_body',
+  'string',
+  'string_literal',
+  'string_content',
+  'string_fragment',
+  'heredoc_body',
   // Comments
-  'comment',             'line_comment',         'block_comment',
+  'comment',
+  'line_comment',
+  'block_comment',
   // Numeric/boolean/null literals
-  'number',              'integer_literal',      'float_literal',
-  'true',                'false',                'null',
+  'number',
+  'integer_literal',
+  'float_literal',
+  'true',
+  'false',
+  'null',
   // Regex
-  'regex',               'regex_pattern',
+  'regex',
+  'regex_pattern',
 ]);
 
 const CLASS_LIKE_TYPES = new Set(['Class', 'Struct', 'Interface']);
@@ -615,7 +660,7 @@ export const buildTypeEnv = (
       const callables = symbolTable.lookupFuzzyCallable(callee);
       if (callables.length !== 1) return undefined;
       return callables[0].returnType;
-    }
+    },
   };
 
   // Pre-compute combined set of node types that need extractTypeBinding.
@@ -651,7 +696,11 @@ export const buildTypeEnv = (
    * retrieve generic type arguments from the original declaration (e.g., extracting T
    * from Result<T, E> for `if let Ok(x) = res`).
    */
-  const extractTypeBinding = (node: SyntaxNode, scopeEnv: Map<string, string>, scope: string): void => {
+  const extractTypeBinding = (
+    node: SyntaxNode,
+    scopeEnv: Map<string, string>,
+    scope: string,
+  ): void => {
     // This guard eliminates 90%+ of calls before any language dispatch.
     if (TYPED_PARAMETER_TYPES.has(node.type)) {
       // Capture the raw type annotation BEFORE extractParameter.
@@ -677,7 +726,10 @@ export const buildTypeEnv = (
         for (let i = 0; i < node.namedChildCount; i++) {
           const child = node.namedChild(i);
           if (!child) continue;
-          if (!fallbackName && (child.type === 'simple_identifier' || child.type === 'identifier')) {
+          if (
+            !fallbackName &&
+            (child.type === 'simple_identifier' || child.type === 'identifier')
+          ) {
             fallbackName = child;
           }
           if (!fallbackType && (child.type === 'user_type' || child.type === 'type_identifier'
@@ -727,15 +779,19 @@ export const buildTypeEnv = (
         if (!wrapped) {
           for (let i = 0; i < node.namedChildCount; i++) {
             const c = node.namedChild(i);
-            if (c?.type === 'variable_declaration') { wrapped = c; break; }
+            if (c?.type === 'variable_declaration') {
+              wrapped = c;
+              break;
+            }
           }
         }
         if (wrapped) typeNode = wrapped.childForFieldName('type');
       }
       if (typeNode) {
-        const nameNode = node.childForFieldName('name')
-          ?? node.childForFieldName('left')
-          ?? node.childForFieldName('pattern');
+        const nameNode =
+          node.childForFieldName('name') ??
+          node.childForFieldName('left') ??
+          node.childForFieldName('pattern');
         if (nameNode) {
           const varName = extractVarName(nameNode);
           if (varName && !declarationTypeNodes.has(`${scope}\0${varName}`)) {
@@ -750,7 +806,10 @@ export const buildTypeEnv = (
       // is on variable_declarator children, capture via keysBefore/keysAfter diff.
       if (typeNode && keysBefore) {
         for (const varName of scopeEnv.keys()) {
-          if (!keysBefore.has(varName) && !declarationTypeNodes.has(`${scope}\0${varName}`)) {
+          if (
+            !keysBefore.has(varName) &&
+            !declarationTypeNodes.has(`${scope}\0${varName}`)
+          ) {
             declarationTypeNodes.set(`${scope}\0${varName}`, typeNode);
           }
         }
@@ -774,8 +833,8 @@ export const buildTypeEnv = (
     // Currently only C++ uses this locally; other languages rely on the SymbolTable path.
     if (CLASS_CONTAINER_TYPES.has(node.type)) {
       // Most languages use 'name' field; Kotlin uses a type_identifier child instead
-      const nameNode = node.childForFieldName('name')
-        ?? findTypeIdentifierChild(node);
+      const nameNode =
+        node.childForFieldName('name') ?? findTypeIdentifierChild(node);
       if (nameNode) localClassNames.add(nameNode.text);
     }
 
@@ -784,6 +843,9 @@ export const buildTypeEnv = (
     if (FUNCTION_NODE_TYPES.has(node.type)) {
       const { funcName } = extractFunctionName(node);
       if (funcName) scope = `${funcName}@${node.startIndex}`;
+    } else {
+      const elixirName = isElixirFunctionDef(node);
+      if (elixirName) scope = `${elixirName}@${node.startIndex}`;
     }
 
     // Only create scope map and call extractTypeBinding for interesting node types.
@@ -799,11 +861,20 @@ export const buildTypeEnv = (
     // or narrow existing variables within a branch (null-check narrowing).
     // Runs after Tier 0/1 so scopeEnv already contains the source variable's type.
     // Conservative: extractor returns undefined when source type is unknown.
-    if (config.extractPatternBinding && (!config.patternBindingNodeTypes || config.patternBindingNodeTypes.has(node.type))) {
+    if (
+      config.extractPatternBinding &&
+      (!config.patternBindingNodeTypes ||
+        config.patternBindingNodeTypes.has(node.type))
+    ) {
       // Ensure scopeEnv exists for pattern binding reads/writes
       if (!env.has(scope)) env.set(scope, new Map());
       const scopeEnv = env.get(scope)!;
-      const patternBinding = config.extractPatternBinding(node, scopeEnv, declarationTypeNodes, scope);
+      const patternBinding = config.extractPatternBinding(
+        node,
+        scopeEnv,
+        declarationTypeNodes,
+        scope,
+      );
       if (patternBinding) {
         if (patternBinding.narrowingRange) {
           // Explicit narrowing range (null-check narrowing): always store in patternOverrides
@@ -822,9 +893,11 @@ export const buildTypeEnv = (
           // preventing cross-arm contamination (e.g., Kotlin when/is).
           const branchNode = findNarrowingBranchScope(node);
           if (branchNode) {
-            if (!patternOverrides.has(scope)) patternOverrides.set(scope, new Map());
+            if (!patternOverrides.has(scope))
+              patternOverrides.set(scope, new Map());
             const varMap = patternOverrides.get(scope)!;
-            if (!varMap.has(patternBinding.varName)) varMap.set(patternBinding.varName, []);
+            if (!varMap.has(patternBinding.varName))
+              varMap.set(patternBinding.varName, []);
             varMap.get(patternBinding.varName)!.push({
               rangeStart: branchNode.startIndex,
               rangeEnd: branchNode.endIndex,
@@ -911,7 +984,8 @@ export const buildTypeEnv = (
   }
 
   return {
-    lookup: (varName, callNode) => lookupInEnv(env, varName, callNode, patternOverrides),
+    lookup: (varName, callNode) =>
+      lookupInEnv(env, varName, callNode, patternOverrides),
     constructorBindings: bindings,
     env,
   };
@@ -932,5 +1006,3 @@ export interface ConstructorBinding {
   /** Enclosing class name when callee is a method on a known receiver (e.g. $this) */
   receiverClassName?: string;
 }
-
-

--- a/gitnexus/src/core/ingestion/type-extractors/elixir.ts
+++ b/gitnexus/src/core/ingestion/type-extractors/elixir.ts
@@ -1,0 +1,180 @@
+import type { LanguageTypeConfig, ParameterExtractor, TypeBindingExtractor, ConstructorBindingScanner, ReturnTypeExtractor } from './types.js';
+import type { SyntaxNode } from '../utils.js';
+
+/**
+ * Elixir type extractor — @spec annotation parsing.
+ *
+ * Elixir has no static type system in the traditional sense, but @spec
+ * annotations provide type information:
+ *
+ *   @spec create(map()) :: {:ok, t()} | {:error, term()}
+ *   def create(attrs) do
+ *     ...
+ *   end
+ *
+ * This extractor parses @spec from preceding unary_operator nodes
+ * (module attributes) to extract parameter and return types.
+ *
+ * For struct construction patterns like `user = %User{name: "Alice"}`,
+ * we extract the struct module as the type.
+ */
+
+/** Regex to extract Elixir type names from @spec */
+const SPEC_RETURN_RE = /::\s*(.+)$/;
+
+/** Elixir built-in type names — excluded from type resolution */
+const ELIXIR_BUILTINS = new Set(['integer', 'float', 'binary', 'boolean', 'atom', 'string', 'map', 'list', 'tuple', 'pid', 'reference', 'term', 'any', 'number', 'keyword', 'charlist', 'iodata', 'iolist', 'bitstring', 'byte', 'char', 'fun', 'module', 'node', 'timeout', 'no_return', 'non_neg_integer', 'pos_integer', 'neg_integer', 'mfa', 'port', 'identifier', 'as_boolean', 'struct', 't']);
+
+/**
+ * Extract simple type name from an Elixir typespec string.
+ * Handles: "String.t()" → "String", "integer()" → "integer",
+ * "{:ok, t()}" → undefined (complex), "User.t()" → "User"
+ */
+const extractElixirTypeName = (typeStr: string): string | undefined => {
+  const trimmed = typeStr.trim();
+
+  // Tuple/union types are too complex
+  if (trimmed.startsWith('{') || trimmed.includes(' | ')) return undefined;
+
+  // Module.t() pattern → Module
+  const dotMatch = trimmed.match(/^(\w+(?:\.\w+)*)\.t\(\)$/);
+  if (dotMatch) {
+    const parts = dotMatch[1].split('.');
+    return parts[parts.length - 1];
+  }
+
+  // Simple type() pattern → type (but filter out primitive types)
+  const simpleMatch = trimmed.match(/^(\w+)\(\)$/);
+  if (simpleMatch) {
+    const name = simpleMatch[1];
+    if (ELIXIR_BUILTINS.has(name)) return undefined;
+    return name;
+  }
+
+  // Bare module name (starts with uppercase)
+  if (/^[A-Z]\w*$/.test(trimmed)) return trimmed;
+
+  return undefined;
+};
+
+/**
+ * Elixir node types that may carry type bindings.
+ * In tree-sitter-elixir, function definitions are `call` nodes
+ * with target `def`/`defp`. We scan for preceding @spec attributes.
+ */
+const DECLARATION_NODE_TYPES: ReadonlySet<string> = new Set([
+  'call',
+]);
+
+/**
+ * Extract @spec annotations from the preceding sibling nodes of a def/defp call.
+ * In tree-sitter-elixir, @spec is a unary_operator with @ operator whose
+ * operand is a call with target "spec".
+ */
+const extractDeclaration: TypeBindingExtractor = (node: SyntaxNode, _env: Map<string, string>): void => {
+  // Only handle def/defp nodes
+  if (node.type !== 'call') return;
+  const target = node.childForFieldName?.('target');
+  if (!target || target.type !== 'identifier') return;
+  if (target.text !== 'def' && target.text !== 'defp') return;
+
+  // @spec types are pre-populated by looking at preceding siblings
+  // but Elixir parameters have no inline types — types come from @spec
+  // This is a no-op for now; the spec parsing happens in extractReturnType
+};
+
+/**
+ * Elixir parameters have no inline type annotations.
+ * Types come from @spec, which is handled separately.
+ */
+const extractParameter: ParameterExtractor = (_node: SyntaxNode, _env: Map<string, string>): void => {
+  // Elixir parameters have no type annotations.
+};
+
+/**
+ * Scan for struct construction: user = %User{name: "Alice"}
+ * In tree-sitter-elixir, this is a map node with a struct child.
+ */
+const scanConstructorBinding: ConstructorBindingScanner = (node) => {
+  // Match assignment: identifier = %StructName{...}
+  if (node.type !== 'binary_operator') return undefined;
+  const children = node.children ?? [];
+  // Binary operator: left = right, operator is '='
+  if (children.length < 3) return undefined;
+  const operator = children.find((c: any) => c.type === '=' || c.text === '=');
+  if (!operator) return undefined;
+
+  const left = node.childForFieldName?.('left');
+  const right = node.childForFieldName?.('right');
+  if (!left || !right) return undefined;
+  if (left.type !== 'identifier') return undefined;
+  if (right.type !== 'map') return undefined;
+
+  // Look for struct child inside the map
+  const structNode = right.children?.find((c: any) => c.type === 'struct');
+  if (!structNode) return undefined;
+
+  // The struct name is an alias or identifier child
+  const nameNode = structNode.children?.find((c: any) => c.type === 'alias' || c.type === 'identifier');
+  if (!nameNode) return undefined;
+
+  // Extract last segment of qualified name: MyApp.User → User
+  const fullName = nameNode.text;
+  const parts = fullName.split('.');
+  const calleeName = parts[parts.length - 1];
+
+  return { varName: left.text, calleeName };
+};
+
+/**
+ * Extract return type from @spec annotation preceding a def/defp.
+ * Walks backward through siblings looking for unary_operator (@spec).
+ */
+const extractReturnType: ReturnTypeExtractor = (node) => {
+  if (node.type !== 'call') return undefined;
+  const target = node.childForFieldName?.('target');
+  if (!target || target.type !== 'identifier') return undefined;
+  if (target.text !== 'def' && target.text !== 'defp') return undefined;
+
+  // Walk backward through siblings looking for @spec
+  let sibling = node.previousSibling;
+  while (sibling) {
+    if (sibling.type === 'unary_operator') {
+      const operand = sibling.childForFieldName?.('operand');
+      if (operand?.type === 'call') {
+        const specTarget = operand.childForFieldName?.('target');
+        if (specTarget?.type === 'identifier' && specTarget.text === 'spec') {
+          // Found @spec — extract return type after ::
+          const specText = operand.text;
+          const match = SPEC_RETURN_RE.exec(specText);
+          if (match) {
+            return extractElixirTypeName(match[1]);
+          }
+        }
+      }
+    } else if (sibling.isNamed && sibling.type !== 'comment') {
+      // call nodes may be @impl/@doc/@deprecated attributes (target is a unary_operator @)
+      // or real def/defp/other calls (target is a plain identifier). Only break on real calls.
+      if (sibling.type === 'call') {
+        const t = sibling.childForFieldName?.('target');
+        if (t?.type === 'identifier') break; // real def/defp/other call — stop
+        // Otherwise target is a unary_operator (e.g. @impl true) — keep walking
+      } else if (sibling.type === 'unary_operator') {
+        // Another @attribute node (e.g. @doc, @moduledoc) — keep walking
+      } else {
+        break;
+      }
+    }
+    sibling = sibling.previousSibling;
+  }
+
+  return undefined;
+};
+
+export const typeConfig: LanguageTypeConfig = {
+  declarationNodeTypes: DECLARATION_NODE_TYPES,
+  extractDeclaration,
+  extractParameter,
+  scanConstructorBinding,
+  extractReturnType,
+};

--- a/gitnexus/src/core/ingestion/type-extractors/index.ts
+++ b/gitnexus/src/core/ingestion/type-extractors/index.ts
@@ -16,6 +16,7 @@ import { typeConfig as swiftConfig } from './swift.js';
 import { typeConfig as cCppConfig } from './c-cpp.js';
 import { typeConfig as phpConfig } from './php.js';
 import { typeConfig as rubyConfig } from './ruby.js';
+import { typeConfig as elixirConfig } from './elixir.js';
 
 export const typeConfigs = {
   [SupportedLanguages.JavaScript]: typescriptConfig,
@@ -31,6 +32,7 @@ export const typeConfigs = {
   [SupportedLanguages.CPlusPlus]: cCppConfig,
   [SupportedLanguages.PHP]: phpConfig,
   [SupportedLanguages.Ruby]: rubyConfig,
+  [SupportedLanguages.Elixir]: elixirConfig,
 } satisfies Record<SupportedLanguages, LanguageTypeConfig>;
 
 export type {

--- a/gitnexus/src/core/ingestion/utils.ts
+++ b/gitnexus/src/core/ingestion/utils.ts
@@ -80,6 +80,8 @@ export const FUNCTION_NODE_TYPES = new Set([
   // Ruby
   'method',           // def foo
   'singleton_method', // def self.foo
+  // Elixir: `call` nodes with def/defp/defmacro/defmacrop target
+  // are handled via isElixirFunctionDef() since `call` is too generic to add here
 ]);
 
 /**
@@ -254,6 +256,14 @@ export const BUILT_IN_NAMES = new Set([
   'any?', 'all?', 'none?', 'count', 'first', 'last',
   'sort_by', 'min_by', 'max_by',
   'group_by', 'partition', 'compact', 'flatten', 'uniq',
+  // Elixir built-ins and Kernel functions
+  'IO', 'Enum', 'Map', 'String', 'List', 'Keyword', 'Tuple',
+  'Agent', 'Task', 'Logger',
+  'raise', 'throw', 'exit', 'spawn', 'send', 'self',
+  'dbg', 'tap', 'then',
+  'is_nil', 'is_map', 'is_list', 'is_binary', 'is_atom', 'is_integer',
+  'length', 'elem', 'hd', 'tl', 'div', 'rem', 'abs', 'max', 'min',
+  'inspect', 'puts',
 ]);
 
 /** Check if a name is a built-in function or common noise that should be filtered out */
@@ -335,6 +345,17 @@ export const findEnclosingClassId = (node: any, filePath: string): string | null
         }
       }
     }
+    // Elixir: defmodule is a call node with target "defmodule"
+    if (current.type === 'call') {
+      const target = current.childForFieldName?.('target');
+      if (target?.type === 'identifier' && target.text === 'defmodule') {
+        const args = current.children?.find((c: any) => c.type === 'arguments');
+        const aliasNode = args?.children?.find((c: any) => c.type === 'alias');
+        if (aliasNode) {
+          return generateId('Module', `${filePath}:${aliasNode.text}`);
+        }
+      }
+    }
     if (CLASS_CONTAINER_TYPES.has(current.type)) {
       // Rust impl_item: for `impl Trait for Struct {}`, pick the type after `for`
       if (current.type === 'impl_item') {
@@ -368,7 +389,39 @@ export const findEnclosingClassId = (node: any, filePath: string): string | null
  * Extract function name and label from a function_definition or similar AST node.
  * Handles C/C++ qualified_identifier (ClassName::MethodName) and other language patterns.
  */
-export const extractFunctionName = (node: SyntaxNode): { funcName: string | null; label: string } => {
+/**
+ * Elixir def keywords that create function/macro definitions.
+ * Used to identify `call` nodes that are actually function definitions.
+ */
+const ELIXIR_FUNCTION_DEF_KEYWORDS = new Set([
+  'def', 'defp', 'defmacro', 'defmacrop', 'defguard', 'defguardp', 'defdelegate',
+]);
+
+/**
+ * Check if a `call` node is an Elixir function definition (def/defp/defmacro/etc.).
+ * Returns the function name if it is, null otherwise.
+ */
+export const isElixirFunctionDef = (node: any): string | null => {
+  if (node.type !== 'call') return null;
+  const target = node.childForFieldName?.('target');
+  if (!target || target.type !== 'identifier') return null;
+  if (!ELIXIR_FUNCTION_DEF_KEYWORDS.has(target.text)) return null;
+
+  // The function name is in the first argument, which is itself a call node.
+  // In tree-sitter-elixir, `arguments` is a named child but NOT a field,
+  // so childForFieldName('arguments') returns null — use children.find instead.
+  const args = node.children?.find((c: any) => c.type === 'arguments');
+  if (!args) return null;
+  const firstArg = args.children?.find((c: any) => c.type === 'call');
+  if (firstArg) {
+    const funcTarget = firstArg.childForFieldName?.('target')
+      ?? firstArg.children?.find((c: any) => c.type === 'identifier');
+    if (funcTarget?.type === 'identifier') return funcTarget.text;
+  }
+  return null;
+};
+
+export const extractFunctionName = (node: any): { funcName: string | null; label: string } => {
   let funcName: string | null = null;
   let label = 'Function';
 
@@ -517,6 +570,12 @@ export const extractFunctionName = (node: SyntaxNode): { funcName: string | null
     }
     funcName = nameNode?.text;
     label = 'Method';
+  } else {
+    // Elixir: call nodes with def/defp/defmacro target are function definitions
+    const elixirName = isElixirFunctionDef(node);
+    if (elixirName) {
+      funcName = elixirName;
+    }
   }
 
   return { funcName, label };
@@ -594,6 +653,8 @@ export const getLanguageFromFilename = (filename: string): SupportedLanguages | 
   }
   // Swift (extensions)
   if (filename.endsWith('.swift')) return SupportedLanguages.Swift;
+  // Elixir
+  if (filename.endsWith('.ex') || filename.endsWith('.exs')) return SupportedLanguages.Elixir;
   return null;
 };
 
@@ -688,6 +749,21 @@ export const extractMethodSignature = (node: SyntaxNode | null | undefined): Met
           isVariadic = true;
           break;
         }
+      }
+    }
+  }
+
+  // Elixir: def/defp/defmacro/... node — parameters are in the inner call's arguments.
+  // Structure: call(target: "def", arguments: (arguments (call(target: "insert", arguments: (arguments ...params...)))))
+  // NOTE: `arguments` is NOT a named field in tree-sitter-elixir — must use children.find().
+  if (parameterCount === 0 && node.type === 'call') {
+    const kw = node.childForFieldName?.('target');
+    if (kw && ELIXIR_FUNCTION_DEF_KEYWORDS.has(kw.text)) {
+      const outerArgs = node.children?.find((c: any) => c.type === 'arguments');
+      const innerCall = outerArgs?.children?.find((c: any) => c.type === 'call');
+      const innerArgs = innerCall?.children?.find((c: any) => c.type === 'arguments');
+      if (innerArgs) {
+        parameterCount = innerArgs.namedChildren.filter((c: any) => c.type !== 'comment').length;
       }
     }
   }
@@ -800,6 +876,16 @@ export const countCallArguments = (callNode: SyntaxNode | null | undefined): num
     count++;
   }
 
+  // Elixir pipe operator: if this call is the right-hand side of a |> binary_operator,
+  // the piped value is an implicit first argument — add 1 to the explicit count.
+  if (callNode.parent?.type === 'binary_operator') {
+    const parent = callNode.parent;
+    const pipeOp = parent.children.find((c: any) => !c.isNamed && c.text === '|>');
+    if (pipeOp && callNode.startIndex > pipeOp.startIndex) {
+      count += 1;
+    }
+  }
+
   return count;
 };
 
@@ -817,6 +903,7 @@ const MEMBER_ACCESS_NODE_TYPES = new Set([
   'selector_expression',         // Go: obj.Method()
   'navigation_suffix',           // Kotlin/Swift: obj.method() — nameNode sits inside navigation_suffix
   'member_binding_expression',   // C#: user?.Method() — null-conditional access
+  'dot',                         // Elixir: Module.func() — nameNode sits inside dot node
 ]);
 
 /**
@@ -910,6 +997,7 @@ const SIMPLE_RECEIVER_TYPES = new Set([
   'self',              // Rust/Python self.method()
   'super',             // TS/JS/Java/Kotlin/Ruby super.method()
   'super_expression',  // Kotlin wraps super in super_expression
+  'alias',             // Elixir: capitalized module names (Repo, MyApp.User)
   'base',              // C# base.Method()
   'parent',            // PHP parent::method()
   'constant',          // Ruby CONSTANT.method() (uppercase identifiers)
@@ -981,6 +1069,11 @@ export const extractReceiverName = (
         }
       }
     }
+  }
+
+  // Elixir dot node: (dot left: (alias "Module") right: (identifier "func"))
+  if (!receiver && parent.type === 'dot') {
+    receiver = parent.childForFieldName('left');
   }
 
   if (!receiver) return undefined;

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -24,6 +24,10 @@ try { Swift = _require('tree-sitter-swift'); } catch {}
 // tree-sitter-kotlin is an optionalDependency — may not be installed
 let Kotlin: any = null;
 try { Kotlin = _require('tree-sitter-kotlin'); } catch {}
+
+// tree-sitter-elixir is an optionalDependency — may not be installed
+let Elixir: any = null;
+try { Elixir = _require('tree-sitter-elixir'); } catch {}
 import {
   getLanguageFromFilename,
   FUNCTION_NODE_TYPES,
@@ -38,6 +42,7 @@ import {
   extractReceiverNode,
   extractMixedChain,
   type MixedChainStep,
+  isElixirFunctionDef,
 } from '../utils.js';
 import { buildTypeEnv } from '../type-env.js';
 import type { ConstructorBinding } from '../type-env.js';
@@ -201,6 +206,7 @@ const languageMap: Record<string, any> = {
   [SupportedLanguages.PHP]: PHP.php_only,
   [SupportedLanguages.Ruby]: Ruby,
   ...(Swift ? { [SupportedLanguages.Swift]: Swift } : {}),
+  ...(Elixir ? { [SupportedLanguages.Elixir]: Elixir } : {}),
 };
 
 /**
@@ -240,6 +246,11 @@ const findEnclosingFunctionId = (node: any, filePath: string): string | null => 
       if (funcName) {
         return generateId(label, `${filePath}:${funcName}`);
       }
+    }
+    // Elixir: call nodes with def/defp/defmacro target are function definitions
+    const elixirName = isElixirFunctionDef(current);
+    if (elixirName) {
+      return generateId('Function', `${filePath}:${elixirName}`);
     }
     current = current.parent;
   }
@@ -1058,11 +1069,17 @@ const processFileGroup = (
             // kind === 'call' — fall through to normal call processing below
           }
 
-          if (!isBuiltInOrNoise(calledName)) {
+          {
             const callNode = captureMap['call'];
+            const callForm = inferCallForm(callNode, callNameNode);
+            // Skip built-in/noise names for free and constructor calls.
+            // Member calls (Repo.insert, Enum.map, etc.) have explicit receiver context
+            // that disambiguates common names, so the noise filter is not applied.
+            // Elixir member calls (e.g. Repo.insert) have explicit module receiver context
+            // that disambiguates common names; bypass the noise filter for those only.
+            if (isBuiltInOrNoise(calledName) && (callForm !== 'member' || language !== SupportedLanguages.Elixir)) continue;
             const sourceId = findEnclosingFunctionId(callNode, file.path)
               || generateId('File', file.path);
-            const callForm = inferCallForm(callNode, callNameNode);
             let receiverName = callForm === 'member' ? extractReceiverName(callNameNode) : undefined;
             let receiverTypeName = receiverName ? typeEnv.lookup(receiverName, callNode) : undefined;
             let receiverMixedChain: MixedChainStep[] | undefined;

--- a/gitnexus/src/core/tree-sitter/parser-loader.ts
+++ b/gitnexus/src/core/tree-sitter/parser-loader.ts
@@ -22,6 +22,10 @@ try { Swift = _require('tree-sitter-swift'); } catch {}
 let Kotlin: any = null;
 try { Kotlin = _require('tree-sitter-kotlin'); } catch {}
 
+// tree-sitter-elixir is an optionalDependency — may not be installed
+let Elixir: any = null;
+try { Elixir = _require('tree-sitter-elixir'); } catch {}
+
 let parser: Parser | null = null;
 
 const languageMap: Record<string, any> = {
@@ -39,6 +43,7 @@ const languageMap: Record<string, any> = {
   [SupportedLanguages.PHP]: PHP.php_only,
   [SupportedLanguages.Ruby]: Ruby,
   ...(Swift ? { [SupportedLanguages.Swift]: Swift } : {}),
+  ...(Elixir ? { [SupportedLanguages.Elixir]: Elixir } : {}),
 };
 
 export const isLanguageAvailable = (language: SupportedLanguages): boolean =>

--- a/gitnexus/test/fixtures/lang-resolution/elixir-alias/lib/my_app/repo.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-alias/lib/my_app/repo.ex
@@ -1,0 +1,5 @@
+defmodule MyApp.Repo do
+  def insert(attrs) do
+    {:ok, attrs}
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-alias/lib/my_app/user.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-alias/lib/my_app/user.ex
@@ -1,0 +1,7 @@
+defmodule MyApp.User do
+  alias MyApp.Repo
+
+  def create(attrs) do
+    Repo.insert(attrs)
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-behaviour/lib/my_server.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-behaviour/lib/my_server.ex
@@ -1,0 +1,33 @@
+defmodule MyServer do
+  use GenServer
+  @behaviour Serializable
+  @behaviour :gen_server
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(state), do: {:ok, state}
+
+  @impl true
+  def handle_call(:get, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl Serializable
+  def serialize(term) do
+    :erlang.term_to_binary(term)
+  end
+end
+
+defprotocol Printable do
+  @spec print(t()) :: String.t()
+  def print(data)
+end
+
+defimpl Printable, for: MyServer do
+  def print(server) do
+    inspect(server)
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-behaviour/lib/serializable.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-behaviour/lib/serializable.ex
@@ -1,0 +1,3 @@
+defmodule Serializable do
+  @callback serialize(term()) :: binary()
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-member-calls/lib/my_app/repo.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-member-calls/lib/my_app/repo.ex
@@ -1,0 +1,5 @@
+defmodule MyApp.Repo do
+  def insert(attrs) do
+    {:ok, attrs}
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-member-calls/lib/my_app/service.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-member-calls/lib/my_app/service.ex
@@ -1,0 +1,7 @@
+defmodule MyApp.Service do
+  alias MyApp.Repo
+
+  def save(attrs) do
+    Repo.insert(attrs)
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-multi-alias/lib/my_app/accounts/admin.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-multi-alias/lib/my_app/accounts/admin.ex
@@ -1,0 +1,3 @@
+defmodule MyApp.Accounts.Admin do
+  defstruct [:name, :role]
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-multi-alias/lib/my_app/accounts/user.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-multi-alias/lib/my_app/accounts/user.ex
@@ -1,0 +1,3 @@
+defmodule MyApp.Accounts.User do
+  defstruct [:name, :email]
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-multi-alias/lib/my_app/service.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-multi-alias/lib/my_app/service.ex
@@ -1,0 +1,7 @@
+defmodule MyApp.Service do
+  alias MyApp.Accounts.{User, Admin}
+
+  def list_users do
+    [%User{name: "Alice"}, %Admin{name: "Bob", role: "admin"}]
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-phoenix/lib/my_app/accounts.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-phoenix/lib/my_app/accounts.ex
@@ -1,0 +1,9 @@
+defmodule MyApp.Accounts do
+  def list_users do
+    []
+  end
+
+  def get_user(_id) do
+    nil
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-phoenix/lib/my_app_web/controllers/user_controller.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-phoenix/lib/my_app_web/controllers/user_controller.ex
@@ -1,0 +1,15 @@
+defmodule MyAppWeb.UserController do
+  use Phoenix.Controller
+
+  alias MyApp.Accounts
+
+  def index(conn, _params) do
+    users = Accounts.list_users()
+    render(conn, :index, users: users)
+  end
+
+  def show(conn, %{"id" => id}) do
+    user = Accounts.get_user(id)
+    render(conn, :show, user: user)
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-phoenix/lib/my_app_web/live/user_live.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-phoenix/lib/my_app_web/live/user_live.ex
@@ -1,0 +1,11 @@
+defmodule MyAppWeb.UserLive do
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :users, [])}
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    {:noreply, socket}
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-phoenix/lib/my_app_web/router.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-phoenix/lib/my_app_web/router.ex
@@ -1,0 +1,8 @@
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+
+  scope "/", MyAppWeb do
+    get "/users", UserController, :index
+    get "/users/:id", UserController, :show
+  end
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-pipe/lib/pipeline.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-pipe/lib/pipeline.ex
@@ -1,0 +1,12 @@
+defmodule Pipeline do
+  def process(data) do
+    data
+    |> step_one()
+    |> step_two()
+    |> step_three()
+  end
+
+  defp step_one(data), do: data
+  defp step_two(data), do: data
+  defp step_three(data), do: data
+end

--- a/gitnexus/test/fixtures/lang-resolution/elixir-visibility/lib/visible.ex
+++ b/gitnexus/test/fixtures/lang-resolution/elixir-visibility/lib/visible.ex
@@ -1,0 +1,13 @@
+defmodule Visible do
+  def public_func(x), do: x
+
+  defp private_func(x), do: x
+
+  defmacro public_macro(expr) do
+    quote do: unquote(expr)
+  end
+
+  defmacrop private_macro(expr) do
+    quote do: unquote(expr)
+  end
+end

--- a/gitnexus/test/fixtures/sample-code/simple.ex
+++ b/gitnexus/test/fixtures/sample-code/simple.ex
@@ -1,0 +1,43 @@
+defmodule MyApp.Accounts.User do
+  @moduledoc "User account management"
+  @behaviour GenServer
+
+  alias MyApp.Repo
+  import Ecto.Query
+  require Logger
+  use GenServer
+
+  @type t :: %__MODULE__{name: String.t(), age: integer()}
+
+  defstruct [:name, :age]
+
+  @spec create(map()) :: {:ok, t()} | {:error, term()}
+  def create(attrs) do
+    attrs
+    |> validate()
+    |> Repo.insert()
+  end
+
+  defp validate(attrs) do
+    attrs
+  end
+
+  defmacro my_macro(expr) do
+    quote do
+      unquote(expr)
+    end
+  end
+
+  defguard is_positive(x) when is_integer(x) and x > 0
+end
+
+defprotocol Printable do
+  @spec print(t()) :: String.t()
+  def print(data)
+end
+
+defimpl Printable, for: MyApp.Accounts.User do
+  def print(user) do
+    user.name
+  end
+end

--- a/gitnexus/test/integration/resolvers/elixir.test.ts
+++ b/gitnexus/test/integration/resolvers/elixir.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Elixir: alias imports, multi-alias expansion, pipe operator calls,
+ *         Phoenix framework detection, behaviour heritage, def/defp visibility
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'path';
+import {
+  FIXTURES, getRelationships, getNodesByLabel, edgeSet,
+  runPipelineFromRepo, type PipelineResult,
+} from './helpers.js';
+import { isLanguageAvailable } from '../../../src/core/tree-sitter/parser-loader.js';
+import { SupportedLanguages } from '../../../src/config/supported-languages.js';
+
+const elixirAvailable = isLanguageAvailable(SupportedLanguages.Elixir);
+
+// ---------------------------------------------------------------------------
+// Alias resolution & qualified calls
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir alias resolution & qualified calls', () => {
+
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-alias'),
+      () => {},
+    );
+  }, 60000);
+
+  it('detects modules', () => {
+    const modules = getNodesByLabel(result, 'Module');
+    expect(modules).toContain('MyApp.User');
+    expect(modules).toContain('MyApp.Repo');
+  });
+
+  it('detects functions', () => {
+    const fns = getNodesByLabel(result, 'Function');
+    expect(fns).toContain('create');
+    expect(fns).toContain('insert');
+  });
+
+  it('resolves alias import: user.ex → repo.ex', () => {
+    const imports = getRelationships(result, 'IMPORTS');
+    const userToRepo = imports.filter(e =>
+      e.sourceFilePath.includes('user.ex') && e.targetFilePath.includes('repo.ex')
+    );
+    expect(userToRepo.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits CALLS edge from create → insert (Module.func() member call)', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const createToInsert = calls.filter(e =>
+      e.source === 'create' && e.target === 'insert'
+    );
+    expect(createToInsert.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-alias expansion
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir multi-alias expansion', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-multi-alias'),
+      () => {},
+    );
+  }, 60000);
+
+  it('detects all modules', () => {
+    const modules = getNodesByLabel(result, 'Module');
+    expect(modules).toContain('MyApp.Accounts.User');
+    expect(modules).toContain('MyApp.Accounts.Admin');
+    expect(modules).toContain('MyApp.Service');
+  });
+
+  it('resolves multi-alias import: service.ex → both user.ex and admin.ex', () => {
+    const imports = getRelationships(result, 'IMPORTS');
+    const serviceImports = imports.filter(e =>
+      e.sourceFilePath.includes('service.ex')
+    );
+    expect(serviceImports.length).toBe(2);
+    const targets = serviceImports.map(e => e.targetFilePath);
+    expect(targets.some(t => t.includes('user.ex'))).toBe(true);
+    expect(targets.some(t => t.includes('admin.ex'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipe operator → call edges
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir pipe operator call edges', () => {
+
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-pipe'),
+      () => {},
+    );
+  }, 60000);
+
+  it('detects module and functions', () => {
+    const modules = getNodesByLabel(result, 'Module');
+    expect(modules).toContain('Pipeline');
+
+    const fns = getNodesByLabel(result, 'Function');
+    expect(fns).toContain('process');
+    expect(fns).toContain('step_one');
+    expect(fns).toContain('step_two');
+    expect(fns).toContain('step_three');
+  });
+
+  it('emits CALLS edges from pipe chain: process calls step_one, step_two, step_three', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const processToSteps = calls.filter(e =>
+      e.source === 'process' &&
+      ['step_one', 'step_two', 'step_three'].includes(e.target)
+    );
+    // Each pipe stage should produce a call edge
+    expect(processToSteps.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phoenix framework detection
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir Phoenix framework detection', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-phoenix'),
+      () => {},
+    );
+  }, 60000);
+
+  it('detects controller, LiveView, and router modules', () => {
+    const modules = getNodesByLabel(result, 'Module');
+    expect(modules).toContain('MyAppWeb.UserController');
+    expect(modules).toContain('MyAppWeb.UserLive');
+    expect(modules).toContain('MyAppWeb.Router');
+  });
+
+  it('detects functions in controller', () => {
+    const fns = getNodesByLabel(result, 'Function');
+    expect(fns).toContain('index');
+    expect(fns).toContain('show');
+  });
+
+  it('resolves alias import: controller → accounts', () => {
+    const imports = getRelationships(result, 'IMPORTS');
+    const controllerToAccounts = imports.filter(e =>
+      e.sourceFilePath.includes('user_controller.ex') &&
+      e.targetFilePath.includes('accounts.ex')
+    );
+    expect(controllerToAccounts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits EXTENDS edge from use Phoenix.Controller', () => {
+    const extends_ = getRelationships(result, 'EXTENDS');
+    const edge = extends_.find(e => e.sourceFilePath.includes('user_controller.ex'));
+    expect(edge).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behaviour heritage (use + @behaviour)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir behaviour heritage', () => {
+
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-behaviour'),
+      () => {},
+    );
+  }, 60000);
+
+  it('detects modules', () => {
+    const modules = getNodesByLabel(result, 'Module');
+    expect(modules).toContain('MyServer');
+    expect(modules).toContain('Serializable');
+  });
+
+  it('detects functions including GenServer callbacks', () => {
+    const fns = getNodesByLabel(result, 'Function');
+    expect(fns).toContain('start_link');
+    expect(fns).toContain('init');
+    expect(fns).toContain('handle_call');
+    expect(fns).toContain('serialize');
+  });
+
+  it('emits EXTENDS edges from use GenServer and @behaviour', () => {
+    const heritage = getRelationships(result, 'EXTENDS');
+    const targets = heritage.map(e => e.target);
+    expect(targets).toContain('Class:GenServer');
+  });
+
+  it('emits IMPLEMENTS edges from @behaviour (alias and atom forms)', () => {
+    const implements_ = getRelationships(result, 'IMPLEMENTS');
+    const targets = implements_.map(e => e.target);
+    expect(targets).toContain('Serializable');
+    // Atom-form: @behaviour :gen_server
+    const atomTarget = implements_.find(e =>
+      e.target.includes('gen_server') || e.rel.targetId.includes('gen_server')
+    );
+    expect(atomTarget).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Visibility (def = exported, defp = not exported)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir def/defp visibility', () => {
+
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-visibility'),
+      () => {},
+    );
+  }, 60000);
+
+  it('detects all functions (public and private)', () => {
+    const fns = getNodesByLabel(result, 'Function');
+    expect(fns).toContain('public_func');
+    expect(fns).toContain('private_func');
+  });
+
+  it('detects macros (public and private)', () => {
+    const macros = getNodesByLabel(result, 'Macro');
+    expect(macros).toContain('public_macro');
+    expect(macros).toContain('private_macro');
+  });
+
+  it('marks def functions as exported', () => {
+    let found = false;
+    result.graph.forEachNode(n => {
+      if (n.properties.name === 'public_func') {
+        expect(n.properties.isExported).toBe(true);
+        found = true;
+      }
+    });
+    expect(found).toBe(true);
+  });
+
+  it('marks defp functions as NOT exported', () => {
+    let found = false;
+    result.graph.forEachNode(n => {
+      if (n.properties.name === 'private_func') {
+        expect(n.properties.isExported).toBe(false);
+        found = true;
+      }
+    });
+    expect(found).toBe(true);
+  });
+
+  it('marks defmacro as exported', () => {
+    let found = false;
+    result.graph.forEachNode(n => {
+      if (n.properties.name === 'public_macro') {
+        expect(n.properties.isExported).toBe(true);
+        found = true;
+      }
+    });
+    expect(found).toBe(true);
+  });
+
+  it('marks defmacrop as NOT exported', () => {
+    let found = false;
+    result.graph.forEachNode(n => {
+      if (n.properties.name === 'private_macro') {
+        expect(n.properties.isExported).toBe(false);
+        found = true;
+      }
+    });
+    expect(found).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Member-based CALLS edges (Module.func())
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir member-based CALLS edges (Module.func())', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-member-calls'),
+      () => {},
+    );
+  }, 60000);
+
+  it('detects modules and functions', () => {
+    const modules = getNodesByLabel(result, 'Module');
+    expect(modules).toContain('MyApp.Repo');
+    expect(modules).toContain('MyApp.Service');
+
+    const fns = getNodesByLabel(result, 'Function');
+    expect(fns).toContain('insert');
+    expect(fns).toContain('save');
+  });
+
+  it('emits CALLS edge from save → insert', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const saveToInsert = calls.filter(e =>
+      e.source === 'save' && e.target === 'insert'
+    );
+    expect(saveToInsert.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('CALLS edge targetFilePath contains repo.ex', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const saveToInsert = calls.filter(e =>
+      e.source === 'save' && e.target === 'insert'
+    );
+    expect(saveToInsert.length).toBeGreaterThanOrEqual(1);
+    expect(saveToInsert[0].targetFilePath).toContain('repo.ex');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HAS_METHOD edges (functions have ownerId pointing to defmodule)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir HAS_METHOD edges (defmodule ownerId)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-behaviour'),
+      () => {},
+    );
+  }, 60000);
+
+  it('functions inside defmodule have HAS_METHOD edges', () => {
+    const hasMethods = getRelationships(result, 'HAS_METHOD');
+    const myServerMethods = hasMethods.filter(e => e.source === 'MyServer');
+    expect(myServerMethods.length).toBeGreaterThanOrEqual(1);
+    const methodNames = myServerMethods.map(e => e.target);
+    expect(methodNames).toContain('start_link');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defimpl creates IMPLEMENTS edges
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!elixirAvailable)('Elixir defimpl IMPLEMENTS edges', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'elixir-behaviour'),
+      () => {},
+    );
+  }, 60000);
+
+  it('emits IMPLEMENTS edge from defimpl for: Module → Protocol', () => {
+    const implements_ = getRelationships(result, 'IMPLEMENTS');
+    // defimpl Printable, for: MyServer should create an edge
+    const printable = implements_.filter(e =>
+      e.target.includes('Printable') || e.rel.targetId.includes('Printable')
+    );
+    expect(printable.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/gitnexus/test/integration/tree-sitter-languages.test.ts
+++ b/gitnexus/test/integration/tree-sitter-languages.test.ts
@@ -379,6 +379,126 @@ describe('Tree-sitter multi-language parsing', () => {
     });
   });
 
+  describe('Elixir', () => {
+    it('parses modules, functions, macros, protocol, and impl if tree-sitter-elixir is available', async () => {
+      try {
+        await loadLanguage(SupportedLanguages.Elixir);
+      } catch {
+        // tree-sitter-elixir not installed — skip
+        return;
+      }
+
+      const content = readFixture('simple.ex');
+      const { matches } = parseAndQuery(parser, content, LANGUAGE_QUERIES[SupportedLanguages.Elixir]);
+      const defs = extractDefinitions(matches);
+
+      expect(defs.length).toBeGreaterThan(0);
+
+      const names = defs.map(d => d.name);
+      const types = defs.map(d => d.type);
+
+      // Module
+      expect(names).toContain('MyApp.Accounts.User');
+      expect(types).toContain('definition.module');
+
+      // Functions
+      expect(names).toContain('create');
+      expect(names).toContain('validate');
+      expect(types).toContain('definition.function');
+
+      // Macro
+      expect(names).toContain('my_macro');
+      expect(types).toContain('definition.macro');
+
+      // Guard with when clause
+      expect(names).toContain('is_positive');
+
+      // Protocol
+      expect(names).toContain('Printable');
+      expect(types).toContain('definition.interface');
+
+      // Impl
+      expect(types).toContain('definition.impl');
+    });
+
+    it('captures imports from alias, import, require, use', async () => {
+      try {
+        await loadLanguage(SupportedLanguages.Elixir);
+      } catch {
+        return;
+      }
+
+      const content = readFixture('simple.ex');
+      const { matches } = parseAndQuery(parser, content, LANGUAGE_QUERIES[SupportedLanguages.Elixir]);
+
+      const imports: string[] = [];
+      for (const match of matches) {
+        for (const capture of match.captures) {
+          if (capture.name === 'import.source') {
+            imports.push(capture.node.text);
+          }
+        }
+      }
+
+      expect(imports).toContain('MyApp.Repo');
+      expect(imports).toContain('Ecto.Query');
+      expect(imports).toContain('Logger');
+      expect(imports).toContain('GenServer');
+    });
+
+    it('captures heritage from use and @behaviour', async () => {
+      try {
+        await loadLanguage(SupportedLanguages.Elixir);
+      } catch {
+        return;
+      }
+
+      const content = readFixture('simple.ex');
+      const { matches } = parseAndQuery(parser, content, LANGUAGE_QUERIES[SupportedLanguages.Elixir]);
+
+      const heritage: { cls: string; ext: string }[] = [];
+      for (const match of matches) {
+        const cls = match.captures.find((c: any) => c.name === 'heritage.class');
+        const ext = match.captures.find((c: any) => c.name === 'heritage.extends');
+        if (cls && ext) {
+          heritage.push({ cls: cls.node.text, ext: ext.node.text });
+        }
+      }
+
+      expect(heritage).toContainEqual({ cls: 'MyApp.Accounts.User', ext: 'GenServer' });
+    });
+
+    it('captures defimpl heritage (IMPLEMENTS edge)', async () => {
+      try {
+        await loadLanguage(SupportedLanguages.Elixir);
+      } catch {
+        return;
+      }
+
+      const content = readFixture('simple.ex');
+      const { matches } = parseAndQuery(parser, content, LANGUAGE_QUERIES[SupportedLanguages.Elixir]);
+
+      const implHeritage: { cls: string; impl: string }[] = [];
+      for (const match of matches) {
+        const cls = match.captures.find((c: any) => c.name === 'heritage.class');
+        const impl = match.captures.find((c: any) => c.name === 'heritage.implements');
+        if (cls && impl) {
+          implHeritage.push({ cls: cls.node.text, impl: impl.node.text });
+        }
+      }
+
+      expect(implHeritage).toContainEqual({ cls: 'MyApp.Accounts.User', impl: 'Printable' });
+    });
+
+    it('gracefully handles missing tree-sitter-elixir', async () => {
+      try {
+        await loadLanguage(SupportedLanguages.Elixir);
+      } catch (e: any) {
+        expect(e.message).toContain('Unsupported language');
+      }
+    });
+  });
+
   describe('unhappy path', () => {
     it('returns null/undefined for unsupported file extensions', () => {
       expect(getLanguageFromFilename('archive.xyz')).toBeNull();


### PR DESCRIPTION
## Core Registration & Parsing:

- `supported-languages.ts`: Added Elixir = 'elixir' enum value
- `parser-loader.ts` + `parse-worker.ts`: Registered tree-sitter-elixir as optional dependency with try/catch import
- `package.json`: Moved tree-sitter-elixir to optionalDependencies
- `utils.ts`: Added .ex/.exs extension mapping, Elixir built-in names, isElixirFunctionDef() helper for enclosing function detection
- `tree-sitter-queries.ts`: Added ELIXIR_QUERIES with `#eq?` predicates for defmodule, def/defp, defmacro/defmacrop, defstruct, defprotocol, defimpl, alias/import/require/use imports, qualified calls, and heritage (use/@behaviour)
- `export-detection.ts`: Added elixirExportChecker — walks up to enclosing call target to check def (public) vs defp (private)
- `call-routing.ts`: Extended HeritageItem to support 'use'/'behaviour' heritage kinds; Elixir uses noRouting since queries handle all dispatch
- `type-extractors/elixir.ts` (new): Stub type config with @spec return type extraction and struct construction scanning
- `resolvers/elixir.ts` (new): CamelCase-to-snake_case module path resolution with multi-alias expansion

## Import Resolution & Call Routing:

- `import-processor.ts`: Added Elixir branch calling `resolveElixirImport()`
- `resolvers/utils.ts`: Added .ex/.exs to EXTENSIONS
- `call-processor.ts` + `type-env.ts`: Added `isElixirFunctionDef()` checks for enclosing function/scope detection (Elixir's def/defp are call nodes, not in FUNCTION_NODE_TYPES)

## Type Extraction:

- Basic `@spec` return type extraction from preceding `unary_operator` nodes
- Struct construction inference (`%User{}` patterns)

## Phoenix Framework Detection:

- Path-based: *_controller.ex, *_live.ex, *_channel.ex, router.ex, endpoint.ex, application.ex, mix.exs
- AST-based: use Phoenix.Router/Controller/LiveView/Channel, use GenServer/Supervisor/Agent

## Tests:

- `simple.ex` fixture: Module, def/defp, defmacro, defstruct, defprotocol, defimpl
- 6 resolution fixtures: alias, multi-alias, pipe, phoenix, behaviour, visibility
- 58 tests all passing (38 language + 20 Elixir resolver tests)
- No regressions in existing tests (1425 unit tests pass, all other resolver tests pass)