### PR TITLE
feat(api): enhance MCP integration with repoId handling and query execution

### DIFF
--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -46,23 +46,26 @@ export const initLbug = async (dbPath: string) => {
 /**
  * Execute multiple queries against one repo DB atomically.
  * While the callback runs, no other request can switch the active DB.
+ *
+ * @param readOnly - Open in read-only mode (no schema creation, no write lock).
+ *                   Use for server/query endpoints that only read.
  */
-export const withLbugDb = async <T>(dbPath: string, operation: () => Promise<T>): Promise<T> => {
+export const withLbugDb = async <T>(dbPath: string, operation: () => Promise<T>, readOnly?: boolean): Promise<T> => {
   return runWithSessionLock(async () => {
-    await ensureLbugInitialized(dbPath);
+    await ensureLbugInitialized(dbPath, readOnly);
     return operation();
   });
 };
 
-const ensureLbugInitialized = async (dbPath: string) => {
+const ensureLbugInitialized = async (dbPath: string, readOnly?: boolean) => {
   if (conn && currentDbPath === dbPath) {
     return { db, conn };
   }
-  await doInitLbug(dbPath);
+  await doInitLbug(dbPath, readOnly);
   return { db, conn };
 };
 
-const doInitLbug = async (dbPath: string) => {
+const doInitLbug = async (dbPath: string, readOnly?: boolean) => {
   // Different database requested — close the old one first
   if (conn || db) {
     try { if (conn) await conn.close(); } catch {}
@@ -73,45 +76,52 @@ const doInitLbug = async (dbPath: string) => {
     ftsLoaded = false;
   }
 
-  // LadybugDB stores the database as a single file (not a directory).
-  // If the path already exists, it must be a valid LadybugDB database file.
-  // Remove stale empty directories or files from older versions.
-  try {
-    const stat = await fs.lstat(dbPath);
-    if (stat.isSymbolicLink()) {
-      // Never follow symlinks — just remove the link itself
-      await fs.unlink(dbPath);
-    } else if (stat.isDirectory()) {
-      // Verify path is within expected storage directory before deleting
-      const realPath = await fs.realpath(dbPath);
-      const parentDir = path.dirname(dbPath);
-      const realParent = await fs.realpath(parentDir);
-      if (!realPath.startsWith(realParent + path.sep) && realPath !== realParent) {
-        throw new Error(`Refusing to delete ${dbPath}: resolved path ${realPath} is outside storage directory`);
+  if (!readOnly) {
+    // LadybugDB stores the database as a single file (not a directory).
+    // If the path already exists, it must be a valid LadybugDB database file.
+    // Remove stale empty directories or files from older versions.
+    try {
+      const stat = await fs.lstat(dbPath);
+      if (stat.isSymbolicLink()) {
+        // Never follow symlinks — just remove the link itself
+        await fs.unlink(dbPath);
+      } else if (stat.isDirectory()) {
+        // Verify path is within expected storage directory before deleting
+        const realPath = await fs.realpath(dbPath);
+        const parentDir = path.dirname(dbPath);
+        const realParent = await fs.realpath(parentDir);
+        if (!realPath.startsWith(realParent + path.sep) && realPath !== realParent) {
+          throw new Error(`Refusing to delete ${dbPath}: resolved path ${realPath} is outside storage directory`);
+        }
+        // Old-style directory database or empty leftover - remove it
+        await fs.rm(dbPath, { recursive: true, force: true });
       }
-      // Old-style directory database or empty leftover - remove it
-      await fs.rm(dbPath, { recursive: true, force: true });
+      // If it's a file, assume it's an existing LadybugDB database - LadybugDB will open it
+    } catch {
+      // Path doesn't exist, which is what LadybugDB wants for a new database
     }
-    // If it's a file, assume it's an existing LadybugDB database - LadybugDB will open it
-  } catch {
-    // Path doesn't exist, which is what LadybugDB wants for a new database
+
+    // Ensure parent directory exists
+    const parentDir = path.dirname(dbPath);
+    await fs.mkdir(parentDir, { recursive: true });
   }
 
-  // Ensure parent directory exists
-  const parentDir = path.dirname(dbPath);
-  await fs.mkdir(parentDir, { recursive: true });
-
-  db = new lbug.Database(dbPath);
+  db = readOnly
+    ? new lbug.Database(dbPath, 0, false, true)  // readOnly = true → no write lock
+    : new lbug.Database(dbPath);
   conn = new lbug.Connection(db);
 
-  for (const schemaQuery of SCHEMA_QUERIES) {
-    try {
-      await conn.query(schemaQuery);
-    } catch (err) {
-      // Only ignore "already exists" errors - log everything else
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!msg.includes('already exists')) {
-        console.warn(`⚠️ Schema creation warning: ${msg.slice(0, 120)}`);
+  // Skip schema creation in read-only mode — tables already exist from analyze
+  if (!readOnly) {
+    for (const schemaQuery of SCHEMA_QUERIES) {
+      try {
+        await conn.query(schemaQuery);
+      } catch (err) {
+        // Only ignore "already exists" errors - log everything else
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!msg.includes('already exists')) {
+          console.warn(`⚠️ Schema creation warning: ${msg.slice(0, 120)}`);
+        }
       }
     }
   }

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -12,8 +12,8 @@ import express from 'express';
 import cors from 'cors';
 import path from 'path';
 import fs from 'fs/promises';
-import { loadMeta, listRegisteredRepos } from '../storage/repo-manager.js';
-import { executeQuery, closeLbug, withLbugDb } from '../core/lbug/lbug-adapter.js';
+import { loadMeta, listRegisteredRepos, RegistryEntry } from '../storage/repo-manager.js';
+import { initLbug, executeQuery as mcpExecuteQuery, closeLbug } from '../mcp/core/lbug-adapter.js';
 import { NODE_TABLES } from '../core/lbug/schema.js';
 import { GraphNode, GraphRelationship } from '../core/graph/types.js';
 import { searchFTSFromLbug } from '../core/search/bm25-index.js';
@@ -23,7 +23,23 @@ import { hybridSearch } from '../core/search/hybrid-search.js';
 import { LocalBackend } from '../mcp/local/local-backend.js';
 import { mountMCPEndpoints } from './mcp-http.js';
 
-const buildGraph = async (): Promise<{ nodes: GraphNode[]; relationships: GraphRelationship[] }> => {
+/**
+ * Derive a repoId for the MCP connection pool.
+ * Matches LocalBackend.repoId() — lowercase name by default.
+ */
+const repoIdFor = (entry: RegistryEntry): string => entry.name.toLowerCase();
+
+/**
+ * Ensure the MCP connection pool has this repo's DB open, then run a query.
+ */
+const queryRepo = async (entry: RegistryEntry, cypher: string): Promise<any[]> => {
+  const id = repoIdFor(entry);
+  const lbugPath = path.join(entry.storagePath, 'lbug');
+  await initLbug(id, lbugPath);
+  return mcpExecuteQuery(id, cypher);
+};
+
+const buildGraph = async (entry: RegistryEntry): Promise<{ nodes: GraphNode[]; relationships: GraphRelationship[] }> => {
   const nodes: GraphNode[] = [];
   for (const table of NODE_TABLES) {
     try {
@@ -40,7 +56,7 @@ const buildGraph = async (): Promise<{ nodes: GraphNode[]; relationships: GraphR
         query = `MATCH (n:${table}) RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine, n.content AS content`;
       }
 
-      const rows = await executeQuery(query);
+      const rows = await queryRepo(entry, query);
       for (const row of rows) {
         nodes.push({
           id: row.id ?? row[0],
@@ -68,7 +84,7 @@ const buildGraph = async (): Promise<{ nodes: GraphNode[]; relationships: GraphR
   }
 
   const relationships: GraphRelationship[] = [];
-  const relRows = await executeQuery(
+  const relRows = await queryRepo(entry,
     `MATCH (a)-[r:CodeRelation]->(b) RETURN a.id AS sourceId, b.id AS targetId, r.type AS type, r.confidence AS confidence, r.reason AS reason, r.step AS step`
   );
   for (const row of relRows) {
@@ -179,8 +195,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
         res.status(404).json({ error: 'Repository not found' });
         return;
       }
-      const lbugPath = path.join(entry.storagePath, 'lbug');
-      const graph = await withLbugDb(lbugPath, async () => buildGraph());
+      const graph = await buildGraph(entry);
       res.json(graph);
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Failed to build graph' });
@@ -201,8 +216,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
         res.status(404).json({ error: 'Repository not found' });
         return;
       }
-      const lbugPath = path.join(entry.storagePath, 'lbug');
-      const result = await withLbugDb(lbugPath, () => executeQuery(cypher));
+      const result = await queryRepo(entry, cypher);
       res.json({ result });
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Query failed' });
@@ -223,21 +237,25 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
         res.status(404).json({ error: 'Repository not found' });
         return;
       }
+      const id = repoIdFor(entry);
       const lbugPath = path.join(entry.storagePath, 'lbug');
+      await initLbug(id, lbugPath);
+
       const parsedLimit = Number(req.body.limit ?? 10);
       const limit = Number.isFinite(parsedLimit)
         ? Math.max(1, Math.min(100, Math.trunc(parsedLimit)))
         : 10;
 
-      const results = await withLbugDb(lbugPath, async () => {
-        const { isEmbedderReady } = await import('../core/embeddings/embedder.js');
-        if (isEmbedderReady()) {
-          const { semanticSearch } = await import('../core/embeddings/embedding-pipeline.js');
-          return hybridSearch(query, limit, executeQuery, semanticSearch);
-        }
+      const repoQuery = (cypher: string) => mcpExecuteQuery(id, cypher);
+      const { isEmbedderReady } = await import('../core/embeddings/embedder.js');
+      let results;
+      if (isEmbedderReady()) {
+        const { semanticSearch } = await import('../core/embeddings/embedding-pipeline.js');
+        results = await hybridSearch(query, limit, repoQuery, semanticSearch);
+      } else {
         // FTS-only fallback when embeddings aren't loaded
-        return searchFTSFromLbug(query, limit);
-      });
+        results = await searchFTSFromLbug(query, limit, id);
+      }
       res.json({ results });
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Search failed' });


### PR DESCRIPTION

## Description 
The server had two independent LadybugDB adapter modules (core/lbug/lbug-adapter and mcp/core/lbug-adapter), each creating separate Database objects to the same file. Per the [LadybugDB concurrency docs](https://docs.ladybugdb.com/concurrency), you cannot have two Database objects on the same file in the same process. Switching repositories in the Web UI is causing issues.

**Fix**: Replaced all core adapter usage in api.ts with the MCP adapter's connection pool (initLbug + mcpExecuteQuery), which opens DBs in read-only mode and shares Database objects across repos. Now there's a single adapter managing all DB connections.
