### PR TITLE
docs: add Dart to supported languages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ GitNexus builds a complete knowledge graph of your codebase through a multi-phas
 | Swift | — | — | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | C | — | — | ✓ | — | ✓ | ✓ | — | ✓ | ✓ |
 | C++ | — | — | ✓ | ✓ | ✓ | ✓ | — | ✓ | ✓ |
+| Dart | ✓ | — | ✓ | ✓ | ✓ | ✓ | — | ✓ | ✓ |
 
 **Imports** — cross-file import resolution · **Named Bindings** — `import { X as Y }` / re-export tracking · **Exports** — public/exported symbol detection · **Heritage** — class inheritance, interfaces, mixins · **Type Annotations** — explicit type extraction for receiver resolution · **Constructor Inference** — infer receiver type from constructor calls (`self`/`this` resolution included for all languages) · **Config** — language toolchain config parsing (tsconfig, go.mod, etc.) · **Frameworks** — AST-based framework pattern detection · **Entry Points** — entry point scoring heuristics
 
@@ -539,7 +540,7 @@ The wiki generator reads the indexed graph structure, groups files into modules 
 - [X] Constructor-Inferred Type Resolution, `self`/`this` Receiver Mapping
 - [X] Wiki Generation, Multi-File Rename, Git-Diff Impact Analysis
 - [X] Process-Grouped Search, 360-Degree Context, Claude Code Hooks
-- [X] Multi-Repo MCP, Zero-Config Setup, 13 Language Support
+- [X] Multi-Repo MCP, Zero-Config Setup, 14 Language Support
 - [X] Community Detection, Process Detection, Confidence Scoring
 - [X] Hybrid Search, Vector Index
 


### PR DESCRIPTION
## Summary

- Add Dart row to the supported languages table — was missing after PR #204 merged Dart as the 14th language
- Update language count from 13 → 14 in the roadmap section

Dart capabilities verified against the codebase:

| Feature | Status | Evidence |
|---|---|---|
| Imports | ✓ | `import-resolvers/dart.ts` — package:, dart:, relative |
| Named Bindings | — | `importSemantics: 'wildcard'` |
| Exports | ✓ | `dartExportChecker` — underscore = private |
| Heritage | ✓ | extends, implements, with queries |
| Type Annotations | ✓ | `extractDartDeclaration`, `extractDartParameter` |
| Constructor Inference | ✓ | `extractDartInitializer`, `detectDartConstructorType` |
| Config | — | No pubspec.yaml parsing |
| Frameworks | ✓ | Flutter path-based + AST-based detection |
| Entry Points | ✓ | Via framework detection (`main.dart` → 3.0× multiplier) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)