### PR TITLE
feat(cli): add --skip-ai-context to disable CLAUDE.md and skills generation (#312)

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -50,6 +50,8 @@ export interface AnalyzeOptions {
   verbose?: boolean;
   /** Index the folder even when no .git directory is present. */
   skipGit?: boolean;
+  /** Skip CLAUDE.md, AGENTS.md, and .claude/skills generation. */
+  skipAiContext?: boolean;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -356,14 +358,17 @@ export const analyzeCommand = async (
     generatedSkills = skillResult.skills;
   }
 
-  const aiContext = await generateAIContextFiles(repoPath, storagePath, projectName, {
-    files: pipelineResult.totalFileCount,
-    nodes: stats.nodes,
-    edges: stats.edges,
-    communities: pipelineResult.communityResult?.stats.totalCommunities,
-    clusters: aggregatedClusterCount,
-    processes: pipelineResult.processResult?.stats.totalProcesses,
-  }, generatedSkills);
+  let aiContext: { files: string[] } = { files: [] };
+  if (!options?.skipAiContext) {
+    aiContext = await generateAIContextFiles(repoPath, storagePath, projectName, {
+      files: pipelineResult.totalFileCount,
+      nodes: stats.nodes,
+      edges: stats.edges,
+      communities: pipelineResult.communityResult?.stats.totalCommunities,
+      clusters: aggregatedClusterCount,
+      processes: pipelineResult.processResult?.stats.totalProcesses,
+    }, generatedSkills);
+  }
 
   await closeLbug();
   // Note: we intentionally do NOT call disposeEmbedder() here.

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -30,6 +30,7 @@ program
   .option('--skills', 'Generate repo-specific skill files from detected communities')
   .option('--skip-git', 'Index a folder without requiring a .git directory')
    .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
+  .option('--skip-ai-context', 'Skip CLAUDE.md, AGENTS.md, and .claude/skills generation')
    .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)')
    .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 


### PR DESCRIPTION
## Summary

Adds `--skip-ai-context` flag to `gitnexus analyze` to prevent automatic generation of CLAUDE.md, AGENTS.md, and .claude/skills. Requested by users working in Cursor, VS Code, and other editors that don't use these Claude-specific files.

Closes #312

## Usage

```bash
# Normal: generates CLAUDE.md + AGENTS.md + .claude/skills/
npx gitnexus analyze

# New: skip AI context file generation
npx gitnexus analyze --skip-ai-context
```

## Changes

### analyze.ts
- Added `skipAiContext?: boolean` to `AnalyzeOptions` interface
- Wrapped `generateAIContextFiles()` call in conditional guard
- When skipped, `aiContext` defaults to `{ files: [] }` — rest of the pipeline runs normally

### index.ts
- Added `--skip-ai-context` option to the `analyze` command definition
- Passed through to `analyzeCommand` via options object

## Testing

```
1900 passed | 1 skipped (unit tests)
npx tsc --noEmit  # No errors
```

No behavioral change when `--skip-ai-context` is not provided.

Addresses #312
