### PR TITLE
fix(swift): correct assignment query for tree-sitter-swift@0.6.0 (#386, #406)

### DIFF
--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -912,12 +912,21 @@ export const SWIFT_QUERIES = `
   (inheritance_specifier inherits_from: (user_type (type_identifier) @heritage.extends))) @heritage
 
 ; Write access: obj.field = value
+; tree-sitter-swift@0.6.0 changed the AST for field assignments:
+;   (assignment
+;     target: (directly_assignable_expression
+;       (navigation_expression
+;         target: (simple_identifier)
+;         suffix: (navigation_suffix suffix: (simple_identifier)))))
+; The old query matched navigation_suffix as a direct child of directly_assignable_expression,
+; but @0.6.0 nests it inside navigation_expression — causing TSQueryErrorStructure (#386, #406).
 (assignment
-  (directly_assignable_expression
-    (_) @assignment.receiver
-    (navigation_suffix
-      (simple_identifier) @assignment.property))
-  (_)) @assignment
+  target: (directly_assignable_expression
+    (navigation_expression
+      target: (_) @assignment.receiver
+      suffix: (navigation_suffix
+        suffix: (simple_identifier) @assignment.property)))
+) @assignment
 
 `;
 

--- a/gitnexus/test/fixtures/lang-resolution/swift-field-assignment/App.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-field-assignment/App.swift
@@ -1,0 +1,9 @@
+class App {
+    var user: User = User()
+
+    func run() {
+        user.name = "Alice"
+        user.age = 30
+        user.update(name: "Alice", age: 30)
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-field-assignment/User.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-field-assignment/User.swift
@@ -1,0 +1,9 @@
+class User {
+    var name: String = ""
+    var age: Int = 0
+
+    func update(name: String, age: Int) {
+        self.name = name
+        self.age = age
+    }
+}

--- a/gitnexus/test/integration/resolvers/swift.test.ts
+++ b/gitnexus/test/integration/resolvers/swift.test.ts
@@ -224,3 +224,46 @@ describe.skipIf(!swiftAvailable)('Swift return-type inference via function retur
     expect(saveCall).toBeDefined();
   });
 });
+
+// Regression test for Issue #386 / #406:
+// Swift assignment query (`obj.field = value`) failed with TSQueryErrorStructure
+// in tree-sitter-swift@0.6.0 because the old query matched navigation_suffix as a
+// direct child of directly_assignable_expression, but @0.6.0 nests it inside
+// navigation_expression. The fix uses named fields (target:/suffix:) to match
+// the actual AST structure, allowing Swift symbol extraction to succeed.
+describe.skipIf(!swiftAvailable)('Swift field assignment query — TSQueryErrorStructure regression (#386, #406)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'swift-field-assignment'),
+      () => {},
+    );
+  }, 60000);
+
+  it('extracts Swift symbols without TSQueryErrorStructure crash', () => {
+    // Before the fix: 0 nodes/edges because the broken assignment query caused
+    // ALL Swift extraction to fail. After the fix: User and App classes are found.
+    const nodes = getNodesByLabel(result, 'Class');
+    expect(nodes.length).toBeGreaterThan(0);
+  });
+
+  it('detects User and App classes', () => {
+    const classes = getNodesByLabel(result, 'Class');
+    const names = classes.map(c => c.name);
+    expect(names).toContain('User');
+    expect(names).toContain('App');
+  });
+
+  it('detects update method on User', () => {
+    const fns = getNodesByLabel(result, 'Function');
+    const update = fns.find(f => f.name === 'update');
+    expect(update).toBeDefined();
+  });
+
+  it('resolves user.update() CALLS edge from App.run to User.update', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const updateCall = calls.find(c => c.target === 'update');
+    expect(updateCall).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem

`tree-sitter-swift@0.6.0` changed the AST structure for field assignments, making the old Swift assignment query structurally invalid. This caused `TSQueryErrorStructure at position 2307` for **every** Swift file, silently blocking all symbol extraction (0 classes, 0 functions, 0 calls).

Reported in #386 and #406. Root cause identified by @marxo126 in #406.

## Root Cause

The old query in `SWIFT_QUERIES` matched `navigation_suffix` as a direct child of `directly_assignable_expression`:

```scheme
; OLD — invalid for tree-sitter-swift@0.6.0
(assignment
  (directly_assignable_expression
    (_) @assignment.receiver
    (navigation_suffix
      (simple_identifier) @assignment.property))
  (_)) @assignment
```

But `@0.6.0` wraps it inside `navigation_expression`:

```
(assignment
  target: (directly_assignable_expression
    (navigation_expression
      target: (simple_identifier)
      suffix: (navigation_suffix
        suffix: (simple_identifier)))))
```

## Fix

Rewrite the query using the correct `@0.6.0` field names and nesting:

```scheme
; NEW — matches tree-sitter-swift@0.6.0 AST
(assignment
  target: (directly_assignable_expression
    (navigation_expression
      target: (_) @assignment.receiver
      suffix: (navigation_suffix
        suffix: (simple_identifier) @assignment.property)))
) @assignment
```

## Tests

Added `test/fixtures/lang-resolution/swift-field-assignment/` with `User.swift` and `App.swift` containing field assignments. Four new `skipIf(!swiftAvailable)` test cases verify:

- Swift symbols are extracted without crash (regression guard for #386/#406)
- `User` and `App` classes are detected
- `update()` method is detected
- `user.update()` CALLS edge is resolved from `App.run`

Closes #386
Closes #406