### PR TITLE
refactor: centralize hardcoded confidence values into RELATIONSHIP_CONFIDENCE (#429)

### DIFF
--- a/gitnexus/src/core/ingestion/markdown-processor.ts
+++ b/gitnexus/src/core/ingestion/markdown-processor.ts
@@ -6,6 +6,7 @@
  * cross-file links.
  */
 
+import { RELATIONSHIP_CONFIDENCE } from './resolution-context.js';
 import path from 'node:path';
 import { generateId } from '../../lib/utils.js';
 import { KnowledgeGraph, GraphNode, GraphRelationship } from '../graph/types.js';
@@ -145,7 +146,7 @@ export const processMarkdown = (
           type: 'IMPORTS',
           sourceId: fileNodeId,
           targetId: targetFileId,
-          confidence: 0.8,
+          confidence: RELATIONSHIP_CONFIDENCE.heuristic,
           reason: 'markdown-link',
         });
         totalLinks++;

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -19,6 +19,7 @@
  * Cypher: MATCH (c:Class)-[r:CodeRelation {type: 'OVERRIDES'}]->(m:Method)
  */
 
+import { RELATIONSHIP_CONFIDENCE } from './resolution-context.js';
 import { KnowledgeGraph, GraphRelationship } from '../graph/types.js';
 import { generateId } from '../../lib/utils.js';
 import { SupportedLanguages } from '../../config/supported-languages.js';
@@ -224,11 +225,11 @@ function resolveByMroOrder(
       return {
         resolvedTo: match.methodId,
         reason: `${reasonPrefix}: ${match.className}::${methodName}`,
-        confidence: 0.9,  // MRO-ordered resolution
+        confidence: RELATIONSHIP_CONFIDENCE.mroOrdered,
       };
     }
   }
-  return { resolvedTo: defs[0].methodId, reason: `${reasonPrefix} fallback: first definition`, confidence: 0.7 };
+  return { resolvedTo: defs[0].methodId, reason: `${reasonPrefix} fallback: first definition`, confidence: RELATIONSHIP_CONFIDENCE.fallback };
 }
 
 function resolveCsharpJava(
@@ -252,7 +253,7 @@ function resolveCsharpJava(
     return {
       resolvedTo: classDefs[0].methodId,
       reason: `class method wins: ${classDefs[0].className}::${methodName}`,
-      confidence: 0.95,  // Class method is authoritative
+      confidence: RELATIONSHIP_CONFIDENCE.classMethod,
     };
   }
 
@@ -268,11 +269,11 @@ function resolveCsharpJava(
     return {
       resolvedTo: interfaceDefs[0].methodId,
       reason: `single interface default: ${interfaceDefs[0].className}::${methodName}`,
-      confidence: 0.85,  // Single interface, unambiguous
+      confidence: RELATIONSHIP_CONFIDENCE.singleInterface,
     };
   }
 
-  return { resolvedTo: null, reason: 'no resolution found', confidence: 0.5 };
+  return { resolvedTo: null, reason: 'no resolution found', confidence: RELATIONSHIP_CONFIDENCE.uncertain };
 }
 
 // ---------------------------------------------------------------------------

--- a/gitnexus/src/core/ingestion/resolution-context.ts
+++ b/gitnexus/src/core/ingestion/resolution-context.ts
@@ -35,6 +35,37 @@ export const TIER_CONFIDENCE: Record<ResolutionTier, number> = {
   'global': 0.5,
 };
 
+/**
+ * Confidence scores for relationship types.
+ *
+ * Structural relationships (DEFINES, CONTAINS, IMPORTS, HAS_PROPERTY) are
+ * always 1.0 — they are syntactically determined.
+ *
+ * Resolution-derived relationships use the confidence from the resolution
+ * tier (TIER_CONFIDENCE) or MRO_CONFIDENCE below.
+ *
+ * See Issue #429 for rationale.
+ */
+export const RELATIONSHIP_CONFIDENCE = {
+  /** Syntactically determined — always correct. */
+  structural: 1.0,
+  /** Class method is authoritative for its name. */
+  classMethod: 0.95,
+  /** MRO-ordered resolution — strong but may have diamond ambiguity. */
+  mroOrdered: 0.9,
+  /** Single interface implementor — unambiguous. */
+  singleInterface: 0.85,
+  /** Heuristic match (e.g., markdown cross-reference, decay factor). */
+  heuristic: 0.8,
+  /** Fallback: first definition when no better signal exists. */
+  fallback: 0.7,
+  /** Unresolved or ambiguous — requires manual inspection. */
+  uncertain: 0.5,
+} as const;
+
+export type RelationshipConfidenceLevel = keyof typeof RELATIONSHIP_CONFIDENCE;
+
+
 // --- Map types ---
 export type ImportMap = Map<string, Set<string>>;
 export type PackageMap = Map<string, Set<string>>;

--- a/gitnexus/test/unit/confidence-constants.test.ts
+++ b/gitnexus/test/unit/confidence-constants.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { TIER_CONFIDENCE, RELATIONSHIP_CONFIDENCE } from '../../src/core/ingestion/resolution-context.js';
+
+describe('RELATIONSHIP_CONFIDENCE', () => {
+  it('exports all expected confidence levels', () => {
+    expect(RELATIONSHIP_CONFIDENCE.structural).toBe(1.0);
+    expect(RELATIONSHIP_CONFIDENCE.classMethod).toBe(0.95);
+    expect(RELATIONSHIP_CONFIDENCE.mroOrdered).toBe(0.9);
+    expect(RELATIONSHIP_CONFIDENCE.singleInterface).toBe(0.85);
+    expect(RELATIONSHIP_CONFIDENCE.heuristic).toBe(0.8);
+    expect(RELATIONSHIP_CONFIDENCE.fallback).toBe(0.7);
+    expect(RELATIONSHIP_CONFIDENCE.uncertain).toBe(0.5);
+  });
+
+  it('has strictly decreasing values from structural to uncertain', () => {
+    const values = [
+      RELATIONSHIP_CONFIDENCE.structural,
+      RELATIONSHIP_CONFIDENCE.classMethod,
+      RELATIONSHIP_CONFIDENCE.mroOrdered,
+      RELATIONSHIP_CONFIDENCE.singleInterface,
+      RELATIONSHIP_CONFIDENCE.heuristic,
+      RELATIONSHIP_CONFIDENCE.fallback,
+      RELATIONSHIP_CONFIDENCE.uncertain,
+    ];
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i]).toBeLessThan(values[i - 1]);
+    }
+  });
+
+  it('all values are in the valid range [0, 1]', () => {
+    for (const [key, value] of Object.entries(RELATIONSHIP_CONFIDENCE)) {
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('TIER_CONFIDENCE values align with RELATIONSHIP_CONFIDENCE semantics', () => {
+    // same-file should equal classMethod (both are authoritative)
+    expect(TIER_CONFIDENCE['same-file']).toBe(RELATIONSHIP_CONFIDENCE.classMethod);
+    // import-scoped should equal mroOrdered (both are strong but scoped)
+    expect(TIER_CONFIDENCE['import-scoped']).toBe(RELATIONSHIP_CONFIDENCE.mroOrdered);
+    // global should equal uncertain (both are low-confidence)
+    expect(TIER_CONFIDENCE['global']).toBe(RELATIONSHIP_CONFIDENCE.uncertain);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `RELATIONSHIP_CONFIDENCE` constant map to `resolution-context.ts` alongside the existing `TIER_CONFIDENCE`, centralizing all hardcoded confidence literals used across the ingestion pipeline.

Closes #429

## Changes

### New constant map (resolution-context.ts)

| Key | Value | Semantic |
|-----|-------|----------|
| `structural` | 1.0 | Syntactically determined (DEFINES, CONTAINS, IMPORTS) |
| `classMethod` | 0.95 | Class method is authoritative for its name |
| `mroOrdered` | 0.9 | MRO-ordered resolution (strong but may have diamond ambiguity) |
| `singleInterface` | 0.85 | Single interface implementor (unambiguous) |
| `heuristic` | 0.8 | Heuristic match (e.g., markdown cross-reference) |
| `fallback` | 0.7 | First definition when no better signal exists |
| `uncertain` | 0.5 | Unresolved or ambiguous |

### Replacements

- **mro-processor.ts**: 5 hardcoded values replaced (`0.95`, `0.9`, `0.85`, `0.7`, `0.5`)
- **markdown-processor.ts**: 1 hardcoded value replaced (`0.8`)

### What was NOT replaced (by design)

Structural `confidence: 1.0` literals in call-processor, pipeline, import-processor, structure-processor, and parse-worker are **intentionally left as literals**. These represent syntactically determined relationships (DEFINES, CONTAINS, IMPORTS, HAS_PROPERTY) that are always correct — replacing them with a named constant would add indirection without semantic benefit.

### Tests

- **confidence-constants.test.ts** (4 tests):
  - Exports all expected confidence levels
  - Strictly decreasing order invariant (structural > classMethod > ... > uncertain)
  - All values in valid [0, 1] range
  - TIER_CONFIDENCE alignment check (same-file=0.95=classMethod, import-scoped=0.9=mroOrdered, global=0.5=uncertain)

## Test results

```
Test Files  97 passed (97)
Tests       3655 passed (3655)
```

All existing tests pass unchanged.
