### PR TITLE
docs(schema): add Community and Process node properties to cypher tool description (#411)

### DIFF
--- a/gitnexus/src/mcp/resources.ts
+++ b/gitnexus/src/mcp/resources.ts
@@ -327,6 +327,8 @@ node_properties:
   Function: "parameterCount (INT32), returnType (STRING), isVariadic (BOOL)"
   Property: "declaredType (STRING) — the field's type annotation (e.g., 'Address', 'City'). Used for field-access chain resolution."
   Constructor: "parameterCount (INT32)"
+  Community: "heuristicLabel (STRING), cohesion (DOUBLE), symbolCount (INT32), keywords (STRING[]), description (STRING), enrichedBy (STRING)"
+  Process: "heuristicLabel (STRING), processType (STRING — 'intra_community' or 'cross_community'), stepCount (INT32), communities (STRING[]), entryPointId (STRING), terminalId (STRING)"
 
 relationships:
   - CONTAINS: File/Folder contains child

--- a/gitnexus/src/mcp/tools.ts
+++ b/gitnexus/src/mcp/tools.ts
@@ -110,8 +110,8 @@ OUTPUT: Returns { markdown, row_count } — results formatted as a Markdown tabl
 
 TIPS:
 - All relationships use single CodeRelation table — filter with {type: 'CALLS'} etc.
-- Community = auto-detected functional area (Leiden algorithm)
-- Process = execution flow trace from entry point to terminal
+- Community = auto-detected functional area (Leiden algorithm). Properties: heuristicLabel, cohesion, symbolCount, keywords, description, enrichedBy
+- Process = execution flow trace from entry point to terminal. Properties: heuristicLabel, processType, stepCount, communities, entryPointId, terminalId
 - Use heuristicLabel (not label) for human-readable community/process names`,
     inputSchema: {
       type: 'object',


### PR DESCRIPTION
## Summary

- Add missing Community and Process node property listings to the `cypher` tool description and `gitnexus://repo/{name}/schema` resource
- Properties sourced from actual LadybugDB schema (`COMMUNITY_SCHEMA` and `PROCESS_SCHEMA` in `schema.ts`)

## Problem

The cypher tool description and schema resource omit Community and Process node properties. Any agent following the tool description writes failing Cypher queries on first attempt (e.g., using `c.memberCount` instead of `c.symbolCount`), wasting tokens and requiring trial-and-error schema discovery.

## Changes

**`src/mcp/resources.ts`** (schema resource):
- Added `Community: "heuristicLabel, cohesion, symbolCount, keywords, description, enrichedBy"`
- Added `Process: "heuristicLabel, processType, stepCount, communities, entryPointId, terminalId"`

**`src/mcp/tools.ts`** (cypher tool TIPS section):
- Added property listings inline for Community and Process nodes

## Verification

Properties match the actual schema definitions in `src/core/lbug/schema.ts`:
- `COMMUNITY_SCHEMA`: id, label, heuristicLabel, keywords, description, enrichedBy, cohesion, symbolCount
- `PROCESS_SCHEMA`: id, label, heuristicLabel, processType, stepCount, communities, entryPointId, terminalId, description, enrichedBy

Closes #411