### PR TITLE
feat: detect @Environment and @Query implicit Swift dependencies

### DIFF
--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -919,6 +919,20 @@ export const SWIFT_QUERIES = `
       (simple_identifier) @assignment.property))
   (_)) @assignment
 
+; Implicit dependency: @Environment(TypeName.self) — SwiftUI dependency injection
+; Captured as a call so the resolver creates a CALLS edge to the injected type.
+(attribute
+  (user_type (type_identifier) @_attr)
+  (navigation_expression
+    (simple_identifier) @call.name
+    (navigation_suffix (simple_identifier)))) @call
+
+; Implicit dependency: @Query(sort: \TypeName.field) — SwiftData model dependency
+(attribute
+  (user_type (type_identifier) @_attr)
+  (navigation_expression
+    (key_path_expression (type_identifier) @call.name))) @call
+
 `;
 
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {


### PR DESCRIPTION
## Problem

SwiftUI's `@Environment(TypeName.self)` and SwiftData's `@Query(sort: \TypeName.field)` create dependencies that are invisible as function calls. GitNexus missed these, making impact analysis incomplete.

**Example:** `ProEntitlementService` showed 1 caller (ContentView constructor), but 6 more views depend on it via `@Environment`. Changing the service would break all 7 — but `impact()` only warned about 1.

## Fix

Added two tree-sitter queries to `SWIFT_QUERIES` that capture attribute patterns as call-like references:

```
; @Environment(TypeName.self)
(attribute
  (user_type (type_identifier) @_attr)
  (navigation_expression
    (simple_identifier) @call.name
    (navigation_suffix (simple_identifier)))) @call

; @Query(sort: \TypeName.field)
(attribute
  (user_type (type_identifier) @_attr)
  (navigation_expression
    (key_path_expression (type_identifier) @call.name))) @call
```

The existing call resolver + constructor fallback handles the rest — no changes needed in `call-processor.ts` or `parse-worker.ts`.

## Results on PricePal (61-file iOS 26 app)

### ProEntitlementService callers

| | Before | After |
|--|--|--|
| Callers | 1 | **7** |

```
ContentView.swift          → ProEntitlementService()                      // constructor
TipJarView.swift           → @Environment(ProEntitlementService.self)     // DI
SettingsTab.swift           → @Environment(ProEntitlementService.self)     // DI
ProUpgradeView.swift        → @Environment(ProEntitlementService.self)     // DI
DataExportView.swift        → @Environment(ProEntitlementService.self)     // DI
SmartSuggestionsView.swift  → @Environment(ProEntitlementService.self)     // DI
ShoppingListView.swift      → @Environment(ProEntitlementService.self)     // DI
```

All verified against source code — zero false positives.

## Scope

This is intentionally minimal — one file changed, two queries added. It catches the most common Swift DI and data patterns. Not covered (future work):
- `@Environment(\.keyPath)` system values (less useful for impact analysis)
- `@Bindable`, `@State`, `@AppStorage` (different attribute structure)
- `@Model` cascade relationships

## Test plan
- [x] Query compilation test passes (all 12 languages)
- [x] All 12 Swift resolver tests pass
- [x] All 3,592 tests pass, 0 regressions
- [x] Verified on real iOS 26 project (PricePal, 61 files)
- [x] Works on both sequential and worker parsing paths

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)