### PR TITLE
fix(web): align QueryResult types with ladybugdb WASM API (#311)

### DIFF
--- a/gitnexus-web/src/types/lbug-wasm.d.ts
+++ b/gitnexus-web/src/types/lbug-wasm.d.ts
@@ -12,7 +12,10 @@ declare module '@ladybugdb/wasm-core' {
     close(): Promise<void>;
   }
   export interface QueryResult {
-    getAll(): Promise<any[]>;
+    /** @deprecated Use getAllRows() or getAllObjects() instead */
+    getAll?(): Promise<any[]>;
+    getAllRows?(): Promise<any[]>;
+    getAllObjects?(): Promise<any[]>;
     hasNext(): Promise<boolean>;
     getNext(): Promise<any>;
   }


### PR DESCRIPTION
## Summary

The `@ladybugdb/wasm-core` module replaced `.getAll()` with `.getAllRows()` and `.getAllObjects()`. The runtime adapter (`lbug-adapter.ts`) already handles this with a fallback chain, but the TypeScript type definition was outdated.

Closes #311

## Changes

### lbug-wasm.d.ts

```diff
  export interface QueryResult {
-   getAll(): Promise<any[]>;
+   /** @deprecated Use getAllRows() or getAllObjects() instead */
+   getAll?(): Promise<any[]>;
+   getAllRows?(): Promise<any[]>;
+   getAllObjects?(): Promise<any[]>;
    hasNext(): Promise<boolean>;
    getNext(): Promise<any>;
  }
```

All three methods are optional because the adapter's fallback chain handles any combination:
```typescript
result.getAll?.() ?? result.getAllObjects?.() ?? result.getAllRows?.()
```

## Type Check

```
npx tsc --noEmit -p tsconfig.app.json  # No errors
```

Addresses #311
