### PR TITLE
feat(nexus-ai): persist chat history to localStorage (#432)

### DIFF
--- a/gitnexus-web/src/core/llm/settings-service.ts
+++ b/gitnexus-web/src/core/llm/settings-service.ts
@@ -17,9 +17,12 @@ import {
   OpenRouterConfig,
   MiniMaxConfig,
   ProviderConfig,
+  ChatMessage,
 } from './types';
 
 const STORAGE_KEY = 'gitnexus-llm-settings';
+const CHAT_HISTORY_PREFIX = 'gitnexus-chat-history';
+const MAX_CHAT_MESSAGES = 50;
 
 /**
  * Load settings from localStorage
@@ -354,5 +357,57 @@ export const fetchOpenRouterModels = async (): Promise<Array<{ id: string; name:
     console.error('Error fetching OpenRouter models:', error);
     return [];
   }
+};
+
+// --- Chat History Persistence ---
+
+/**
+ * Build a localStorage key for a project's chat history
+ */
+const chatHistoryKey = (projectName: string): string =>
+  `${CHAT_HISTORY_PREFIX}:${projectName}`;
+
+/**
+ * Load chat history from localStorage for a given project
+ */
+export const loadChatHistory = (projectName: string): ChatMessage[] => {
+  if (!projectName) return [];
+  try {
+    const stored = localStorage.getItem(chatHistoryKey(projectName));
+    if (!stored) return [];
+    const parsed = JSON.parse(stored) as ChatMessage[];
+    // Restore Date objects from ISO strings
+    return parsed.map(m => ({ ...m, timestamp: new Date(m.timestamp) }));
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Save chat history to localStorage for a given project.
+ * Only the most recent MAX_CHAT_MESSAGES messages are kept.
+ */
+export const saveChatHistory = (projectName: string, messages: ChatMessage[]): void => {
+  if (!projectName) return;
+  try {
+    const trimmed = messages.slice(-MAX_CHAT_MESSAGES);
+    localStorage.setItem(chatHistoryKey(projectName), JSON.stringify(trimmed));
+  } catch {
+    // localStorage full — silently drop oldest entries and retry
+    try {
+      const trimmed = messages.slice(-Math.floor(MAX_CHAT_MESSAGES / 2));
+      localStorage.setItem(chatHistoryKey(projectName), JSON.stringify(trimmed));
+    } catch {
+      // Give up — don't crash the app
+    }
+  }
+};
+
+/**
+ * Clear chat history for a given project
+ */
+export const clearChatHistory = (projectName: string): void => {
+  if (!projectName) return;
+  localStorage.removeItem(chatHistoryKey(projectName));
 };
 

--- a/gitnexus-web/src/hooks/useAppState.tsx
+++ b/gitnexus-web/src/hooks/useAppState.tsx
@@ -8,7 +8,7 @@ import type { IngestionWorkerApi } from '../workers/ingestion.worker';
 import type { FileEntry } from '../services/zip';
 import type { EmbeddingProgress, SemanticSearchResult } from '../core/embeddings/types';
 import type { LLMSettings, ProviderConfig, AgentStreamChunk, ChatMessage, ToolCallInfo, MessageStep } from '../core/llm/types';
-import { loadSettings, getActiveProviderConfig, saveSettings } from '../core/llm/settings-service';
+import { loadSettings, getActiveProviderConfig, saveSettings, loadChatHistory, saveChatHistory, clearChatHistory } from '../core/llm/settings-service';
 import type { AgentMessage } from '../core/llm/agent';
 import { DEFAULT_VISIBLE_EDGES, type EdgeType } from '../lib/constants';
 import type { RepoSummary, ConnectToServerResult } from '../services/server-connection';
@@ -295,10 +295,25 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   const [isAgentInitializing, setIsAgentInitializing] = useState(false);
   const [agentError, setAgentError] = useState<string | null>(null);
 
-  // Chat state
+  // Chat state — initialise from localStorage when projectName is known
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const [isChatLoading, setIsChatLoading] = useState(false);
   const [currentToolCalls, setCurrentToolCalls] = useState<ToolCallInfo[]>([]);
+
+  // Restore chat history when project name changes
+  useEffect(() => {
+    if (projectName) {
+      const saved = loadChatHistory(projectName);
+      if (saved.length > 0) setChatMessages(saved);
+    }
+  }, [projectName]);
+
+  // Persist chat history whenever messages change
+  useEffect(() => {
+    if (projectName && chatMessages.length > 0) {
+      saveChatHistory(projectName, chatMessages);
+    }
+  }, [projectName, chatMessages]);
 
   // Code References Panel state
   const [codeReferences, setCodeReferences] = useState<CodeReference[]>([]);
@@ -981,7 +996,8 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     setChatMessages([]);
     setCurrentToolCalls([]);
     setAgentError(null);
-  }, []);
+    if (projectName) clearChatHistory(projectName);
+  }, [projectName]);
 
   // Switch to a different repo on the connected server
   const switchRepo = useCallback(async (repoName: string) => {


### PR DESCRIPTION
## Summary

Persists NexusAI chat conversations to localStorage so they survive page refreshes. History is keyed by project name, ensuring each project maintains its own conversation context.

## Changes

### `settings-service.ts`
- Added `loadChatHistory(projectName)` ? reads and deserializes saved messages
- Added `saveChatHistory(projectName, messages)` ? persists up to 50 messages
- Added `clearChatHistory(projectName)` ? removes stored history

### `useAppState.tsx`
- Chat messages auto-restore when `projectName` is set (useEffect)
- Chat messages auto-save on every state change (useEffect)
- `clearChat()` now also clears persisted history

## Design Decisions

- **Keyed by project name** ? switching projects loads the correct history
- **50-message limit** ? prevents localStorage quota exhaustion
- **Graceful degradation** ? if localStorage is full, halves the limit and retries; never crashes
- **Date restoration** ? timestamps are serialized as ISO strings and restored as Date objects

## Testing

Manual verification: messages persist across page reload, clear button works, project switching loads correct history.

Closes #432
