### PR TITLE
fix(community): improve heuristic cluster labeling (#413)

### DIFF
--- a/gitnexus/src/core/ingestion/community-processor.ts
+++ b/gitnexus/src/core/ingestion/community-processor.ts
@@ -367,8 +367,7 @@ const generateHeuristicLabel = (
   // Try dominant node type (e.g., "Functions" or "Classes")
   const typeCounts = new Map<string, number>();
   memberIds.forEach(nodeId => {
-    const labels = graph.getNodeAttribute(nodeId, 'labels');
-    const nodeType = Array.isArray(labels) ? labels[0] : (typeof labels === 'string' ? labels : '');
+    const nodeType = graph.getNodeAttribute(nodeId, 'type') ?? '';
     if (nodeType && nodeType !== 'Node') {
       typeCounts.set(nodeType, (typeCounts.get(nodeType) || 0) + 1);
     }
@@ -381,7 +380,7 @@ const generateHeuristicLabel = (
       dominantType = type;
     }
   });
-  // Use dominant type + most-connected symbol name
+  // Use dominant type + shortest symbol name
   if (dominantType && names.length > 0) {
     const sortedNames = [...names].sort((a, b) => a.length - b.length);
     const shortestName = sortedNames[0];


### PR DESCRIPTION
## Summary

Most clusters get generic `Cluster_N` names because the heuristic labeling only looks at the immediate parent directory and skips a short list of 7 common folder names. This PR improves labeling with three strategies.

Addresses #413

## Changes

### 1. Expanded generic folder skip list (7 → 28)

Added: `internal`, `pkg`, `app`, `modules`, `components`, `services`, `controllers`, `models`, `views`, `types`, `interfaces`, `test(s)`, `__tests__`, `spec(s)`, `dist`, `build`, `out`, `bin`, `scripts`

### 2. Grandparent directory fallback

For deeply nested structures like `src/auth/middleware/validate.ts`, the parent directory is `middleware` (generic). Now also considers `auth` (grandparent) as a candidate label, with 0.5 weight.

### 3. Dominant node type + symbol name

When no folder-based label works and no common name prefix exists, instead of `Cluster_7`:
- Check the dominant node type in the cluster (Function, Class, etc.)
- Combine with the shortest symbol name: `Function_validateUser`

### Labeling cascade

```
1. Most-common non-generic parent folder → "Auth"
2. Grandparent directory (0.5 weight) → "Auth"  
3. Common name prefix → "validate"
4. Dominant type + shortest name → "Function_validateUser"
5. Fallback → "Cluster_7"
```

## Tests

```
1900 passed | 1 skipped
npx tsc --noEmit  # No errors
```
