### PR TITLE
fix/opencode mcp gitnexus timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ claude mcp add gitnexus -- npx -y gitnexus@latest mcp
 {
   "mcp": {
     "gitnexus": {
-      "tyoe": "local",
+      "type": "local",
       "command": ["gitnexus", "mcp"]
     }
   }


### PR DESCRIPTION
## PR Description

This PR updates the README to fix the MCP configuration for OpenCode, which was not working with the previous setup.

I validated the behavior against OpenCode's current MCP documentation. For **local MCP servers**, OpenCode defines `command` as an **array containing both the executable and its arguments**, for example:

```json
{
  "mcp": {
    "my-local-mcp-server": {
      "type": "local",
      "command": ["npx", "-y", "my-mcp-command"]
    }
  }
}
```

There is no documented support for a separate `args` field in this context.

Because of that, using:

```json
{
  "command": "npx",
  "args": ["-y", "gitnexus@latest", "mcp"]
}
```

does not match the documented configuration format, and in my case OpenCode rejected it.

The working configuration aligned with the docs is:

```json
{
  "mcp": {
    "gitnexus": {
      "type": "local",
      "command": ["gitnexus", "mcp"]
    }
  }
}
```
