### PR TITLE
fix(mcp): expose per-repo resources in resources/list for clients without template support (#410)

### DIFF
--- a/gitnexus/src/mcp/resources.ts
+++ b/gitnexus/src/mcp/resources.ts
@@ -23,7 +23,7 @@ export interface ResourceTemplate {
 }
 
 /**
- * Static resources — includes per-repo resources and the global repos list
+ * Static resources — global resources not scoped to a specific repo
  */
 export function getResourceDefinitions(): ResourceDefinition[] {
   return [
@@ -40,6 +40,55 @@ export function getResourceDefinitions(): ResourceDefinition[] {
       mimeType: 'text/markdown',
     },
   ];
+}
+
+/**
+ * Dynamic per-repo resource definitions — expands templates into concrete URIs
+ * for all currently indexed repositories.
+ *
+ * MCP clients that only query resources/list (not resources/templates/list) rely
+ * on this to discover gitnexus://repo/{name}/context etc. without knowing repo
+ * names in advance.  See: https://github.com/abhigyanpatwari/GitNexus/issues/410
+ */
+export async function getDynamicResourceDefinitions(backend: LocalBackend): Promise<ResourceDefinition[]> {
+  let repos: Array<{ name: string }>;
+  try {
+    repos = await backend.listRepos();
+  } catch {
+    return [];
+  }
+
+  const definitions: ResourceDefinition[] = [];
+  for (const repo of repos) {
+    const name = encodeURIComponent(repo.name);
+    definitions.push(
+      {
+        uri: `gitnexus://repo/${name}/context`,
+        name: `${repo.name} — Overview`,
+        description: `Stats, staleness check, and available tools for ${repo.name}`,
+        mimeType: 'text/yaml',
+      },
+      {
+        uri: `gitnexus://repo/${name}/clusters`,
+        name: `${repo.name} — Modules`,
+        description: `All functional areas (Leiden clusters) for ${repo.name}`,
+        mimeType: 'text/yaml',
+      },
+      {
+        uri: `gitnexus://repo/${name}/processes`,
+        name: `${repo.name} — Processes`,
+        description: `All execution flows for ${repo.name}`,
+        mimeType: 'text/yaml',
+      },
+      {
+        uri: `gitnexus://repo/${name}/schema`,
+        name: `${repo.name} — Graph Schema`,
+        description: `Node/edge schema for Cypher queries against ${repo.name}`,
+        mimeType: 'text/yaml',
+      },
+    );
+  }
+  return definitions;
 }
 
 /**

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -26,7 +26,7 @@ import {
 import { GITNEXUS_TOOLS } from './tools.js';
 import { realStdoutWrite } from './core/lbug-adapter.js';
 import type { LocalBackend } from './local/local-backend.js';
-import { getResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
+import { getResourceDefinitions, getDynamicResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
 
 /**
  * Next-step hints appended to tool responses.
@@ -98,11 +98,15 @@ export function createMCPServer(backend: LocalBackend): Server {
     }
   );
 
-  // Handle list resources request
+  // Handle list resources request — returns both static global resources and
+  // concrete per-repo resources so MCP clients that don't support resource
+  // templates can still discover and read repo-scoped URIs.
+  // Fixes: https://github.com/abhigyanpatwari/GitNexus/issues/410
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    const resources = getResourceDefinitions();
+    const staticResources = getResourceDefinitions();
+    const dynamicResources = await getDynamicResourceDefinitions(backend);
     return {
-      resources: resources.map(r => ({
+      resources: [...staticResources, ...dynamicResources].map(r => ({
         uri: r.uri,
         name: r.name,
         description: r.description,


### PR DESCRIPTION
## Problem

Fixes #410

MCP clients that only query `resources/list` (not `resources/templates/list`) cannot discover repo-scoped resource URIs. The server currently returns only 2 static resources (`gitnexus://repos`, `gitnexus://setup`). All the per-repo URIs (`gitnexus://repo/{name}/context` etc.) are defined as _templates_, which many clients do not enumerate or resolve.

**Result**: Claude Code, opencode, and other clients report the server has no readable resources for any specific repo.

## Root Cause

`ListResourcesRequestSchema` handler only returns the static `getResourceDefinitions()` output. The MCP resource templates spec is client-opt-in — clients that don't poll `resources/templates/list` never learn about repo-scoped URIs.

## Fix

Added `getDynamicResourceDefinitions(backend)` in `resources.ts` that:
1. Calls `backend.listRepos()` to get all indexed repositories
2. Generates concrete `ResourceDefinition` entries for each repo: `/context`, `/clusters`, `/processes`, `/schema`
3. Silently returns `[]` if the registry is empty or unavailable

Updated the `ListResourcesRequestSchema` handler in `server.ts` to merge static + dynamic resources.

**Before** (resources/list response):
```
gitnexus://repos
gitnexus://setup
```

**After** (with HAYASHI_SHUNSUKE indexed):
```
gitnexus://repos
gitnexus://setup
gitnexus://repo/HAYASHI_SHUNSUKE/context
gitnexus://repo/HAYASHI_SHUNSUKE/clusters
gitnexus://repo/HAYASHI_SHUNSUKE/processes
gitnexus://repo/HAYASHI_SHUNSUKE/schema
```

## Testing

- All 1900 unit tests pass (`npm run test:unit`)
- `npm run build` (tsc) succeeds with no errors
- Manually verified: `resources/list` now returns per-repo URIs when a repo is indexed

## Notes

- Repo names with special characters are `encodeURIComponent`-encoded in the URI (the existing `parseUri` already uses `decodeURIComponent`)
- `getDynamicResourceDefinitions` is `async` and swallows backend errors (returns `[]`) so server startup is never blocked
- Resource templates are kept as-is — clients that do support templates still get the full template discovery