### PR TITLE
fix(nexus-ai): improve streaming error messages for Ollama/OpenRouter (#436)

### DIFF
--- a/gitnexus-web/src/core/llm/agent.ts
+++ b/gitnexus-web/src/core/llm/agent.ts
@@ -199,16 +199,6 @@ export const createChatModel = (config: ProviderConfig): BaseChatModel => {
     case 'openrouter': {
       const openRouterConfig = config as OpenRouterConfig;
 
-      // Debug logging
-      if (import.meta.env.DEV) {
-        console.log('🌐 OpenRouter config:', {
-          hasApiKey: !!openRouterConfig.apiKey,
-          apiKeyLength: openRouterConfig.apiKey?.length || 0,
-          model: openRouterConfig.model,
-          baseUrl: openRouterConfig.baseUrl,
-        });
-      }
-
       if (!openRouterConfig.apiKey || openRouterConfig.apiKey.trim() === '') {
         throw new Error('OpenRouter API key is required but was not provided');
       }
@@ -539,7 +529,11 @@ export async function* streamAgentResponse(
     }
     yield { 
       type: 'error', 
-      error: message,
+      error: message.includes('context length')
+        ? `${message}. Try reducing conversation length or increasing the model context window.`
+        : message.includes('connection refused') || message.includes('ECONNREFUSED')
+        ? `${message}. Check that your Ollama server is running at the configured URL.`
+        : message,
     };
   }
 }


### PR DESCRIPTION
## Summary

Improves error handling for Ollama and OpenRouter streaming in NexusAI.

Closes #436

## Changes

### Verbose debug logging removed

The OpenRouter provider case had a debug block logging API key length and base URL on every model creation. This is removed — sensitive info should not be logged even in DEV mode.

### Contextual error messages

Stream errors now include actionable context based on the error type:

| Error Pattern | Added Context |
|--------------|--------------|
| `context length` | "Try reducing conversation length or increasing the model context window." |
| `connection refused` / `ECONNREFUSED` | "Check that your Ollama server is running at the configured URL." |
| Other errors | Passed through unchanged |

### Note on streaming support

Investigation confirmed that both Ollama and OpenRouter already have `streaming: true` configured. The original issue assumption that streaming was missing was incorrect. The actual gap was error UX — users got raw error messages with no guidance.

## Type Check

```
npx tsc --noEmit -p tsconfig.app.json  # No errors
```

Addresses #436
