### PR TITLE
fix: opencode mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ claude mcp add gitnexus -- npx -y gitnexus@latest mcp
 {
   "mcp": {
     "gitnexus": {
-      "command": "npx",
-      "args": ["-y", "gitnexus@latest", "mcp"]
+      "tyoe": "local",
+      "command": ["gitnexus", "mcp"]
     }
   }
 }


### PR DESCRIPTION
Updated the gitnexus MCP configuration to call the command directly instead of using npx. This prevents the 30000ms timeout issues I encountered when the system tried to fetch the package on every startup. Note: Users should install gitnexus globally (npm install -g gitnexus) for this to work.