### PR TITLE
fix: route Cypher queries to backend API in server mode

### DIFF
--- a/gitnexus-web/src/hooks/useAppState.tsx
+++ b/gitnexus-web/src/hooks/useAppState.tsx
@@ -467,12 +467,29 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const runQuery = useCallback(async (cypher: string): Promise<any[]> => {
+    // In server mode, route Cypher queries to the backend HTTP API
+    // (the local WASM LadybugDB is not initialized when connected to a server)
+    if (serverBaseUrl) {
+      const response = await fetch(`${serverBaseUrl}/query`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cypher, repo: projectName }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || `Server query failed: ${response.status}`);
+      }
+      const body = await response.json();
+      return (body.result ?? body) as any[];
+    }
     const api = apiRef.current;
     if (!api) throw new Error('Worker not initialized');
     return api.runQuery(cypher);
-  }, []);
+  }, [serverBaseUrl, projectName]);
 
   const isDatabaseReady = useCallback(async (): Promise<boolean> => {
+    // In server mode, the database is always "ready" (queries go to the backend)
+    if (serverBaseUrl) return true;
     const api = apiRef.current;
     if (!api) return false;
     try {
@@ -480,7 +497,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     } catch {
       return false;
     }
-  }, []);
+  }, [serverBaseUrl]);
 
   // Embedding methods
   const startEmbeddings = useCallback(async (forceDevice?: 'webgpu' | 'wasm'): Promise<void> => {


### PR DESCRIPTION
## Summary

- In server mode, `runQuery()` tried to execute Cypher against the local WASM LadybugDB, which is never initialized when connected to a backend server. This caused the **Processes panel** to list processes (from the graph data fetched via `/api/graph`) but fail silently when clicking a process to view its steps, edges, or highlight in the graph.
- Routes Cypher queries to the server's `/api/query` HTTP endpoint when `serverBaseUrl` is set, instead of going through the WASM worker.
- Also fixes `isDatabaseReady()` to return `true` in server mode, unblocking the QueryFAB (Cypher query panel).

## Test plan

- [x] Start a GitNexus server (`npx gitnexus serve`)
- [x] Open the web UI and connect to the server
- [x] Open the **Processes** tab in the right panel — processes should be listed
- [x] Click a process **View** button — the flow modal should render with steps and edges
- [x] Click the **lightbulb** icon on a process — nodes should highlight in the graph
- [x] Open the **Cypher query panel** (QueryFAB) and run a query — results should return
- [x] Verify local mode (drag & drop / git clone) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)