### PR TITLE
fix(impact): serialize enrichment queries to prevent concurrent query crash (#316)

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1412,27 +1412,29 @@ export class LocalBackend {
       const d1Ids = (grouped[1] || []).map((i: any) => `'${i.id.replace(/'/g, "''")}'`).join(', ');
 
       // Affected processes: which execution flows are broken and at which step
-      const [processRows, moduleRows, directModuleRows] = await Promise.all([
-        executeQuery(repo.id, `
-          MATCH (s)-[r:CodeRelation {type: 'STEP_IN_PROCESS'}]->(p:Process)
-          WHERE s.id IN [${allIds}]
-          RETURN p.heuristicLabel AS name, COUNT(DISTINCT s.id) AS hits, MIN(r.step) AS minStep, p.stepCount AS stepCount
-          ORDER BY hits DESC
-          LIMIT 20
-        `).catch(() => []),
-        executeQuery(repo.id, `
-          MATCH (s)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
-          WHERE s.id IN [${allIds}]
-          RETURN c.heuristicLabel AS name, COUNT(DISTINCT s.id) AS hits
-          ORDER BY hits DESC
-          LIMIT 20
-        `).catch(() => []),
-        d1Ids ? executeQuery(repo.id, `
-          MATCH (s)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
-          WHERE s.id IN [${d1Ids}]
-          RETURN DISTINCT c.heuristicLabel AS name
-        `).catch(() => []) : Promise.resolve([]),
-      ]);
+      // Run enrichment queries sequentially to avoid concurrent query crashes (#316)
+      // that can cause SIGSEGV when the connection pool is under pressure.
+      const processRows = await executeQuery(repo.id, `
+        MATCH (s)-[r:CodeRelation {type: 'STEP_IN_PROCESS'}]->(p:Process)
+        WHERE s.id IN [${allIds}]
+        RETURN p.heuristicLabel AS name, COUNT(DISTINCT s.id) AS hits, MIN(r.step) AS minStep, p.stepCount AS stepCount
+        ORDER BY hits DESC
+        LIMIT 20
+      `).catch(() => []);
+
+      const moduleRows = await executeQuery(repo.id, `
+        MATCH (s)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
+        WHERE s.id IN [${allIds}]
+        RETURN c.heuristicLabel AS name, COUNT(DISTINCT s.id) AS hits
+        ORDER BY hits DESC
+        LIMIT 20
+      `).catch(() => []);
+
+      const directModuleRows = d1Ids ? await executeQuery(repo.id, `
+        MATCH (s)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
+        WHERE s.id IN [${d1Ids}]
+        RETURN DISTINCT c.heuristicLabel AS name
+      `).catch(() => []) : [];
 
       affectedProcesses = processRows.map((r: any) => ({
         name: r.name || r[0],


### PR DESCRIPTION
## Problem

`gitnexus impact` crashes with SIGSEGV (exit code -1073741819 on Windows) when the enrichment phase runs 3 concurrent queries via `Promise.all()` (#316).

The root cause (identified by @fangxiang2025 in the issue) is that the connection pool's dynamic growth path returns a newly created connection before FTS initialization completes. When 3 concurrent enrichment queries hit the pool simultaneously, the 3rd query gets an uninitialized connection, triggering a native crash.

## Fix

**Serialize the enrichment queries** — run them sequentially instead of via `Promise.all()`.

### Before:
```typescript
const [processRows, moduleRows, directModuleRows] = await Promise.all([
  executeQuery(repo.id, /* processes query */).catch(() => []),
  executeQuery(repo.id, /* modules query */).catch(() => []),
  executeQuery(repo.id, /* direct modules query */).catch(() => []),
]);
```

### After:
```typescript
const processRows = await executeQuery(repo.id, /* processes query */).catch(() => []);
const moduleRows = await executeQuery(repo.id, /* modules query */).catch(() => []);
const directModuleRows = await executeQuery(repo.id, /* direct modules query */).catch(() => []);
```

## Why Sequential?

1. **Prevents the crash** — No concurrent pool pressure, no uninitialized connections
2. **Minimal performance impact** — Each enrichment query takes ~20-40ms. Sequential adds at most ~100ms total, which is acceptable vs. process crash
3. **Safe with existing error handling** — Each query still has `.catch(() => [])` for graceful degradation
4. **No pool changes needed** — This is a safer fix than modifying the connection pool internals

## Alternative approaches considered

- **Pool fix (await FTS before returning)** — Would fix the root cause but requires changes to the connection pool that could affect all query paths, not just impact
- **Increase `INITIAL_CONNS_PER_REPO` to 3** — Works but is a band-aid; any code path that exceeds the prewarm count would still hit the same issue

## Testing

Verified in production across 25+ repositories on macOS (Apple Silicon). The sequential approach has been used in our operational toolkit ([gitnexus-stable-ops](https://github.com/ShunsukeHayashi/gitnexus-stable-ops)) without issues.

Related: #292 (same root cause on arm64 macOS), #321 (general impact crash — see PR #345 for error boundary)
