### PR TITLE
fix(ui): use actual repository name instead of top-level folder for GitHub clones

### DIFF
--- a/gitnexus-web/src/App.tsx
+++ b/gitnexus-web/src/App.tsx
@@ -85,9 +85,12 @@ const AppContent = () => {
     }
   }, [setViewMode, setGraph, setFileContents, setProgress, setProjectName, runPipeline, startEmbeddingsWithFallback, initializeAgent]);
 
-  const handleGitClone = useCallback(async (files: FileEntry[]) => {
-    const firstPath = files[0]?.path || 'repository';
-    const projectName = firstPath.split('/')[0].replace(/-\d+$/, '') || 'repository';
+  const handleGitClone = useCallback(async (files: FileEntry[], repoName?: string) => {
+    let projectName = repoName;
+    if (!projectName) {
+      const firstPath = files[0]?.path || 'repository';
+      projectName = firstPath.split('/')[0].replace(/-\d+$/, '') || 'repository';
+    }
 
     setProjectName(projectName);
     setProgress({ phase: 'extracting', percent: 0, message: 'Starting...', detail: 'Preparing to process files' });
@@ -125,7 +128,8 @@ const AppContent = () => {
   const handleServerConnect = useCallback((result: ConnectToServerResult): Promise<void> => {
     // Extract project name from repoPath
     const repoPath = result.repoInfo.repoPath;
-    const projectName = repoPath.split('/').pop() || 'server-project';
+    const parts = repoPath.split('/').filter(p => p && !p.startsWith('.'));
+    const projectName = parts[parts.length - 1] || parts[0] || 'server-project';
     setProjectName(projectName);
 
     // Build KnowledgeGraph from server data for visualization

--- a/gitnexus-web/src/components/DropZone.tsx
+++ b/gitnexus-web/src/components/DropZone.tsx
@@ -6,7 +6,7 @@ import { FileEntry } from '../services/zip';
 
 interface DropZoneProps {
   onFileSelect: (file: File) => void;
-  onGitClone?: (files: FileEntry[]) => void;
+  onGitClone?: (files: FileEntry[], repoName?: string) => void;
   onServerConnect?: (result: ConnectToServerResult, serverUrl?: string) => void;
 }
 
@@ -108,7 +108,7 @@ export const DropZone = ({ onFileSelect, onGitClone, onServerConnect }: DropZone
       setGithubToken('');
 
       if (onGitClone) {
-        onGitClone(files);
+        onGitClone(files, parsed.repo);
       }
     } catch (err) {
       console.error('Clone failed:', err);

--- a/gitnexus-web/src/hooks/useAppState.tsx
+++ b/gitnexus-web/src/hooks/useAppState.tsx
@@ -971,7 +971,7 @@ const AppStateProviderInner = ({ children }: { children: ReactNode }) => {
 
           case 'done':
             // Finalize the assistant message - just call updateMessage one more time
-          scheduleMessageUpdate();
+            scheduleMessageUpdate();
             break;
         }
       });
@@ -1036,7 +1036,7 @@ const AppStateProviderInner = ({ children }: { children: ReactNode }) => {
 
       // Reuse the same handleServerConnect logic inline
       const repoPath = result.repoInfo.repoPath;
-      const pName = result.repoInfo.name || repoPath.split('/').pop() || 'server-project';
+      const pName = repoName || result.repoInfo.name || repoPath.split('/').pop() || 'server-project';
       setProjectName(pName);
 
       const graph = createKnowledgeGraph();


### PR DESCRIPTION
Fixes a bug where cloning a repository from a GitHub URL incorrectly named the project `.claude` (or whichever folder appeared first alphabetically in the downloaded files). 

We now extract the correct repository name directly from the parsed GitHub URL instead of attempting to derive it from the sorted file paths.
