### PR TITLE
refactor: centralize all hardcoded confidence values into RELATIONSHIP_CONFIDENCE map (#429)

### DIFF
--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -3,7 +3,7 @@ import { ASTCache } from './ast-cache.js';
 import type { SymbolDefinition, SymbolTable } from './symbol-table.js';
 import Parser from 'tree-sitter';
 import type { ResolutionContext } from './resolution-context.js';
-import { TIER_CONFIDENCE, type ResolutionTier } from './resolution-context.js';
+import { TIER_CONFIDENCE, RELATIONSHIP_CONFIDENCE, type ResolutionTier } from './resolution-context.js';
 import { isLanguageAvailable, loadParser, loadLanguage } from '../tree-sitter/parser-loader.js';
 import { LANGUAGE_QUERIES } from './tree-sitter-queries.js';
 import { generateId } from '../../lib/utils.js';
@@ -475,13 +475,13 @@ export const processCalls = async (
               const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
               graph.addRelationship({
                 id: relId, sourceId: fileId, targetId: nodeId,
-                type: 'DEFINES', confidence: 1.0, reason: '',
+                type: 'DEFINES', confidence: RELATIONSHIP_CONFIDENCE.structural, reason: '',
               });
               if (propEnclosingClassId) {
                 graph.addRelationship({
                   id: generateId('HAS_PROPERTY', `${propEnclosingClassId}->${nodeId}`),
                   sourceId: propEnclosingClassId, targetId: nodeId,
-                  type: 'HAS_PROPERTY', confidence: 1.0, reason: '',
+                  type: 'HAS_PROPERTY', confidence: RELATIONSHIP_CONFIDENCE.structural, reason: '',
                 });
               }
             }
@@ -628,7 +628,7 @@ export const processCalls = async (
         sourceId: pw.srcId,
         targetId: fieldOwner.nodeId,
         type: 'ACCESSES',
-        confidence: 1.0,
+        confidence: RELATIONSHIP_CONFIDENCE.structural,
         reason: 'write',
       });
     }
@@ -1048,7 +1048,7 @@ const makeAccessEmitter = (
       sourceId,
       targetId: fieldNodeId,
       type: 'ACCESSES',
-      confidence: 1.0,
+      confidence: RELATIONSHIP_CONFIDENCE.structural,
       reason: 'read',
     });
   };
@@ -1273,7 +1273,7 @@ export const processAssignmentsFromExtracted = (
       sourceId: asn.sourceId,
       targetId: fieldOwner.nodeId,
       type: 'ACCESSES',
-      confidence: 1.0,
+      confidence: RELATIONSHIP_CONFIDENCE.structural,
       reason: 'write',
     });
   }

--- a/gitnexus/src/core/ingestion/import-processor.ts
+++ b/gitnexus/src/core/ingestion/import-processor.ts
@@ -11,6 +11,7 @@ import { loadImportConfigs } from './language-config.js';
 import { buildSuffixIndex } from './resolvers/index.js';
 import { callRouters } from './call-routing.js';
 import type { ResolutionContext } from './resolution-context.js';
+import { RELATIONSHIP_CONFIDENCE } from './resolution-context.js';
 import type { SuffixIndex } from './resolvers/index.js';
 import { importResolvers, namedBindingExtractors, preprocessImportPath } from './import-resolution.js';
 import type { ImportResult, ResolveCtx, NamedBinding } from './import-resolution.js';
@@ -85,7 +86,7 @@ function createImportEdgeHelpers(graph: KnowledgeGraph, importMap: ImportMap) {
     const targetId = generateId('File', resolvedPath);
     const relId = generateId('IMPORTS', `${filePath}->${resolvedPath}`);
     totalImportsResolved++;
-    graph.addRelationship({ id: relId, sourceId, targetId, type: 'IMPORTS', confidence: 1.0, reason: '' });
+    graph.addRelationship({ id: relId, sourceId, targetId, type: 'IMPORTS', confidence: RELATIONSHIP_CONFIDENCE.structural, reason: '' });
   };
 
   const addImportEdge = (filePath: string, resolvedPath: string) => {

--- a/gitnexus/src/core/ingestion/markdown-processor.ts
+++ b/gitnexus/src/core/ingestion/markdown-processor.ts
@@ -9,6 +9,7 @@
 import path from 'node:path';
 import { generateId } from '../../lib/utils.js';
 import { KnowledgeGraph, GraphNode, GraphRelationship } from '../graph/types.js';
+import { RELATIONSHIP_CONFIDENCE } from './resolution-context.js';
 
 const HEADING_RE = /^(#{1,6})\s+(.+)$/;
 const LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g;
@@ -98,7 +99,7 @@ export const processMarkdown = (
         type: 'CONTAINS',
         sourceId: parentId,
         targetId: sectionId,
-        confidence: 1.0,
+        confidence: RELATIONSHIP_CONFIDENCE.structural,
         reason: 'markdown-heading',
       });
 
@@ -145,7 +146,7 @@ export const processMarkdown = (
           type: 'IMPORTS',
           sourceId: fileNodeId,
           targetId: targetFileId,
-          confidence: 0.8,
+          confidence: RELATIONSHIP_CONFIDENCE.heuristic,
           reason: 'markdown-link',
         });
         totalLinks++;

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -22,6 +22,7 @@
 import { KnowledgeGraph, GraphRelationship } from '../graph/types.js';
 import { generateId } from '../../lib/utils.js';
 import { SupportedLanguages } from '../../config/supported-languages.js';
+import { RELATIONSHIP_CONFIDENCE } from './resolution-context.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -224,11 +225,11 @@ function resolveByMroOrder(
       return {
         resolvedTo: match.methodId,
         reason: `${reasonPrefix}: ${match.className}::${methodName}`,
-        confidence: 0.9,  // MRO-ordered resolution
+        confidence: RELATIONSHIP_CONFIDENCE.mroOrdered,
       };
     }
   }
-  return { resolvedTo: defs[0].methodId, reason: `${reasonPrefix} fallback: first definition`, confidence: 0.7 };
+  return { resolvedTo: defs[0].methodId, reason: `${reasonPrefix} fallback: first definition`, confidence: RELATIONSHIP_CONFIDENCE.fallback };
 }
 
 function resolveCsharpJava(
@@ -252,7 +253,7 @@ function resolveCsharpJava(
     return {
       resolvedTo: classDefs[0].methodId,
       reason: `class method wins: ${classDefs[0].className}::${methodName}`,
-      confidence: 0.95,  // Class method is authoritative
+      confidence: RELATIONSHIP_CONFIDENCE.resolved,
     };
   }
 
@@ -260,7 +261,7 @@ function resolveCsharpJava(
     return {
       resolvedTo: null,
       reason: `ambiguous: ${methodName} defined in multiple interfaces: ${interfaceDefs.map(d => d.className).join(', ')}`,
-      confidence: 0.5,
+      confidence: RELATIONSHIP_CONFIDENCE.uncertain,
     };
   }
 
@@ -268,11 +269,11 @@ function resolveCsharpJava(
     return {
       resolvedTo: interfaceDefs[0].methodId,
       reason: `single interface default: ${interfaceDefs[0].className}::${methodName}`,
-      confidence: 0.85,  // Single interface, unambiguous
+      confidence: RELATIONSHIP_CONFIDENCE.interfaceSingle,
     };
   }
 
-  return { resolvedTo: null, reason: 'no resolution found', confidence: 0.5 };
+  return { resolvedTo: null, reason: 'no resolution found', confidence: RELATIONSHIP_CONFIDENCE.uncertain };
 }
 
 // ---------------------------------------------------------------------------
@@ -380,7 +381,7 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
           resolution = {
             resolvedTo: null,
             reason: `Rust requires qualified syntax: <Type as Trait>::${methodName}()`,
-            confidence: 0.5,
+            confidence: RELATIONSHIP_CONFIDENCE.uncertain,
           };
           break;
         default:

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -13,6 +13,7 @@ import { typeConfigs } from './type-extractors/index.js';
 import { WorkerPool } from './workers/worker-pool.js';
 import type { ParseWorkerResult, ParseWorkerInput, ExtractedImport, ExtractedCall, ExtractedAssignment, ExtractedHeritage, ExtractedRoute, FileConstructorBindings, FileTypeEnvBindings } from './workers/parse-worker.js';
 import { getTreeSitterBufferSize, TREE_SITTER_MAX_BUFFER } from './constants.js';
+import { RELATIONSHIP_CONFIDENCE } from './resolution-context.js';
 
 export type FileProgressCallback = (current: number, total: number, filePath: string) => void;
 
@@ -276,7 +277,7 @@ const processParsingSequential = async (
         sourceId: fileId,
         targetId: nodeId,
         type: 'DEFINES',
-        confidence: 1.0,
+        confidence: RELATIONSHIP_CONFIDENCE.structural,
         reason: '',
       };
 
@@ -290,7 +291,7 @@ const processParsingSequential = async (
           sourceId: enclosingClassId,
           targetId: nodeId,
           type: memberEdgeType,
-          confidence: 1.0,
+          confidence: RELATIONSHIP_CONFIDENCE.structural,
           reason: '',
         });
       }

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -13,7 +13,7 @@ import { processHeritage, processHeritageFromExtracted } from './heritage-proces
 import { computeMRO } from './mro-processor.js';
 import { processCommunities } from './community-processor.js';
 import { processProcesses } from './process-processor.js';
-import { createResolutionContext } from './resolution-context.js';
+import { createResolutionContext, RELATIONSHIP_CONFIDENCE } from './resolution-context.js';
 import { createASTCache } from './ast-cache.js';
 import { PipelineProgress, PipelineResult } from '../../types/pipeline.js';
 import { walkRepositoryPaths, readFileContents } from './filesystem-walker.js';
@@ -792,7 +792,7 @@ export const runPipelineFromRepo = async (
           type: 'MEMBER_OF',
           sourceId: membership.nodeId,
           targetId: membership.communityId,
-          confidence: 1.0,
+          confidence: RELATIONSHIP_CONFIDENCE.structural,
           reason: 'leiden-algorithm',
         });
       });
@@ -851,7 +851,7 @@ export const runPipelineFromRepo = async (
           type: 'STEP_IN_PROCESS',
           sourceId: step.nodeId,
           targetId: step.processId,
-          confidence: 1.0,
+          confidence: RELATIONSHIP_CONFIDENCE.structural,
           reason: 'trace-detection',
           step: step.step,
         });

--- a/gitnexus/src/core/ingestion/resolution-context.ts
+++ b/gitnexus/src/core/ingestion/resolution-context.ts
@@ -35,6 +35,17 @@ export const TIER_CONFIDENCE: Record<ResolutionTier, number> = {
   'global': 0.5,
 };
 
+/** Confidence scores for relationship edges by resolution quality. */
+export const RELATIONSHIP_CONFIDENCE = {
+  structural: 1.0,
+  resolved: 0.95,
+  heuristic: 0.8,
+  fallback: 0.7,
+  mroOrdered: 0.9,
+  interfaceSingle: 0.85,
+  uncertain: 0.5,
+} as const;
+
 // --- Map types ---
 export type ImportMap = Map<string, Set<string>>;
 export type PackageMap = Map<string, Set<string>>;

--- a/gitnexus/src/core/ingestion/structure-processor.ts
+++ b/gitnexus/src/core/ingestion/structure-processor.ts
@@ -1,5 +1,6 @@
 import { generateId } from "../../lib/utils.js";
 import { KnowledgeGraph, GraphNode, GraphRelationship } from "../graph/types.js";
+import { RELATIONSHIP_CONFIDENCE } from './resolution-context.js';
 
 export const processStructure = ( graph: KnowledgeGraph, paths: string[])=>{
     paths.forEach( path => {
@@ -33,7 +34,7 @@ export const processStructure = ( graph: KnowledgeGraph, paths: string[])=>{
                     type: 'CONTAINS',
                     sourceId: parentId,
                     targetId: nodeId,
-                    confidence: 1.0,
+                    confidence: RELATIONSHIP_CONFIDENCE.structural,
                     reason: '',
                 }
 

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -49,6 +49,7 @@ import { generateId } from '../../../lib/utils.js';
 import { namedBindingExtractors, preprocessImportPath } from '../import-resolution.js';
 import type { NamedBinding } from '../import-resolution.js';
 import { callRouters } from '../call-routing.js';
+import { RELATIONSHIP_CONFIDENCE } from '../resolution-context.js';
 import { extractPropertyDeclaredType } from '../type-extractors/shared.js';
 import type { NodeLabel } from '../../graph/types.js';
 
@@ -1030,7 +1031,7 @@ const processFileGroup = (
                   sourceId: fileId,
                   targetId: nodeId,
                   type: 'DEFINES',
-                  confidence: 1.0,
+                  confidence: RELATIONSHIP_CONFIDENCE.structural,
                   reason: '',
                 });
                 if (propEnclosingClassId) {
@@ -1039,7 +1040,7 @@ const processFileGroup = (
                     sourceId: propEnclosingClassId,
                     targetId: nodeId,
                     type: 'HAS_PROPERTY',
-                    confidence: 1.0,
+                    confidence: RELATIONSHIP_CONFIDENCE.structural,
                     reason: '',
                   });
                 }
@@ -1231,7 +1232,7 @@ const processFileGroup = (
         sourceId: fileId,
         targetId: nodeId,
         type: 'DEFINES',
-        confidence: 1.0,
+        confidence: RELATIONSHIP_CONFIDENCE.structural,
         reason: '',
       });
 
@@ -1243,7 +1244,7 @@ const processFileGroup = (
           sourceId: enclosingClassId,
           targetId: nodeId,
           type: memberEdgeType,
-          confidence: 1.0,
+          confidence: RELATIONSHIP_CONFIDENCE.structural,
           reason: '',
         });
       }


### PR DESCRIPTION
## Summary

Extends the `TIER_CONFIDENCE` pattern (introduced in #427) into a broader `RELATIONSHIP_CONFIDENCE` constant map, providing a single source of truth for all relationship edge confidence values across the ingestion pipeline.

## Changes

### New constant in `resolution-context.ts`

```typescript
export const RELATIONSHIP_CONFIDENCE = {
  structural: 1.0,       // DEFINES, HAS_PROPERTY, IMPORTS, CONTAINS, DECLARES
  resolved: 0.95,        // Class method (authoritative resolution)
  mroOrdered: 0.9,       // MRO-ordered resolution
  interfaceSingle: 0.85, // Single interface, unambiguous
  heuristic: 0.8,        // Pattern-matched relationships (markdown links etc.)
  fallback: 0.7,         // Fallback heuristic (first definition)
  uncertain: 0.5,        // Low-confidence / global-tier guesses
} as const;
```

### Files updated (~20 magic numbers replaced)

| File | Occurrences |
|------|-------------|
| `call-processor.ts` | 5 |
| `workers/parse-worker.ts` | 4 |
| `mro-processor.ts` | 6 |
| `parsing-processor.ts` | 2 |
| `pipeline.ts` | 2 |
| `markdown-processor.ts` | 2 |
| `import-processor.ts` | 1 |
| `structure-processor.ts` | 1 |

### What was intentionally left unchanged

- Dynamic confidence values (`resolved.confidence`, computed expressions like `confidence * 0.8`)
- `TIER_CONFIDENCE` usage (resolution tier scores — different semantic domain)
- Type definitions (`confidence: number`)

## Benefits

- **Single source of truth** — tuning one value adjusts all relationships of that class
- **Self-documenting** — `RELATIONSHIP_CONFIDENCE.structural` communicates intent vs bare `1.0`
- **Consistent with existing patterns** — follows the `TIER_CONFIDENCE` convention already in the codebase

## Testing

All pre-existing test failures (`call-form.test.ts`, `method-signature.test.ts`, `type-env.test.ts`) are present on `main` branch as well (missing `tree-sitter-kotlin` dependency in test environment — unrelated to this change). All other tests pass.

Closes #429
