### PR TITLE
fix(web): resolve Vercel build errors from security hardening PR

### DIFF
--- a/gitnexus-web/src/components/ProcessFlowModal.tsx
+++ b/gitnexus-web/src/components/ProcessFlowModal.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useEffect, useRef, useCallback, useState } from 'react';
-import { X, GitBranch, Copy, Focus, Layers, ZoomIn, ZoomOut } from '@/lib/lucide-icons';
+import { X, GitBranch, Copy, Focus, Layers, ZoomIn, ZoomOut } from 'lucide-react';
 import mermaid from 'mermaid';
 import DOMPurify from 'dompurify';
 import { ProcessData, generateProcessMermaid } from '../lib/mermaid-generator';

--- a/gitnexus-web/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus-web/src/core/embeddings/embedding-pipeline.ts
@@ -124,7 +124,7 @@ const createVectorIndex = async (
   `;
 
   try {
-    await executeQuery(cypher, false); // readOnly=false: CALL CREATE_VECTOR_INDEX is a write operation
+    await executeQuery(cypher);
   } catch (error) {
     // Index might already exist
     if (import.meta.env.DEV) {


### PR DESCRIPTION
## Summary
- **ProcessFlowModal.tsx**: PR #475 changed the `lucide-react` import to `@/lib/lucide-icons`, but that module doesn't exist. Reverted to `lucide-react` (consistent with all other components).
- **embedding-pipeline.ts**: PR #475 added a second argument `false` to `executeQuery(cypher, false)`, but the function signature only accepts 1 argument `(cypher: string) => Promise<any[]>`. Removed the extra argument.

Both issues were introduced in #475 (web-security-hardening) and break the Vercel build.

## Test plan
- [x] `npx tsc --noEmit` passes clean in gitnexus-web
- [ ] Verify Vercel deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)