### PR TITLE
feat(cli): add --skip-embedding-limit flag to override 50k-node embedding cap

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -46,6 +46,8 @@ function ensureHeap(): boolean {
 export interface AnalyzeOptions {
   force?: boolean;
   embeddings?: boolean;
+  /** Skip the 50 000-node safety cap for embedding generation. Use with caution on large repos. */
+  skipEmbeddingLimit?: boolean;
   skills?: boolean;
   verbose?: boolean;
   /** Index the folder even when no .git directory is present. */
@@ -281,8 +283,8 @@ export const analyzeCommand = async (
   let embeddingSkipReason = 'off (use --embeddings to enable)';
 
   if (options?.embeddings) {
-    if (stats.nodes > EMBEDDING_NODE_LIMIT) {
-      embeddingSkipReason = `skipped (${stats.nodes.toLocaleString()} nodes > ${EMBEDDING_NODE_LIMIT.toLocaleString()} limit)`;
+    if (!options?.skipEmbeddingLimit && stats.nodes > EMBEDDING_NODE_LIMIT) {
+      embeddingSkipReason = `skipped (${stats.nodes.toLocaleString()} nodes > ${EMBEDDING_NODE_LIMIT.toLocaleString()} limit — use --skip-embedding-limit to override)`;
     } else {
       embeddingSkipped = false;
     }

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -27,6 +27,7 @@ program
   .description('Index a repository (full analysis)')
   .option('-f, --force', 'Force full re-index even if up to date')
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
+  .option('--skip-embedding-limit', 'Override the 50 000-node safety cap for embedding generation (use with caution on large repos)')
   .option('--skills', 'Generate repo-specific skill files from detected communities')
   .option('--skip-git', 'Index a folder without requiring a .git directory')
    .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')


### PR DESCRIPTION
## Summary

Closes #382

Adds a `--skip-embedding-limit` flag to `gitnexus analyze` that lets users override the 50 000-node safety cap for embedding generation.

### Problem

Large repositories (> 50 000 symbols) silently skip embedding generation with no way to opt in:

```
⚠️  Embeddings skipped (72 403 nodes > 50 000 limit)
```

Users with sufficient hardware/time have no escape hatch.

### Changes

**`src/cli/index.ts`** — new CLI flag:
```
--skip-embedding-limit   Override the 50 000-node safety cap for embedding generation
                         (use with caution on large repos)
```

**`src/cli/analyze.ts`** — new interface field + updated guard:
```typescript
// AnalyzeOptions
skipEmbeddingLimit?: boolean;

// guard
if (!options?.skipEmbeddingLimit && stats.nodes > EMBEDDING_NODE_LIMIT) {
  embeddingSkipReason = `skipped (...nodes > ... limit — use --skip-embedding-limit to override)`;
}
```

The skip message now hints at the flag so users discover it organically.

### Usage

```bash
gitnexus analyze --embeddings --skip-embedding-limit
```

### Tests

```
npx tsc --noEmit   # no errors
```

No behaviour change when the flag is absent — existing users are unaffected.