### PR TITLE
feat: data-shape tracking — Phase 1: StateSlot nodes and data_flow tool

### DIFF
--- a/docs/superpowers/plans/2026-03-26-data-shape-tracking.md
+++ b/docs/superpowers/plans/2026-03-26-data-shape-tracking.md
@@ -1,0 +1,1911 @@
+# Data-Shape Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add end-to-end data-flow shape tracking to GitNexus so it can detect mismatches where multiple consumers share a cache key, context, or state slot but expect different data shapes.
+
+**Architecture:** New `StateSlot` node type with `PRODUCES`/`CONSUMES` edges carrying shape info on the edge. Detection via tree-sitter AST extraction in the parse worker, plus a new pipeline phase (3.7) that creates graph nodes. New `data_flow` MCP tool and extensions to existing `shape_check`/`api_impact`/`impact`/`context` tools.
+
+**Tech Stack:** TypeScript, tree-sitter (AST), LadybugDB (graph DB), vitest (tests), MCP protocol
+
+**Spec:** `docs/superpowers/specs/2026-03-26-data-shape-tracking-design.md`
+
+**Worktree:** `/private/tmp/gitnexus-data-shape-tracking` (branch `feat/data-shape-tracking`)
+
+---
+
+## File Structure
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `src/core/ingestion/state-slot-detectors/types.ts` | `ExtractedStateSlot` interface and `SlotKind` type |
+| `src/core/ingestion/state-slot-detectors/react-query.ts` | React Query / TanStack Query detector |
+| `src/core/ingestion/state-slot-detectors/swr.ts` | SWR detector |
+| `src/core/ingestion/state-slot-detectors/react-context.ts` | React Context detector (Phase 3) |
+| `src/core/ingestion/state-slot-detectors/redux.ts` | Redux createSlice detector (Phase 3) |
+| `src/core/ingestion/state-slot-detectors/zustand.ts` | Zustand store detector (Phase 3) |
+| `src/core/ingestion/state-slot-detectors/index.ts` | Barrel export + `detectStateSlots()` orchestrator |
+| `src/core/ingestion/state-slot-processor.ts` | Pipeline phase 3.7: create StateSlot nodes + PRODUCES/CONSUMES edges |
+| `src/core/ingestion/shape-inference.ts` | AST-based shape inference (object literals, destructuring, property access) |
+| `test/fixtures/state-slot-seed.ts` | Cypher seed data for data_flow E2E tests |
+| `test/fixtures/state-slot-fixtures/` | Mini TS/JS files for pipeline-level state slot tests |
+| `test/integration/data-flow-e2e.test.ts` | E2E test for data_flow MCP tool |
+| `test/unit/state-slot-detectors.test.ts` | Unit tests for each detector |
+| `test/unit/shape-inference.test.ts` | Unit tests for shape inference |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `src/core/graph/types.ts` | Add `StateSlot` to `NodeLabel`, add `slotKind`/`cacheKey` to `NodeProperties`, add `PRODUCES`/`CONSUMES` to `RelationshipType` |
+| `src/core/lbug/schema.ts` | Add `STATE_SLOT_SCHEMA`, update `NODE_TABLES`, `REL_TYPES`, `RELATION_SCHEMA`, `NODE_SCHEMA_QUERIES` |
+| `src/core/lbug/csv-generator.ts` | Add `stateSlotWriter` and `case 'StateSlot'` |
+| `src/core/ingestion/tree-sitter-queries.ts` | Add `datahook.*` capture queries to TS and JS query strings |
+| `src/core/ingestion/workers/parse-worker.ts` | Add `ExtractedDataHook` interface, `datahook` dispatch, accumulate in `ParseWorkerResult` |
+| `src/core/ingestion/pipeline.ts` | Add Phase 3.7 (state slot detection), accumulate `allDataHooks`, call `processStateSlots()` |
+| `src/mcp/tools.ts` | Add `data_flow` tool definition |
+| `src/mcp/local/local-backend.ts` | Add `dataFlow()` method, `case 'data_flow'` in `callTool()`, extend `shapeCheck()`/`apiImpact()`/`_impactImpl()`/`context()` |
+| `src/mcp/server.ts` | Add next-step hint for `data_flow` |
+
+---
+
+## Phase 1: Foundation (React Query + SWR + Core Infrastructure)
+
+### Task 1: Add StateSlot to Graph Types
+
+**Files:**
+- Modify: `gitnexus/src/core/graph/types.ts:1-121`
+
+- [ ] **Step 1: Add StateSlot to NodeLabel union**
+
+In `types.ts`, add `'StateSlot'` after `'Tool'` in the `NodeLabel` union (line 38):
+
+```typescript
+  | 'Tool'
+  | 'StateSlot';   // Shared state: React Query cache, Context, Redux slice, etc.
+```
+
+- [ ] **Step 2: Add StateSlot-specific properties to NodeProperties**
+
+After the Route-specific properties (around line 79), add:
+
+```typescript
+  // StateSlot-specific
+  slotKind?: string;       // react-query | swr | react-context | redux | zustand | trpc | graphql | custom-hook
+  cacheKey?: string;        // Literal or pattern of cache/state key
+```
+
+- [ ] **Step 3: Add PRODUCES and CONSUMES to RelationshipType**
+
+After `'WRAPS'` in the `RelationshipType` union (line 101):
+
+```typescript
+  | 'WRAPS'           // Reserved, not yet emitted
+  | 'PRODUCES'        // Function/Method -> StateSlot (writes data into shared state)
+  | 'CONSUMES';       // Function/Method -> StateSlot (reads data from shared state)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gitnexus/src/core/graph/types.ts
+git commit -m "feat(types): add StateSlot node label and PRODUCES/CONSUMES relationship types"
+```
+
+---
+
+### Task 2: Add StateSlot to LadybugDB Schema
+
+**Files:**
+- Modify: `gitnexus/src/core/lbug/schema.ts:15-518`
+
+- [ ] **Step 1: Add 'StateSlot' to NODE_TABLES array**
+
+After `'Tool'` in `NODE_TABLES` (line 21):
+
+```typescript
+  'Route',
+  'Tool',
+  'StateSlot'
+] as const;
+```
+
+- [ ] **Step 2: Add 'PRODUCES' and 'CONSUMES' to REL_TYPES**
+
+After `'WRAPS'` in `REL_TYPES` (line 32):
+
+```typescript
+export const REL_TYPES = ['CONTAINS', 'DEFINES', 'IMPORTS', 'CALLS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'HAS_PROPERTY', 'ACCESSES', 'OVERRIDES', 'MEMBER_OF', 'STEP_IN_PROCESS', 'HANDLES_ROUTE', 'FETCHES', 'HANDLES_TOOL', 'ENTRY_POINT_OF', 'WRAPS', 'PRODUCES', 'CONSUMES'] as const;
+```
+
+- [ ] **Step 3: Add STATE_SLOT_SCHEMA constant**
+
+After `TOOL_SCHEMA` (line 218):
+
+```typescript
+// Shared state slots (React Query cache, Context, Redux slice, etc.)
+export const STATE_SLOT_SCHEMA = `
+CREATE NODE TABLE StateSlot (
+  id STRING,
+  name STRING,
+  filePath STRING,
+  slotKind STRING,
+  cacheKey STRING,
+  PRIMARY KEY (id)
+)`;
+```
+
+- [ ] **Step 4: Add StateSlot FROM/TO entries to RELATION_SCHEMA**
+
+After the Tool FROM/TO entries (line 338), add:
+
+```typescript
+  FROM Function TO StateSlot,
+  FROM Method TO StateSlot,
+  FROM File TO StateSlot,
+  FROM StateSlot TO Process,
+```
+
+- [ ] **Step 5: Add STATE_SLOT_SCHEMA to NODE_SCHEMA_QUERIES**
+
+After `TOOL_SCHEMA` in the array (line 513):
+
+```typescript
+  // MCP tools
+  TOOL_SCHEMA,
+  // Shared state slots
+  STATE_SLOT_SCHEMA,
+];
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gitnexus/src/core/lbug/schema.ts
+git commit -m "feat(schema): add StateSlot node table and PRODUCES/CONSUMES to LadybugDB schema"
+```
+
+---
+
+### Task 3: Add StateSlot to CSV Generator
+
+**Files:**
+- Modify: `gitnexus/src/core/lbug/csv-generator.ts:245-443`
+
+- [ ] **Step 1: Add stateSlotWriter creation**
+
+After `toolWriter` creation (around line 247):
+
+```typescript
+const stateSlotWriter = new BufferedCSVWriter(path.join(csvDir, 'stateslot.csv'), 'id,name,filePath,slotKind,cacheKey');
+```
+
+- [ ] **Step 2: Add case 'StateSlot' in the switch block**
+
+After the `case 'Tool':` block (around line 376):
+
+```typescript
+case 'StateSlot':
+  await stateSlotWriter.addRow([
+    escapeCSVField(node.id),
+    escapeCSVField(node.properties.name || ''),
+    escapeCSVField(node.properties.filePath || ''),
+    escapeCSVField((node.properties as any).slotKind || ''),
+    escapeCSVField((node.properties as any).cacheKey || ''),
+  ].join(','));
+  break;
+```
+
+- [ ] **Step 3: Add stateSlotWriter to allWriters and tableMap**
+
+Add to `allWriters` array (around line 414):
+
+```typescript
+stateSlotWriter,
+```
+
+Add to `tableMap` result entries (around line 442):
+
+```typescript
+['StateSlot' as NodeTableName, stateSlotWriter],
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gitnexus/src/core/lbug/csv-generator.ts
+git commit -m "feat(csv): add StateSlot CSV generation for LadybugDB bulk import"
+```
+
+---
+
+### Task 4: Create Detector Types
+
+**Files:**
+- Create: `gitnexus/src/core/ingestion/state-slot-detectors/types.ts`
+
+- [ ] **Step 1: Write the ExtractedStateSlot interface**
+
+```typescript
+/**
+ * Shared types for state slot detection across frameworks.
+ */
+
+export type SlotKind = 'react-query' | 'swr' | 'react-context' | 'redux' | 'zustand' | 'trpc' | 'graphql' | 'custom-hook';
+
+export type ShapeConfidence = 'type-checked' | 'ast-literal' | 'heuristic';
+
+export interface ExtractedStateSlotProducer {
+  /** Function/method name that produces data into this slot */
+  functionName: string;
+  /** File where the producer lives */
+  filePath: string;
+  /** Line number of the producing call */
+  lineNumber: number;
+  /** Top-level keys this producer writes */
+  keys: string[];
+  /** Confidence tier */
+  confidence: ShapeConfidence;
+  /** Raw TS type annotation if available (e.g. 'VendorPattern[]') */
+  sourceType?: string;
+}
+
+export interface ExtractedStateSlotConsumer {
+  /** Function/method name that consumes data from this slot */
+  functionName: string;
+  /** File where the consumer lives */
+  filePath: string;
+  /** Line number of the consuming call */
+  lineNumber: number;
+  /** Properties this consumer accesses */
+  accessedKeys: string[];
+  /** Confidence tier */
+  confidence: ShapeConfidence;
+}
+
+export interface ExtractedStateSlot {
+  /** Human-readable identifier (e.g. "['vendor-patterns', slug]") */
+  name: string;
+  /** Framework that manages this state */
+  slotKind: SlotKind;
+  /** Literal or pattern of the cache/state key */
+  cacheKey: string;
+  /** File where the slot is first defined/configured */
+  filePath: string;
+  /** Line number of the slot definition */
+  lineNumber: number;
+  /** Functions that write data into this slot */
+  producers: ExtractedStateSlotProducer[];
+  /** Functions that read data from this slot */
+  consumers: ExtractedStateSlotConsumer[];
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add gitnexus/src/core/ingestion/state-slot-detectors/types.ts
+git commit -m "feat(types): add ExtractedStateSlot interface for state slot detection"
+```
+
+---
+
+### Task 5: Write Shape Inference Module
+
+**Files:**
+- Create: `gitnexus/src/core/ingestion/shape-inference.ts`
+- Create: `gitnexus/test/unit/shape-inference.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  extractObjectLiteralKeys,
+  extractDestructuredKeys,
+  extractPropertyAccessKeys,
+  cacheKeyPrefix,
+  cacheKeysOverlap,
+} from '../../src/core/ingestion/shape-inference.js';
+
+describe('shape-inference', () => {
+  describe('extractObjectLiteralKeys', () => {
+    it('extracts top-level keys from JSON return', () => {
+      const code = `return Response.json({ patterns, total, page })`;
+      expect(extractObjectLiteralKeys(code)).toEqual(['patterns', 'total', 'page']);
+    });
+
+    it('extracts keys from NextResponse.json', () => {
+      const code = `return NextResponse.json({ data: items, pagination: { page, limit } })`;
+      expect(extractObjectLiteralKeys(code)).toEqual(['data', 'pagination']);
+    });
+
+    it('returns empty for no object literal', () => {
+      expect(extractObjectLiteralKeys(`return data`)).toEqual([]);
+    });
+  });
+
+  describe('extractDestructuredKeys', () => {
+    it('extracts destructured keys from data variable', () => {
+      const code = `const { patterns, total } = data;`;
+      expect(extractDestructuredKeys(code)).toEqual(['patterns', 'total']);
+    });
+
+    it('extracts from response.json() destructuring', () => {
+      const code = `const { items, count } = await res.json();`;
+      expect(extractDestructuredKeys(code)).toEqual(['items', 'count']);
+    });
+
+    it('extracts from nested destructuring (top level only)', () => {
+      const code = `const { data: { items }, total } = response;`;
+      expect(extractDestructuredKeys(code)).toContain('total');
+    });
+  });
+
+  describe('extractPropertyAccessKeys', () => {
+    it('extracts dot-access keys on data variable', () => {
+      const code = `console.log(data.patterns);\nconst x = data.total;`;
+      expect(extractPropertyAccessKeys(code)).toEqual(expect.arrayContaining(['patterns', 'total']));
+    });
+
+    it('extracts optional chaining keys', () => {
+      const code = `data?.items?.length`;
+      expect(extractPropertyAccessKeys(code)).toContain('items');
+    });
+
+    it('filters out method-like accesses', () => {
+      const keys = extractPropertyAccessKeys(`data.toString(); data.length; data.items`);
+      expect(keys).not.toContain('toString');
+      expect(keys).not.toContain('length');
+      expect(keys).toContain('items');
+    });
+  });
+
+  describe('cacheKeyPrefix', () => {
+    it('extracts static prefix from array key', () => {
+      expect(cacheKeyPrefix(`['vendor-patterns', slug]`)).toBe('vendor-patterns');
+    });
+
+    it('extracts prefix from single-string key', () => {
+      expect(cacheKeyPrefix(`'vendor-patterns'`)).toBe('vendor-patterns');
+    });
+
+    it('extracts prefix from template literal', () => {
+      expect(cacheKeyPrefix('`/api/vendors/${id}`')).toBe('/api/vendors/');
+    });
+  });
+
+  describe('cacheKeysOverlap', () => {
+    it('detects exact match', () => {
+      expect(cacheKeysOverlap(`['vendor-patterns', slug]`, `['vendor-patterns', slug]`)).toBe(true);
+    });
+
+    it('detects prefix match with different dynamic parts', () => {
+      expect(cacheKeysOverlap(`['vendor-patterns', slug]`, `['vendor-patterns', id]`)).toBe(true);
+    });
+
+    it('rejects different prefixes', () => {
+      expect(cacheKeysOverlap(`['vendor-patterns']`, `['grants']`)).toBe(false);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /private/tmp/gitnexus-data-shape-tracking/gitnexus && npx vitest run test/unit/shape-inference.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+/**
+ * AST-based shape inference utilities.
+ *
+ * Extracts data shape information from source code using regex patterns
+ * (not tree-sitter — these run on raw text for flexibility across contexts).
+ */
+
+/** Keys that are method-like and should be filtered from property access results */
+const ACCESS_BLOCKLIST = new Set([
+  'length', 'toString', 'valueOf', 'hasOwnProperty', 'constructor',
+  'push', 'pop', 'shift', 'unshift', 'slice', 'splice', 'map', 'filter',
+  'reduce', 'forEach', 'find', 'findIndex', 'includes', 'indexOf',
+  'keys', 'values', 'entries', 'then', 'catch', 'finally',
+  'json', 'text', 'blob', 'arrayBuffer', 'formData', 'clone', 'ok', 'status',
+]);
+
+/**
+ * Extract top-level keys from object literals in .json() or return statements.
+ * Uses brace-depth counting (same approach as response-shapes.ts).
+ */
+export function extractObjectLiteralKeys(code: string): string[] {
+  const keys: string[] = [];
+  // Find .json({ ... }) or return { ... }
+  const jsonPattern = /\.json\s*\(\s*\{|return\s+\{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = jsonPattern.exec(code)) !== null) {
+    const braceStart = code.indexOf('{', match.index);
+    if (braceStart === -1) continue;
+
+    let depth = 0;
+    let keyStart = -1;
+    for (let i = braceStart; i < code.length; i++) {
+      const ch = code[i];
+      if (ch === '{') {
+        depth++;
+        if (depth === 1) keyStart = i + 1;
+      } else if (ch === '}') {
+        depth--;
+        if (depth === 0) break;
+      } else if (depth === 1 && ch === ':') {
+        // Extract key before the colon
+        const beforeColon = code.slice(keyStart, i).trim();
+        // Handle quoted keys and identifier keys
+        const keyMatch = beforeColon.match(/(?:['"]([^'"]+)['"]|(\w+))\s*$/);
+        if (keyMatch) {
+          keys.push(keyMatch[1] || keyMatch[2]);
+        }
+      } else if (depth === 1 && (ch === ',' || ch === '}')) {
+        // Shorthand property: { patterns, total }
+        const segment = code.slice(keyStart, i).trim();
+        if (segment && /^\w+$/.test(segment)) {
+          keys.push(segment);
+        }
+        keyStart = i + 1;
+      }
+    }
+  }
+
+  return [...new Set(keys)];
+}
+
+/**
+ * Extract destructured keys from variable declarations.
+ * Matches: const { key1, key2 } = data/response/result/res.json()
+ */
+export function extractDestructuredKeys(code: string): string[] {
+  const keys: string[] = [];
+  const pattern = /const\s+\{\s*([^}]+)\}\s*=\s*/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(code)) !== null) {
+    const inner = match[1];
+    // Split by commas, extract the key name (before any colon for renaming)
+    for (const part of inner.split(',')) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      // Handle: key, key: alias, key: { nested }, ...rest
+      const keyMatch = trimmed.match(/^(\w+)/);
+      if (keyMatch && keyMatch[1] !== 'rest') {
+        keys.push(keyMatch[1]);
+      }
+    }
+  }
+
+  return [...new Set(keys)];
+}
+
+/**
+ * Extract property access keys from dot-access and optional chaining patterns.
+ * Matches: data.key, response?.key, result.key
+ */
+export function extractPropertyAccessKeys(code: string): string[] {
+  const keys: string[] = [];
+  const dataVarNames = /(?:data|response|result|res|json|payload|body|state|value)/;
+  const pattern = new RegExp(
+    `(?:${dataVarNames.source})\\??\\.([a-zA-Z_]\\w*)`,
+    'g',
+  );
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(code)) !== null) {
+    const key = match[1];
+    if (!ACCESS_BLOCKLIST.has(key)) {
+      keys.push(key);
+    }
+  }
+
+  return [...new Set(keys)];
+}
+
+/**
+ * Extract static prefix from a cache key expression.
+ * Examples:
+ *   "['vendor-patterns', slug]" → "vendor-patterns"
+ *   "'vendor-patterns'" → "vendor-patterns"
+ *   "`/api/vendors/${id}`" → "/api/vendors/"
+ */
+export function cacheKeyPrefix(cacheKey: string): string {
+  // Array format: ['prefix', ...]
+  const arrayMatch = cacheKey.match(/\[\s*['"]([^'"]+)['"]/);
+  if (arrayMatch) return arrayMatch[1];
+
+  // Single string: 'prefix'
+  const stringMatch = cacheKey.match(/^['"]([^'"]+)['"]/);
+  if (stringMatch) return stringMatch[1];
+
+  // Template literal: `/api/path/${var}`
+  const templateMatch = cacheKey.match(/^`([^$`]+)/);
+  if (templateMatch) return templateMatch[1];
+
+  return cacheKey;
+}
+
+/**
+ * Check if two cache keys potentially overlap (could point to same slot).
+ * Uses prefix matching — if static prefixes match, keys might collide.
+ */
+export function cacheKeysOverlap(key1: string, key2: string): boolean {
+  const prefix1 = cacheKeyPrefix(key1);
+  const prefix2 = cacheKeyPrefix(key2);
+  return prefix1 === prefix2 && prefix1.length > 0;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /private/tmp/gitnexus-data-shape-tracking/gitnexus && npx vitest run test/unit/shape-inference.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gitnexus/src/core/ingestion/shape-inference.ts gitnexus/test/unit/shape-inference.test.ts
+git commit -m "feat: add shape inference utilities for object literals, destructuring, and cache key matching"
+```
+
+---
+
+### Task 6: Write React Query Detector
+
+**Files:**
+- Create: `gitnexus/src/core/ingestion/state-slot-detectors/react-query.ts`
+- Create: `gitnexus/test/unit/state-slot-detectors.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { detectReactQuerySlots } from '../../src/core/ingestion/state-slot-detectors/react-query.js';
+
+describe('detectReactQuerySlots', () => {
+  it('detects useQuery with array queryKey', () => {
+    const code = `
+      export function useVendorPatterns(slug) {
+        return useQuery({
+          queryKey: ['vendor-patterns', slug],
+          queryFn: () => fetch('/api/vendors').then(r => r.json()),
+        });
+      }
+    `;
+    const slots = detectReactQuerySlots(code, 'hooks/useVendorPatterns.ts');
+    expect(slots).toHaveLength(1);
+    expect(slots[0].slotKind).toBe('react-query');
+    expect(slots[0].cacheKey).toContain('vendor-patterns');
+    expect(slots[0].producers).toHaveLength(1);
+    expect(slots[0].producers[0].filePath).toBe('hooks/useVendorPatterns.ts');
+  });
+
+  it('detects multiple useQuery calls in same file', () => {
+    const code = `
+      export function usePatterns(slug) {
+        return useQuery({ queryKey: ['vendor-patterns', slug], queryFn: fetchPatterns });
+      }
+      export function usePatternCount(slug) {
+        return useQuery({ queryKey: ['vendor-patterns', slug], queryFn: fetchCount });
+      }
+    `;
+    const slots = detectReactQuerySlots(code, 'hooks/vendors.ts');
+    expect(slots).toHaveLength(2);
+    // Both share same cache key prefix
+    expect(slots[0].cacheKey).toContain('vendor-patterns');
+    expect(slots[1].cacheKey).toContain('vendor-patterns');
+  });
+
+  it('detects useMutation', () => {
+    const code = `
+      const mutation = useMutation({
+        mutationKey: ['update-vendor'],
+        mutationFn: (data) => fetch('/api/vendors', { method: 'POST', body: JSON.stringify(data) }),
+      });
+    `;
+    const slots = detectReactQuerySlots(code, 'hooks/useUpdateVendor.ts');
+    expect(slots).toHaveLength(1);
+    expect(slots[0].cacheKey).toContain('update-vendor');
+  });
+
+  it('detects useInfiniteQuery', () => {
+    const code = `
+      useInfiniteQuery({
+        queryKey: ['vendors-list'],
+        queryFn: ({ pageParam }) => fetchVendors(pageParam),
+      });
+    `;
+    const slots = detectReactQuerySlots(code, 'hooks/useVendors.ts');
+    expect(slots).toHaveLength(1);
+  });
+
+  it('detects useSuspenseQuery', () => {
+    const code = `
+      useSuspenseQuery({
+        queryKey: ['vendor-detail', id],
+        queryFn: () => fetchVendor(id),
+      });
+    `;
+    const slots = detectReactQuerySlots(code, 'hooks/useVendor.ts');
+    expect(slots).toHaveLength(1);
+  });
+
+  it('returns empty for files without React Query hooks', () => {
+    const code = `export function add(a, b) { return a + b; }`;
+    expect(detectReactQuerySlots(code, 'utils/math.ts')).toEqual([]);
+  });
+
+  it('extracts consumer accessed keys from destructuring', () => {
+    const code = `
+      export function useVendors() {
+        const { data } = useQuery({
+          queryKey: ['vendors'],
+          queryFn: fetchVendors,
+        });
+        const items = data?.patterns;
+        const count = data?.total;
+        return { items, count };
+      }
+    `;
+    const slots = detectReactQuerySlots(code, 'hooks/useVendors.ts');
+    expect(slots).toHaveLength(1);
+    expect(slots[0].consumers).toHaveLength(1);
+    expect(slots[0].consumers[0].accessedKeys).toEqual(
+      expect.arrayContaining(['patterns', 'total']),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /private/tmp/gitnexus-data-shape-tracking/gitnexus && npx vitest run test/unit/state-slot-detectors.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+/**
+ * React Query / TanStack Query state slot detector.
+ *
+ * Detects useQuery, useMutation, useInfiniteQuery, useSuspenseQuery calls
+ * and extracts cache keys, producer shapes, and consumer access patterns.
+ */
+
+import type { ExtractedStateSlot, ExtractedStateSlotProducer, ExtractedStateSlotConsumer } from './types.js';
+import { extractDestructuredKeys, extractPropertyAccessKeys } from '../shape-inference.js';
+
+const REACT_QUERY_HOOKS = /\b(useQuery|useMutation|useInfiniteQuery|useSuspenseQuery)\s*\(\s*\{/g;
+const QUERY_KEY_PATTERN = /queryKey\s*:\s*(\[[^\]]*\]|['"][^'"]+['"])/;
+const MUTATION_KEY_PATTERN = /mutationKey\s*:\s*(\[[^\]]*\]|['"][^'"]+['"])/;
+
+/**
+ * Extract the options object for a React Query hook call starting at the opening brace.
+ * Uses brace-depth counting to find the matching closing brace.
+ */
+function extractOptionsBlock(code: string, braceStart: number): string {
+  let depth = 0;
+  for (let i = braceStart; i < code.length; i++) {
+    if (code[i] === '{') depth++;
+    else if (code[i] === '}') {
+      depth--;
+      if (depth === 0) return code.slice(braceStart, i + 1);
+    }
+  }
+  return code.slice(braceStart);
+}
+
+/**
+ * Find the enclosing function name for a position in code.
+ * Looks backwards for `function NAME` or `const NAME =` patterns.
+ */
+function findEnclosingFunctionName(code: string, position: number): string {
+  const before = code.slice(0, position);
+  // Try: export function NAME, function NAME, const NAME =
+  const funcMatch = before.match(/(?:export\s+)?(?:function|const|let|var)\s+(\w+)\s*(?:=\s*(?:\([^)]*\)\s*=>|\w+\s*=>|function)|\s*\()/g);
+  if (funcMatch) {
+    const last = funcMatch[funcMatch.length - 1];
+    const nameMatch = last.match(/(?:function|const|let|var)\s+(\w+)/);
+    if (nameMatch) return nameMatch[1];
+  }
+  return '<anonymous>';
+}
+
+/**
+ * Detect React Query / TanStack Query state slots in source code.
+ */
+export function detectReactQuerySlots(code: string, filePath: string): ExtractedStateSlot[] {
+  const slots: ExtractedStateSlot[] = [];
+
+  let match: RegExpExecArray | null;
+  REACT_QUERY_HOOKS.lastIndex = 0;
+
+  while ((match = REACT_QUERY_HOOKS.exec(code)) !== null) {
+    const hookName = match[1];
+    const isMutation = hookName === 'useMutation';
+    const braceStart = code.indexOf('{', match.index + hookName.length);
+    if (braceStart === -1) continue;
+
+    const optionsBlock = extractOptionsBlock(code, braceStart);
+    const keyPattern = isMutation ? MUTATION_KEY_PATTERN : QUERY_KEY_PATTERN;
+    const keyMatch = optionsBlock.match(keyPattern);
+    if (!keyMatch) continue;
+
+    const cacheKey = keyMatch[1];
+    const lineNumber = code.slice(0, match.index).split('\n').length;
+    const functionName = findEnclosingFunctionName(code, match.index);
+
+    // The hook call is both a producer (writes queryFn result to cache) and defines the slot
+    const producer: ExtractedStateSlotProducer = {
+      functionName,
+      filePath,
+      lineNumber,
+      keys: [], // Will be enriched by shape inference in the pipeline
+      confidence: 'heuristic',
+    };
+
+    // Look for consumer access patterns in the surrounding function context
+    // Find the function body that contains this hook call
+    const consumers: ExtractedStateSlotConsumer[] = [];
+    const funcEnd = findFunctionEnd(code, match.index);
+    const funcBody = code.slice(match.index, funcEnd);
+
+    const destructuredKeys = extractDestructuredKeys(funcBody);
+    const accessKeys = extractPropertyAccessKeys(funcBody);
+    const allKeys = [...new Set([...destructuredKeys, ...accessKeys])];
+
+    if (allKeys.length > 0) {
+      consumers.push({
+        functionName,
+        filePath,
+        lineNumber,
+        accessedKeys: allKeys,
+        confidence: 'heuristic',
+      });
+    }
+
+    slots.push({
+      name: `${hookName}(${cacheKey})`,
+      slotKind: 'react-query',
+      cacheKey,
+      filePath,
+      lineNumber,
+      producers: [producer],
+      consumers,
+    });
+  }
+
+  return slots;
+}
+
+/**
+ * Find the end of the function containing a given position.
+ * Simple heuristic: find the next function/export boundary or end of file.
+ */
+function findFunctionEnd(code: string, position: number): number {
+  // Look for the next top-level function/export declaration after the current position
+  const afterPos = code.slice(position + 1);
+  const nextFunc = afterPos.search(/\n(?:export\s+)?(?:function|const|let|var)\s+\w+/);
+  if (nextFunc !== -1) return position + 1 + nextFunc;
+  return code.length;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /private/tmp/gitnexus-data-shape-tracking/gitnexus && npx vitest run test/unit/state-slot-detectors.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gitnexus/src/core/ingestion/state-slot-detectors/react-query.ts gitnexus/test/unit/state-slot-detectors.test.ts
+git commit -m "feat: add React Query state slot detector with cache key extraction"
+```
+
+---
+
+### Task 7: Write SWR Detector
+
+**Files:**
+- Create: `gitnexus/src/core/ingestion/state-slot-detectors/swr.ts`
+- Modify: `gitnexus/test/unit/state-slot-detectors.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `state-slot-detectors.test.ts`:
+
+```typescript
+import { detectSWRSlots } from '../../src/core/ingestion/state-slot-detectors/swr.js';
+
+describe('detectSWRSlots', () => {
+  it('detects useSWR with string key', () => {
+    const code = `
+      export function useVendor(id) {
+        const { data, error } = useSWR('/api/vendors/' + id, fetcher);
+        return { data, error };
+      }
+    `;
+    const slots = detectSWRSlots(code, 'hooks/useVendor.ts');
+    expect(slots).toHaveLength(1);
+    expect(slots[0].slotKind).toBe('swr');
+    expect(slots[0].cacheKey).toContain('/api/vendors/');
+  });
+
+  it('detects useSWR with array key', () => {
+    const code = `
+      const { data } = useSWR(['vendors', id], fetchVendor);
+    `;
+    const slots = detectSWRSlots(code, 'hooks/useVendor.ts');
+    expect(slots).toHaveLength(1);
+    expect(slots[0].cacheKey).toContain('vendors');
+  });
+
+  it('detects useSWRMutation', () => {
+    const code = `
+      const { trigger } = useSWRMutation('/api/vendors', updateVendor);
+    `;
+    const slots = detectSWRSlots(code, 'hooks/useUpdateVendor.ts');
+    expect(slots).toHaveLength(1);
+  });
+
+  it('returns empty for files without SWR', () => {
+    expect(detectSWRSlots(`const x = 1;`, 'utils.ts')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /private/tmp/gitnexus-data-shape-tracking/gitnexus && npx vitest run test/unit/state-slot-detectors.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+/**
+ * SWR state slot detector.
+ *
+ * Detects useSWR and useSWRMutation calls and extracts cache keys.
+ */
+
+import type { ExtractedStateSlot, ExtractedStateSlotProducer, ExtractedStateSlotConsumer } from './types.js';
+import { extractDestructuredKeys, extractPropertyAccessKeys } from '../shape-inference.js';
+
+const SWR_HOOKS = /\b(useSWR|useSWRMutation)\s*\(\s*/g;
+
+/**
+ * Extract the first argument (cache key) from a SWR hook call.
+ * SWR key is the first argument: useSWR(key, fetcher, options?)
+ */
+function extractSWRKey(code: string, callStart: number): string | null {
+  const afterParen = code.indexOf('(', callStart);
+  if (afterParen === -1) return null;
+
+  let pos = afterParen + 1;
+  // Skip whitespace
+  while (pos < code.length && /\s/.test(code[pos])) pos++;
+
+  // Array key: ['key', var]
+  if (code[pos] === '[') {
+    const end = code.indexOf(']', pos);
+    if (end !== -1) return code.slice(pos, end + 1);
+  }
+
+  // String key: '/api/path' or "/api/path"
+  if (code[pos] === "'" || code[pos] === '"') {
+    const quote = code[pos];
+    const end = code.indexOf(quote, pos + 1);
+    if (end !== -1) return code.slice(pos, end + 1);
+  }
+
+  // Template literal: `/api/path/${id}`
+  if (code[pos] === '`') {
+    const end = code.indexOf('`', pos + 1);
+    if (end !== -1) return code.slice(pos, end + 1);
+  }
+
+  // Expression with string concat: '/api/vendors/' + id
+  // Capture up to the comma separator
+  const exprEnd = code.indexOf(',', pos);
+  if (exprEnd !== -1) {
+    const expr = code.slice(pos, exprEnd).trim();
+    // Only keep if it starts with a string literal
+    if (/^['"`]/.test(expr)) return expr;
+  }
+
+  return null;
+}
+
+function findEnclosingFunctionName(code: string, position: number): string {
+  const before = code.slice(0, position);
+  const funcMatch = before.match(/(?:export\s+)?(?:function|const|let|var)\s+(\w+)\s*(?:=\s*(?:\([^)]*\)\s*=>|\w+\s*=>|function)|\s*\()/g);
+  if (funcMatch) {
+    const last = funcMatch[funcMatch.length - 1];
+    const nameMatch = last.match(/(?:function|const|let|var)\s+(\w+)/);
+    if (nameMatch) return nameMatch[1];
+  }
+  return '<anonymous>';
+}
+
+/**
+ * Detect SWR state slots in source code.
+ */
+export function detectSWRSlots(code: string, filePath: string): ExtractedStateSlot[] {
+  const slots: ExtractedStateSlot[] = [];
+
+  let match: RegExpExecArray | null;
+  SWR_HOOKS.lastIndex = 0;
+
+  while ((match = SWR_HOOKS.exec(code)) !== null) {
+    const hookName = match[1];
+    const cacheKey = extractSWRKey(code, match.index);
+    if (!cacheKey) continue;
+
+    const lineNumber = code.slice(0, match.index).split('\n').length;
+    const functionName = findEnclosingFunctionName(code, match.index);
+
+    const producer: ExtractedStateSlotProducer = {
+      functionName,
+      filePath,
+      lineNumber,
+      keys: [],
+      confidence: 'heuristic',
+    };
+
+    // Look for consumer access patterns after the hook call
+    const consumers: ExtractedStateSlotConsumer[] = [];
+    const contextEnd = Math.min(match.index + 500, code.length);
+    const contextCode = code.slice(match.index, contextEnd);
+
+    const destructuredKeys = extractDestructuredKeys(contextCode);
+    const accessKeys = extractPropertyAccessKeys(contextCode);
+    const allKeys = [...new Set([...destructuredKeys, ...accessKeys])];
+
+    if (allKeys.length > 0) {
+      consumers.push({
+        functionName,
+        filePath,
+        lineNumber,
+        accessedKeys: allKeys,
+        confidence: 'heuristic',
+      });
+    }
+
+    slots.push({
+      name: `${hookName}(${cacheKey})`,
+      slotKind: 'swr',
+      cacheKey,
+      filePath,
+      lineNumber,
+      producers: [producer],
+      consumers,
+    });
+  }
+
+  return slots;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /private/tmp/gitnexus-data-shape-tracking/gitnexus && npx vitest run test/unit/state-slot-detectors.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gitnexus/src/core/ingestion/state-slot-detectors/swr.ts gitnexus/test/unit/state-slot-detectors.test.ts
+git commit -m "feat: add SWR state slot detector"
+```
+
+---
+
+### Task 8: Create Detector Index and Barrel Export
+
+**Files:**
+- Create: `gitnexus/src/core/ingestion/state-slot-detectors/index.ts`
+
+- [ ] **Step 1: Write the barrel export and orchestrator**
+
+```typescript
+/**
+ * State slot detection orchestrator.
+ *
+ * Runs all registered detectors against file content and returns
+ * merged ExtractedStateSlot results.
+ */
+
+import type { ExtractedStateSlot } from './types.js';
+import { detectReactQuerySlots } from './react-query.js';
+import { detectSWRSlots } from './swr.js';
+
+export type { ExtractedStateSlot, SlotKind, ShapeConfidence, ExtractedStateSlotProducer, ExtractedStateSlotConsumer } from './types.js';
+
+type Detector = (code: string, filePath: string) => ExtractedStateSlot[];
+
+const DETECTORS: Detector[] = [
+  detectReactQuerySlots,
+  detectSWRSlots,
+  // Phase 3: detectReactContextSlots, detectReduxSlots, detectZustandSlots
+  // Phase 4: detectTRPCSlots, detectGraphQLSlots
+];
+
+/**
+ * Run all state slot detectors on a file and return merged results.
+ */
+export function detectStateSlots(code: string, filePath: string): ExtractedStateSlot[] {
+  const results: ExtractedStateSlot[] = [];
+  for (const detector of DETECTORS) {
+    results.push(...detector(code, filePath));
+  }
+  return results;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add gitnexus/src/core/ingestion/state-slot-detectors/index.ts
+git commit -m "feat: add state slot detector orchestrator with barrel exports"
+```
+
+---
+
+### Task 9: Create State Slot Processor (Pipeline Phase 3.7)
+
+**Files:**
+- Create: `gitnexus/src/core/ingestion/state-slot-processor.ts`
+
+- [ ] **Step 1: Write the processor**
+
+```typescript
+/**
+ * Pipeline Phase 3.7: State Slot Processing.
+ *
+ * Creates StateSlot nodes and PRODUCES/CONSUMES edges from ExtractedStateSlot data.
+ * Runs after route detection (3.5) and tool detection (3.6).
+ */
+
+import type { KnowledgeGraph } from '../graph/graph.js';
+import type { ExtractedStateSlot } from './state-slot-detectors/index.js';
+import { cacheKeysOverlap } from './shape-inference.js';
+
+// Re-use the existing generateId from the pipeline (consistent ID format)
+function generateId(prefix: string, key: string): string {
+  return `${prefix}:${key}`;
+}
+
+export interface StateSlotProcessorResult {
+  slotsCreated: number;
+  producesEdges: number;
+  consumesEdges: number;
+  overlapWarnings: number;
+}
+
+/**
+ * Process extracted state slots into the knowledge graph.
+ *
+ * Creates StateSlot nodes and PRODUCES/CONSUMES edges. Also detects
+ * potential cache key overlaps (same prefix, different producers).
+ */
+export function processStateSlots(
+  graph: KnowledgeGraph,
+  allSlots: ExtractedStateSlot[],
+): StateSlotProcessorResult {
+  const stats: StateSlotProcessorResult = {
+    slotsCreated: 0,
+    producesEdges: 0,
+    consumesEdges: 0,
+    overlapWarnings: 0,
+  };
+
+  // Deduplicate slots by cacheKey — merge producers/consumers for same key
+  const slotsByKey = new Map<string, ExtractedStateSlot>();
+
+  for (const slot of allSlots) {
+    const existing = slotsByKey.get(slot.cacheKey);
+    if (existing) {
+      existing.producers.push(...slot.producers);
+      existing.consumers.push(...slot.consumers);
+    } else {
+      slotsByKey.set(slot.cacheKey, { ...slot, producers: [...slot.producers], consumers: [...slot.consumers] });
+    }
+  }
+
+  // Create StateSlot nodes and edges
+  for (const [cacheKey, slot] of slotsByKey) {
+    const slotNodeId = generateId('StateSlot', `${slot.slotKind}:${cacheKey}`);
+
+    graph.addNode({
+      id: slotNodeId,
+      label: 'StateSlot',
+      properties: {
+        name: slot.name,
+        filePath: slot.filePath,
+        slotKind: slot.slotKind,
+        cacheKey: slot.cacheKey,
+      },
+    });
+    stats.slotsCreated++;
+
+    // PRODUCES edges
+    for (const producer of slot.producers) {
+      const producerNodeId = findSymbolId(graph, producer.functionName, producer.filePath)
+        || generateId('File', producer.filePath);
+
+      const edgeReason = buildProducesReason(producer);
+      graph.addRelationship({
+        id: generateId('PRODUCES', `${producerNodeId}->${slotNodeId}`),
+        sourceId: producerNodeId,
+        targetId: slotNodeId,
+        type: 'PRODUCES',
+        confidence: confidenceToNumber(producer.confidence),
+        reason: edgeReason,
+      });
+      stats.producesEdges++;
+    }
+
+    // CONSUMES edges
+    for (const consumer of slot.consumers) {
+      const consumerNodeId = findSymbolId(graph, consumer.functionName, consumer.filePath)
+        || generateId('File', consumer.filePath);
+
+      const edgeReason = buildConsumesReason(consumer);
+      graph.addRelationship({
+        id: generateId('CONSUMES', `${consumerNodeId}->${slotNodeId}`),
+        sourceId: consumerNodeId,
+        targetId: slotNodeId,
+        type: 'CONSUMES',
+        confidence: confidenceToNumber(consumer.confidence),
+        reason: edgeReason,
+      });
+      stats.consumesEdges++;
+    }
+  }
+
+  // Detect cache key prefix overlaps across different slots
+  const keys = [...slotsByKey.keys()];
+  for (let i = 0; i < keys.length; i++) {
+    for (let j = i + 1; j < keys.length; j++) {
+      if (keys[i] !== keys[j] && cacheKeysOverlap(keys[i], keys[j])) {
+        stats.overlapWarnings++;
+      }
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * Find a Function/Method node ID by name and filePath in the graph.
+ */
+function findSymbolId(graph: KnowledgeGraph, name: string, filePath: string): string | undefined {
+  // Try common ID patterns used by the pipeline
+  for (const prefix of ['Function', 'Method']) {
+    const candidateId = generateId(prefix, `${filePath}:${name}`);
+    if (graph.getNode(candidateId)) return candidateId;
+  }
+  // Fallback: search nodes by name and filePath
+  for (const node of graph.nodes) {
+    if (node.properties.name === name && node.properties.filePath === filePath) {
+      return node.id;
+    }
+  }
+  return undefined;
+}
+
+function confidenceToNumber(confidence: string): number {
+  switch (confidence) {
+    case 'type-checked': return 1.0;
+    case 'ast-literal': return 0.8;
+    case 'heuristic': return 0.6;
+    default: return 0.5;
+  }
+}
+
+function buildProducesReason(producer: { keys: string[]; confidence: string; sourceType?: string }): string {
+  const parts = [`shape-${producer.confidence}`];
+  if (producer.keys.length > 0) parts.push(`keys:${producer.keys.join(',')}`);
+  if (producer.sourceType) parts.push(`type:${producer.sourceType}`);
+  return parts.join('|');
+}
+
+function buildConsumesReason(consumer: { accessedKeys: string[]; confidence: string }): string {
+  const parts = [`shape-${consumer.confidence}`];
+  if (consumer.accessedKeys.length > 0) parts.push(`keys:${consumer.accessedKeys.join(',')}`);
+  return parts.join('|');
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add gitnexus/src/core/ingestion/state-slot-processor.ts
+git commit -m "feat: add state slot processor for pipeline phase 3.7"
+```
+
+---
+
+### Task 10: Integrate State Slot Detection into Pipeline
+
+**Files:**
+- Modify: `gitnexus/src/core/ingestion/pipeline.ts`
+
+- [ ] **Step 1: Add imports at top of pipeline.ts**
+
+Add after existing imports:
+
+```typescript
+import { detectStateSlots } from './state-slot-detectors/index.js';
+import type { ExtractedStateSlot } from './state-slot-detectors/index.js';
+import { processStateSlots } from './state-slot-processor.js';
+```
+
+- [ ] **Step 2: Add accumulator in runChunkedParseAndResolve**
+
+After `const allToolDefs: ExtractedToolDef[] = [];` (line 630), add:
+
+```typescript
+  // Accumulate state slot detections for Phase 3.7
+  const allStateSlots: ExtractedStateSlot[] = [];
+```
+
+- [ ] **Step 3: Add state slot detection inside the chunk loop**
+
+After `allToolDefs.push(...chunkWorkerData.toolDefs);` (line 757), add:
+
+```typescript
+        // Detect state slots (React Query, SWR, etc.) from file contents
+        for (const [filePath, content] of chunkContents) {
+          const slots = detectStateSlots(content, filePath);
+          if (slots.length > 0) allStateSlots.push(...slots);
+        }
+```
+
+Note: `chunkContents` is already available in scope (line 637). We run detection on raw source text (not AST), which is fast.
+
+- [ ] **Step 4: Add allStateSlots to the return value**
+
+Update the return type of `runChunkedParseAndResolve` (line 505) to include:
+
+```typescript
+  allStateSlots: ExtractedStateSlot[];
+```
+
+And add to the return statement (around line 860):
+
+```typescript
+  return { exportedTypeMap, allFetchCalls, allExtractedRoutes, allDecoratorRoutes, allToolDefs, allStateSlots };
+```
+
+- [ ] **Step 5: Add Phase 3.7 in the pipeline orchestrator**
+
+After Phase 3.6 (tool detection, around line 1244), add:
+
+```typescript
+  // ── Phase 3.7: State Slot Detection ────────────────────────────────────────
+  if (allStateSlots.length > 0) {
+    onProgress({
+      phase: 'state-slots',
+      percent: 89,
+      message: `Processing ${allStateSlots.length} state slot(s)...`,
+      stats: { filesProcessed: totalFiles, totalFiles, nodesCreated: graph.nodeCount },
+    });
+
+    const slotResult = processStateSlots(graph, allStateSlots);
+
+    if (isDev) {
+      console.log(`🗄️ State slots: ${slotResult.slotsCreated} created, ${slotResult.producesEdges} PRODUCES, ${slotResult.consumesEdges} CONSUMES, ${slotResult.overlapWarnings} overlap warnings`);
+    }
+  }
+```
+
+- [ ] **Step 6: Update destructuring of runChunkedParseAndResolve result**
+
+Update the line that destructures the result (around line 1074) to include `allStateSlots`:
+
+```typescript
+  const { exportedTypeMap, allFetchCalls, allExtractedRoutes, allDecoratorRoutes, allToolDefs, allStateSlots } = await runChunkedParseAndResolve(
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gitnexus/src/core/ingestion/pipeline.ts
+git commit -m "feat: integrate state slot detection as pipeline phase 3.7"
+```
+
+---
+
+### Task 11: Create Seed Data for E2E Tests
+
+**Files:**
+- Create: `gitnexus/test/fixtures/state-slot-seed.ts`
+
+- [ ] **Step 1: Write seed data**
+
+```typescript
+import type { FTSIndexDef } from '../helpers/test-indexed-db.js';
+
+/**
+ * Seed data for data_flow E2E tests.
+ *
+ * Simulates a Next.js project with:
+ * - Two React Query hooks sharing cache key ['vendor-patterns', slug]
+ *   with DIFFERENT produced shapes (the original bug)
+ * - One SWR hook with a different key (no conflict)
+ * - Consumer components with different access patterns
+ */
+export const STATE_SLOT_SEED_DATA = [
+  // ─── Files ─────────────────────────────────────────────────────────
+  `CREATE (f:File {id: 'file:hooks/useVendorPatterns.ts', name: 'useVendorPatterns.ts', filePath: 'hooks/useVendorPatterns.ts', content: 'useQuery vendor-patterns'})`,
+  `CREATE (f:File {id: 'file:hooks/useVendorCount.ts', name: 'useVendorCount.ts', filePath: 'hooks/useVendorCount.ts', content: 'useQuery vendor-patterns count'})`,
+  `CREATE (f:File {id: 'file:hooks/useGrants.ts', name: 'useGrants.ts', filePath: 'hooks/useGrants.ts', content: 'useSWR grants'})`,
+  `CREATE (f:File {id: 'file:components/VendorList.tsx', name: 'VendorList.tsx', filePath: 'components/VendorList.tsx', content: 'displays vendor patterns'})`,
+  `CREATE (f:File {id: 'file:components/VendorStats.tsx', name: 'VendorStats.tsx', filePath: 'components/VendorStats.tsx', content: 'displays vendor count'})`,
+
+  // ─── StateSlot nodes ───────────────────────────────────────────────
+  // Two hooks share this cache key with different shapes
+  `CREATE (s:StateSlot {id: 'StateSlot:react-query:[vendor-patterns, slug]', name: 'useQuery([vendor-patterns, slug])', filePath: 'hooks/useVendorPatterns.ts', slotKind: 'react-query', cacheKey: '[vendor-patterns, slug]'})`,
+  // SWR slot with no conflicts
+  `CREATE (s:StateSlot {id: 'StateSlot:swr:/api/grants', name: 'useSWR(/api/grants)', filePath: 'hooks/useGrants.ts', slotKind: 'swr', cacheKey: '/api/grants'})`,
+
+  // ─── Functions ─────────────────────────────────────────────────────
+  `CREATE (fn:Function {id: 'func:useVendorPatterns', name: 'useVendorPatterns', filePath: 'hooks/useVendorPatterns.ts', startLine: 1, endLine: 10, isExported: true, content: 'export function useVendorPatterns()', description: 'Hook returning vendor patterns list'})`,
+  `CREATE (fn:Function {id: 'func:useVendorCount', name: 'useVendorCount', filePath: 'hooks/useVendorCount.ts', startLine: 1, endLine: 8, isExported: true, content: 'export function useVendorCount()', description: 'Hook returning vendor count'})`,
+  `CREATE (fn:Function {id: 'func:useGrants', name: 'useGrants', filePath: 'hooks/useGrants.ts', startLine: 1, endLine: 6, isExported: true, content: 'export function useGrants()', description: 'Hook returning grants'})`,
+  `CREATE (fn:Function {id: 'func:VendorList', name: 'VendorList', filePath: 'components/VendorList.tsx', startLine: 1, endLine: 15, isExported: true, content: 'export function VendorList()', description: 'Vendor list component'})`,
+  `CREATE (fn:Function {id: 'func:VendorStats', name: 'VendorStats', filePath: 'components/VendorStats.tsx', startLine: 1, endLine: 10, isExported: true, content: 'export function VendorStats()', description: 'Vendor stats component'})`,
+
+  // ─── PRODUCES edges (hooks → StateSlot) ─────────────────────────────
+  // useVendorPatterns produces {patterns, total, page} into the shared slot
+  `MATCH (fn:Function), (s:StateSlot) WHERE fn.id = 'func:useVendorPatterns' AND s.id = 'StateSlot:react-query:[vendor-patterns, slug]'
+   CREATE (fn)-[:CodeRelation {type: 'PRODUCES', confidence: 0.8, reason: 'shape-ast-literal|keys:patterns,total,page', step: 0}]->(s)`,
+  // useVendorCount produces {total} into the SAME slot (CONFLICT!)
+  `MATCH (fn:Function), (s:StateSlot) WHERE fn.id = 'func:useVendorCount' AND s.id = 'StateSlot:react-query:[vendor-patterns, slug]'
+   CREATE (fn)-[:CodeRelation {type: 'PRODUCES', confidence: 0.8, reason: 'shape-ast-literal|keys:total', step: 0}]->(s)`,
+  // useGrants produces {grants, pagination} into a different slot (no conflict)
+  `MATCH (fn:Function), (s:StateSlot) WHERE fn.id = 'func:useGrants' AND s.id = 'StateSlot:swr:/api/grants'
+   CREATE (fn)-[:CodeRelation {type: 'PRODUCES', confidence: 0.6, reason: 'shape-heuristic|keys:grants,pagination', step: 0}]->(s)`,
+
+  // ─── CONSUMES edges (components → StateSlot) ───────────────────────
+  // VendorList accesses patterns and page from the shared slot
+  `MATCH (fn:Function), (s:StateSlot) WHERE fn.id = 'func:VendorList' AND s.id = 'StateSlot:react-query:[vendor-patterns, slug]'
+   CREATE (fn)-[:CodeRelation {type: 'CONSUMES', confidence: 0.6, reason: 'shape-heuristic|keys:patterns,page', step: 0}]->(s)`,
+  // VendorStats accesses total from the shared slot
+  `MATCH (fn:Function), (s:StateSlot) WHERE fn.id = 'func:VendorStats' AND s.id = 'StateSlot:react-query:[vendor-patterns, slug]'
+   CREATE (fn)-[:CodeRelation {type: 'CONSUMES', confidence: 0.6, reason: 'shape-heuristic|keys:total', step: 0}]->(s)`,
+];
+
+export const STATE_SLOT_FTS_INDEXES: FTSIndexDef[] = [
+  { table: 'Function', indexName: 'function_fts', columns: ['name', 'content', 'description'] },
+  { table: 'File', indexName: 'file_fts', columns: ['name', 'content'] },
+];
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add gitnexus/test/fixtures/state-slot-seed.ts
+git commit -m "test: add seed data for data_flow E2E tests with cache key conflict scenario"
+```
+
+---
+
+### Task 12: Add data_flow MCP Tool Definition
+
+**Files:**
+- Modify: `gitnexus/src/mcp/tools.ts`
+
+- [ ] **Step 1: Add data_flow to GITNEXUS_TOOLS array**
+
+After the `api_impact` tool definition (or at the end of the array):
+
+```typescript
+  {
+    name: 'data_flow',
+    description: `Show data flow through shared state slots (React Query cache keys, SWR keys, React Context, Redux slices, Zustand stores).
+
+WHEN TO USE: When you need to understand how data flows through shared state, detect cache key collisions, or find shape mismatches where two hooks/components share a state slot but expect different data shapes.
+
+Returns: state slots with their producers (who writes data), consumers (who reads data), shape comparison, and mismatch verdict (ok/suspicious/conflict).
+
+AFTER THIS: If mismatches are found, use \`context\` on the producer/consumer functions to understand the full call chain.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Filter by cache key, context name, or slice name (substring match)' },
+        slotKind: { type: 'string', description: 'Filter by state slot kind', enum: ['react-query', 'swr', 'react-context', 'redux', 'zustand', 'trpc', 'graphql', 'custom-hook'] },
+        mismatchesOnly: { type: 'string', description: 'Set to "true" to only show slots with shape conflicts' },
+        repo: { type: 'string', description: 'Repository name or path. Omit if only one repo is indexed.' },
+      },
+      required: [],
+    },
+  },
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add gitnexus/src/mcp/tools.ts
+git commit -m "feat(mcp): add data_flow tool definition"
+```
+
+---
+
+### Task 13: Implement data_flow Tool in Local Backend
+
+**Files:**
+- Modify: `gitnexus/src/mcp/local/local-backend.ts`
+
+- [ ] **Step 1: Add 'data_flow' case to callTool() dispatch**
+
+In the `callTool()` switch (around line 417), add before `default:`:
+
+```typescript
+    case 'data_flow':   return this.dataFlow(repo, params);
+```
+
+- [ ] **Step 2: Implement dataFlow() method**
+
+Add after `apiImpact()` method (around line 1900):
+
+```typescript
+  /**
+   * data_flow tool: Show data flow through shared state slots with mismatch detection.
+   */
+  private async dataFlow(
+    repo: RepoHandle,
+    params: { query?: string; slotKind?: string; mismatchesOnly?: string },
+  ): Promise<any> {
+    await this.ensureInitialized(repo.id);
+
+    // Build filter clauses
+    const conditions: string[] = [];
+    const queryParams: Record<string, any> = {};
+
+    if (params.query) {
+      conditions.push(`(s.name CONTAINS $query OR s.cacheKey CONTAINS $query)`);
+      queryParams.query = params.query;
+    }
+    if (params.slotKind) {
+      conditions.push(`s.slotKind = $slotKind`);
+      queryParams.slotKind = params.slotKind;
+    }
+
+    const whereClause = conditions.length > 0
+      ? `WHERE ${conditions.join(' AND ')}`
+      : '';
+
+    // Query StateSlot nodes with their PRODUCES and CONSUMES edges
+    const slotsQuery = `
+      MATCH (s:StateSlot)
+      ${whereClause}
+      RETURN s.id AS id, s.name AS name, s.filePath AS filePath,
+             s.slotKind AS slotKind, s.cacheKey AS cacheKey
+      ORDER BY s.slotKind, s.name
+    `;
+
+    const slotRows = await executeParameterized(repo.id, slotsQuery, queryParams);
+
+    if (!slotRows || slotRows.length === 0) {
+      return { slots: [], total: 0, message: 'No state slots found.' };
+    }
+
+    const results = [];
+
+    for (const slot of slotRows) {
+      // Get producers
+      const producersQuery = `
+        MATCH (fn)-[r:CodeRelation]->(s:StateSlot)
+        WHERE s.id = $slotId AND r.type = 'PRODUCES'
+        RETURN fn.name AS name, fn.filePath AS filePath, r.reason AS reason, r.confidence AS confidence
+      `;
+      const producerRows = await executeParameterized(repo.id, producersQuery, { slotId: slot.id });
+
+      // Get consumers
+      const consumersQuery = `
+        MATCH (fn)-[r:CodeRelation]->(s:StateSlot)
+        WHERE s.id = $slotId AND r.type = 'CONSUMES'
+        RETURN fn.name AS name, fn.filePath AS filePath, r.reason AS reason, r.confidence AS confidence
+      `;
+      const consumerRows = await executeParameterized(repo.id, consumersQuery, { slotId: slot.id });
+
+      const producers = (producerRows || []).map((p: any) => ({
+        name: p.name,
+        file: p.filePath,
+        ...parseShapeReason(p.reason),
+        confidence: p.confidence,
+      }));
+
+      const consumers = (consumerRows || []).map((c: any) => ({
+        name: c.name,
+        file: c.filePath,
+        ...parseShapeReason(c.reason),
+        confidence: c.confidence,
+      }));
+
+      // Determine mismatch verdict
+      const verdict = computeShapeVerdict(producers, consumers);
+
+      if (params.mismatchesOnly === 'true' && verdict.status === 'ok') continue;
+
+      results.push({
+        name: slot.name,
+        slotKind: slot.slotKind,
+        cacheKey: slot.cacheKey,
+        file: slot.filePath,
+        producers,
+        consumers,
+        verdict,
+      });
+    }
+
+    return {
+      slots: results,
+      total: results.length,
+      conflicts: results.filter(r => r.verdict.status === 'conflict').length,
+      suspicious: results.filter(r => r.verdict.status === 'suspicious').length,
+    };
+  }
+```
+
+- [ ] **Step 3: Add helper functions**
+
+Add near the top of the file (with other helpers) or at the bottom:
+
+```typescript
+/**
+ * Parse shape metadata from PRODUCES/CONSUMES edge reason field.
+ * Format: "shape-{confidence}|keys:k1,k2|type:TypeName"
+ */
+function parseShapeReason(reason: string): { keys: string[]; sourceType?: string } {
+  const keys: string[] = [];
+  let sourceType: string | undefined;
+
+  if (!reason) return { keys };
+
+  const parts = reason.split('|');
+  for (const part of parts) {
+    if (part.startsWith('keys:')) {
+      keys.push(...part.slice(5).split(',').filter(Boolean));
+    } else if (part.startsWith('type:')) {
+      sourceType = part.slice(5);
+    }
+  }
+
+  return { keys, ...(sourceType ? { sourceType } : {}) };
+}
+
+/**
+ * Compare producer and consumer shapes to determine mismatch verdict.
+ */
+function computeShapeVerdict(
+  producers: { name: string; keys: string[] }[],
+  consumers: { name: string; keys: string[] }[],
+): { status: 'ok' | 'suspicious' | 'conflict'; reason: string } {
+  // Check for producer shape conflicts (different producers write different shapes)
+  if (producers.length >= 2) {
+    const shapes = producers.map(p => p.keys.sort().join(','));
+    const uniqueShapes = new Set(shapes);
+    if (uniqueShapes.size > 1) {
+      const diffs = producers.map(p => `${p.name} writes {${p.keys.join(', ')}}`).join('; ');
+      return {
+        status: 'conflict',
+        reason: `Multiple producers write different shapes to same slot: ${diffs}`,
+      };
+    }
+  }
+
+  // Check for consumer accessing keys not in any producer
+  if (producers.length > 0 && consumers.length > 0) {
+    const allProducedKeys = new Set(producers.flatMap(p => p.keys));
+    if (allProducedKeys.size > 0) {
+      for (const consumer of consumers) {
+        const unknownKeys = consumer.keys.filter(k => !allProducedKeys.has(k));
+        if (unknownKeys.length > 0) {
+          return {
+            status: 'suspicious',
+            reason: `${consumer.name} accesses keys not in any producer: {${unknownKeys.join(', ')}}`,
+          };
+        }
+      }
+    }
+  }
+
+  return { status: 'ok', reason: 'No shape mismatches detected' };
+}
+```
+
+- [ ] **Step 4: Add next-step hint in server.ts**
+
+In `getNextStepHint()` in `server.ts`, add a case:
+
+```typescript
+case 'data_flow':
+  return '\n\n💡 Next: Use `context` on any producer/consumer to see its full call chain, or `api_impact` to check the upstream API route.';
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gitnexus/src/mcp/local/local-backend.ts gitnexus/src/mcp/server.ts
+git commit -m "feat(mcp): implement data_flow tool with shape mismatch detection"
+```
+
+---
+
+### Task 14: Write E2E Test for data_flow Tool
+
+**Files:**
+- Create: `gitnexus/test/integration/data-flow-e2e.test.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+```typescript
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { LocalBackend } from '../../src/mcp/local/local-backend.js';
+import { listRegisteredRepos } from '../../src/storage/repo-manager.js';
+import { withTestLbugDB } from '../helpers/test-indexed-db.js';
+import { STATE_SLOT_SEED_DATA, STATE_SLOT_FTS_INDEXES } from '../fixtures/state-slot-seed.js';
+
+vi.mock('../../src/storage/repo-manager.js', () => ({
+  listRegisteredRepos: vi.fn().mockResolvedValue([]),
+  cleanupOldKuzuFiles: vi.fn().mockResolvedValue({ found: false, needsReindex: false }),
+}));
+
+withTestLbugDB('data-flow-e2e', (handle) => {
+  let backend: LocalBackend;
+
+  beforeAll(async () => {
+    const ext = handle as typeof handle & { _backend?: LocalBackend };
+    backend = ext._backend!;
+  });
+
+  describe('data_flow tool', () => {
+    it('returns all state slots when no filter', async () => {
+      const result = await backend.callTool('data_flow', {});
+      expect(result).not.toHaveProperty('error');
+      expect(result.total).toBe(2); // react-query + swr
+      expect(result.slots).toHaveLength(2);
+    });
+
+    it('filters by slotKind', async () => {
+      const result = await backend.callTool('data_flow', { slotKind: 'react-query' });
+      expect(result.slots).toHaveLength(1);
+      expect(result.slots[0].slotKind).toBe('react-query');
+    });
+
+    it('filters by query substring', async () => {
+      const result = await backend.callTool('data_flow', { query: 'vendor-patterns' });
+      expect(result.slots).toHaveLength(1);
+      expect(result.slots[0].cacheKey).toContain('vendor-patterns');
+    });
+
+    it('detects shape conflict in shared cache key', async () => {
+      const result = await backend.callTool('data_flow', { query: 'vendor-patterns' });
+      const slot = result.slots[0];
+      expect(slot.verdict.status).toBe('conflict');
+      expect(slot.verdict.reason).toContain('different shapes');
+      expect(slot.producers).toHaveLength(2);
+    });
+
+    it('shows ok verdict for non-conflicting slot', async () => {
+      const result = await backend.callTool('data_flow', { query: 'grants' });
+      const slot = result.slots[0];
+      expect(slot.verdict.status).toBe('ok');
+    });
+
+    it('mismatchesOnly filters to conflicts only', async () => {
+      const result = await backend.callTool('data_flow', { mismatchesOnly: 'true' });
+      expect(result.slots.length).toBeLessThan(2);
+      for (const slot of result.slots) {
+        expect(slot.verdict.status).not.toBe('ok');
+      }
+    });
+
+    it('returns producer and consumer details', async () => {
+      const result = await backend.callTool('data_flow', { query: 'vendor-patterns' });
+      const slot = result.slots[0];
+
+      // Producers
+      expect(slot.producers.some((p: any) => p.name === 'useVendorPatterns')).toBe(true);
+      expect(slot.producers.some((p: any) => p.name === 'useVendorCount')).toBe(true);
+
+      // Consumers
+      expect(slot.consumers.some((c: any) => c.name === 'VendorList')).toBe(true);
+      expect(slot.consumers.some((c: any) => c.name === 'VendorStats')).toBe(true);
+
+      // Shape keys
+      const patternsProducer = slot.producers.find((p: any) => p.name === 'useVendorPatterns');
+      expect(patternsProducer.keys).toEqual(expect.arrayContaining(['patterns', 'total', 'page']));
+
+      const countProducer = slot.producers.find((p: any) => p.name === 'useVendorCount');
+      expect(countProducer.keys).toEqual(['total']);
+    });
+  });
+}, {
+  seed: STATE_SLOT_SEED_DATA,
+  ftsIndexes: STATE_SLOT_FTS_INDEXES,
+  poolAdapter: true,
+  afterSetup: async (handle) => {
+    vi.mocked(listRegisteredRepos).mockResolvedValue([{
+      name: 'test-state-repo',
+      path: '/test/state-repo',
+      storagePath: handle.tmpHandle.dbPath,
+      indexedAt: new Date().toISOString(),
+      lastCommit: 'abc123',
+      stats: { files: 5, nodes: 10, communities: 0, processes: 0 },
+    }]);
+    const backend = new LocalBackend();
+    await backend.init();
+    (handle as any)._backend = backend;
+  },
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /private/tmp/gitnexus-data-shape-tracking/gitnexus && npx vitest run test/integration/data-flow-e2e.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Break a fixture to verify test catches failures**
+
+Temporarily change the seed to remove one producer (delete the `useVendorCount PRODUCES` edge). Re-run the test — it should fail on the "detects shape conflict" assertion. Then revert the change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gitnexus/test/integration/data-flow-e2e.test.ts
+git commit -m "test: add E2E tests for data_flow tool with shape conflict detection"
+```
+
+---
+
+### Task 15: Run Full Test Suite and Fix Breakages
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd /private/tmp/gitnexus-data-shape-tracking/gitnexus && npx vitest run`
+Expected: All existing tests pass + new tests pass. Watch for:
+- Schema tests that assert on node/edge type counts
+- Tests that iterate all NodeLabel or RelationshipType values
+
+- [ ] **Step 2: Fix any count-based assertions**
+
+Per memory (`auto_project_gitnexus-schema-count-test-assertions.md`), count-based test assertions break when adding node types. Find and update any tests asserting exact counts of node tables or relationship types.
+
+- [ ] **Step 3: Commit fixes**
+
+```bash
+git add -A
+git commit -m "fix: update count-based test assertions for new StateSlot/PRODUCES/CONSUMES types"
+```
+
+---
+
+## Phase 2: TypeScript Type Pass + Route Chaining (Outline)
+
+### Task 16: TypeScript Type Extractor
+**Files:** Create `src/core/ingestion/ts-type-extractor.ts`
+- Use TypeScript compiler API (`ts.createProgram`) to extract generic type arguments from `useQuery<T>` calls
+- Resolve type aliases one level (e.g., `type VendorResponse = { patterns: VendorPattern[], total: number }` → keys `["patterns", "total"]`)
+- Extract `as` assertions: `data as VendorPattern[]`
+- Opt-in per repository via pipeline options (skip for non-TS repos)
+- This produces `type-checked` confidence shapes
+
+### Task 17: Route-to-Cache Chaining
+**Files:** Modify `src/core/ingestion/state-slot-processor.ts`
+- After creating StateSlot nodes, check if any producer's function has a FETCHES edge to a Route node
+- If so, copy the Route's `responseKeys` as the StateSlot's produced keys
+- Upgrades shape confidence from `heuristic` to `ast-literal` for those producers
+
+### Task 18: Wrapper Hook Resolution (Phase 3.7.1)
+**Files:** Modify `src/core/ingestion/state-slot-processor.ts`
+- After state slots are created, trace CALLS edges backwards
+- If function A calls function B, and B has a PRODUCES edge to a StateSlot, create an indirect PRODUCES edge from A to the same StateSlot
+- Max depth: 2 levels
+- This connects `useVendorPatterns()` wrapper to the underlying `useQuery` StateSlot
+
+### Task 19: queryClient.setQueryData Detection
+**Files:** Create `src/core/ingestion/state-slot-detectors/query-client.ts`
+- Detect `queryClient.setQueryData(['key'], data)` and `queryClient.setQueriesData` patterns
+- Extract the cache key from the first argument
+- Create a PRODUCES edge (this is a programmatic cache mutation)
+
+### Task 20: Extend shape_check with State Layer
+**Files:** Modify `src/mcp/local/local-backend.ts`
+- In `shapeCheck()`, after checking Route responseKeys vs FETCHES accessedKeys, also query StateSlot nodes
+- For each StateSlot, compare PRODUCES keys vs CONSUMES accessedKeys
+- Include state-layer mismatches in the output
+
+### Task 21: Extend api_impact with State Layer
+**Files:** Modify `src/mcp/local/local-backend.ts`
+- In `apiImpact()`, add a "State Layer" section
+- For each route's consumers, if the consumer function also has a PRODUCES edge to a StateSlot, show the StateSlot and downstream mismatches
+- Include in risk assessment
+
+### Task 22: Real-Repo Validation (fluentiagrant-app)
+- Run the full pipeline on fluentiagrant-app
+- Verify the original vendor-patterns cache key collision is detected
+- Verify no false positives on unrelated hooks
+
+---
+
+## Phase 3: React Context + Redux/Zustand (Outline)
+
+### Task 23: React Context Detector
+**Files:** Create `src/core/ingestion/state-slot-detectors/react-context.ts`
+- Detect `createContext(defaultValue)` — extract shape from default value
+- Detect `<Provider value={...}>` — extract shape from value prop
+- Detect `useContext(SomeContext)` — track property accesses on the returned value
+- SlotKind: `react-context`
+
+### Task 24: Redux createSlice Detector
+**Files:** Create `src/core/ingestion/state-slot-detectors/redux.ts`
+- Detect `createSlice({ name: '...', initialState: {...} })` — extract shape from initialState
+- Detect `useSelector((state) => state.slice.field)` — extract accessed keys
+- SlotKind: `redux`
+
+### Task 25: Zustand Store Detector
+**Files:** Create `src/core/ingestion/state-slot-detectors/zustand.ts`
+- Detect `create((set, get) => ({...}))` — extract shape from factory return
+- Detect `useStore((state) => state.field)` — extract accessed keys
+- SlotKind: `zustand`
+
+### Task 26: Extend impact and context Tools
+**Files:** Modify `src/mcp/local/local-backend.ts`
+- In `_impactImpl()`: when BFS hits a function with a PRODUCES edge, follow through to CONSUMES consumers
+- In `context()`: include PRODUCES/CONSUMES edges in the 360-degree view
+
+### Task 27: Real-Repo Validation (Context/Redux/Zustand projects)
+- Run on projects that use these patterns
+- Verify detection and zero false positives on unrelated code
+
+---
+
+## Phase 4: Custom Hooks + GraphQL + tRPC (Outline)
+
+### Task 28: Custom Hook Chain Detector
+**Files:** Create `src/core/ingestion/state-slot-detectors/custom-hook.ts`
+- Detect hooks that wrap other hooks and reshape the return value
+- Compare return shapes across CALLS edges
+- SlotKind: `custom-hook`
+
+### Task 29: GraphQL Query/Fragment Detector
+**Files:** Create `src/core/ingestion/state-slot-detectors/graphql.ts`
+- Parse tagged template literals (`gql\`...\``) for field selections
+- Parse `.graphql`/`.gql` files
+- Match query names to consumer access patterns
+- SlotKind: `graphql`
+
+### Task 30: tRPC Procedure Detector
+**Files:** Create `src/core/ingestion/state-slot-detectors/trpc.ts`
+- Detect `trpc.router({ ... })` procedure definitions with input/output schemas
+- Detect client-side `trpc.procedure.useQuery()` calls
+- Cross-framework detection: tRPC → React Query cache
+- SlotKind: `trpc`
+
+### Task 31: Final Integration Testing
+- Run on 6+ real projects
+- Verify cross-framework detection (tRPC → React Query)
+- Performance benchmarking on large repos
+
+---
+
+## Post-Implementation Process (After Each Phase)
+
+1. Run `/simplify` on the branch
+2. Real-repo validation (fluentiagrant-app, collector, etc.)
+3. Squash duplicate commits
+4. Audit PR body for private project references
+5. Push to fork and create PRs

--- a/docs/superpowers/specs/2026-03-26-data-shape-tracking-design.md
+++ b/docs/superpowers/specs/2026-03-26-data-shape-tracking-design.md
@@ -1,0 +1,248 @@
+# Data-Shape Tracking for GitNexus
+
+**Date:** 2026-03-26
+**Status:** Approved
+**Approach:** Layered Hybrid (AST base + optional TS type pass)
+
+## Problem
+
+GitNexus tracks symbol call graphs but has no visibility into runtime data shapes. Two hooks sharing a React Query cache key like `['vendor-patterns', slug]` appear as independent functions in the graph — GitNexus cannot detect that one stores `{total: 42}` while the other expects `VendorPattern[]` from the same cache slot. This class of bug is runtime-only, produces no type errors, and is extremely hard to find manually.
+
+## Scope
+
+Full end-to-end data-flow shape tracking: API response → cache/store → consumer component, detecting mismatches at any boundary.
+
+### Framework Coverage (all phases)
+
+| # | Framework/Pattern | Phase |
+|---|-------------------|-------|
+| 1 | React Query / TanStack Query | 1 |
+| 2 | SWR | 1 |
+| 3 | API route responses (existing, extended) | 2 |
+| 4 | Fetch/axios consumers (existing, chained) | 2 |
+| 5 | React Context | 3 |
+| 6 | Redux / Zustand | 3 |
+| 7 | Custom hook chains | 4 |
+| 8 | GraphQL query/fragment shapes | 4 |
+| 9 | tRPC procedure input/output | 4 |
+
+## Graph Model
+
+### New Node: `StateSlot`
+
+Represents any shared intermediate state that has producers and consumers.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | string | Human-readable identifier (e.g., `['vendor-patterns', slug]`, `VendorContext`, `store.auth`) |
+| `slotKind` | enum | `react-query` \| `swr` \| `react-context` \| `redux` \| `zustand` \| `trpc` \| `graphql` \| `custom-hook` |
+| `cacheKey` | string? | Literal or pattern of the cache/state key |
+| `filePath` | string | File where the slot is first defined/configured |
+
+### New Edge: `PRODUCES` (Function/Method → StateSlot)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `keys` | string[] | Top-level keys this producer writes |
+| `confidence` | enum | `type-checked` \| `ast-literal` \| `heuristic` |
+| `sourceType` | string? | Raw TS type annotation if available |
+
+### New Edge: `CONSUMES` (Function/Method → StateSlot)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `accessedKeys` | string[] | Properties this consumer reads |
+| `confidence` | enum | `type-checked` \| `ast-literal` \| `heuristic` |
+
+### Mismatch Detection
+
+A mismatch exists when a StateSlot has PRODUCES edges with different `keys`, or when a CONSUMES edge's `accessedKeys` references keys not present in any PRODUCES edge. Queryable in one Cypher hop — no extra joins needed.
+
+## Detection Pipeline
+
+### Phase 3.7: State Slot Detection (new)
+
+Runs per-file after route detection (3.5) and tool detection (3.6). Each detector is a standalone exported function returning `ExtractedStateSlot[]`.
+
+| Detector | What it finds | How |
+|----------|--------------|-----|
+| `react-query` | `useQuery`, `useMutation`, `useInfiniteQuery`, `useSuspenseQuery` | AST: match call expression, extract `queryKey` array literal, extract `queryFn` reference |
+| `swr` | `useSWR`, `useSWRMutation` | AST: first argument is cache key (string or array) |
+| `react-context` | `createContext()` → `useContext()` | AST: track default value shape, Provider value prop shape, useContext access patterns |
+| `queryClient-mutations` | `queryClient.setQueryData`, `setQueriesData`, `invalidateQueries` | AST: member call on queryClient, extract first arg as cache key |
+| `redux` | `createSlice` → `useSelector` | AST: slice initialState shape → selector return access patterns |
+| `zustand` | `create()` store → `useStore(selector)` | AST: store factory shape → selector access patterns |
+| `custom-hook-chain` | Hook A returns shape, Hook B wraps A and reshapes | Depends on Phase 3.7.1 wrapper resolution; compare return shapes across CALLS edges |
+| `trpc` | `trpc.router` → `trpc.procedure.useQuery` | AST: router input/output schemas → client-side access |
+| `graphql` | Query/fragment field selections | AST: parse tagged template literals or .gql files for field names |
+
+### Phase 3.7.1: Wrapper Hook Resolution (new)
+
+After state slots are extracted, trace through wrapper hooks:
+- If `useVendorPatterns(slug)` has a CALLS edge to a function containing `useQuery({queryKey: ...})`, propagate the cache key up to the wrapper
+- Max depth: 2 levels (wrapper → wrapper → actual query call)
+- Connects consumers of wrapper hooks to the underlying StateSlot
+
+### Phase 3.8: Shape Inference (new)
+
+Two layers with tiered confidence:
+
+**AST layer (all languages):**
+- Object literal keys in return statements / queryFn bodies
+- Destructuring patterns at consumer sites
+- Property access chains (`.data.patterns`, `.total`)
+- Prefix-match cache keys — flag shared prefixes even if full keys differ
+
+**TS type layer (opt-in, TypeScript only):**
+- Generic type arguments: `useQuery<VendorPattern[]>` → shape is `VendorPattern[]`
+- Type alias resolution (one level): `type VendorResponse = { patterns: VendorPattern[], total: number }` → keys `["patterns", "total"]`
+- `as` assertions: `data as VendorPattern[]`
+
+Confidence tiers: `type-checked` > `ast-literal` > `heuristic`
+
+### Phase 3.8.1: Route-to-Cache Chaining (new)
+
+If a queryFn contains a fetch() that already has a FETCHES edge to a Route node, the Route's `responseKeys` become the StateSlot's produced shape. Reuses existing infrastructure — just wiring data through new StateSlot nodes.
+
+### Detection Boosters
+
+These techniques maximize catch rate beyond basic detection:
+
+1. **Prefix-match cache keys** — two hooks with `['vendor-patterns', slug]` and `['vendor-patterns', id]` share static prefix `'vendor-patterns'`. Flag as potential collision even if variable portions differ.
+2. **Wrapper hook tracing** — follow CALLS edges through custom hooks to find underlying cache keys (2 levels max).
+3. **queryClient.setQueryData tracking** — detect programmatic cache mutations as PRODUCES edges.
+4. **Route-to-cache chaining** — reuse existing Route responseKeys as produced shapes when queryFn fetches a known route.
+5. **Suspicious flagging** — same cache key prefix + different access patterns = `suspicious` verdict even at heuristic confidence. Don't require proof of mismatch.
+6. **Context default + Provider tracking** — both createContext default value and Provider value prop are AST-visible shape sources.
+
+### Estimated Detection Rate
+
+| Codebase type | Estimate |
+|--------------|----------|
+| Well-typed TypeScript | ~80-85% |
+| Loosely-typed JavaScript | ~50-55% |
+
+### Known Limitations
+
+- **Dynamic cache keys built programmatically** (e.g., `getQueryKey('vendor', slug)`) — cannot resolve function return to literal
+- **Shapes hidden behind deep call chains** (3+ levels) — AST sees function reference, not eventual shape
+- **Runtime-conditional shapes** — static analysis cannot model server-side branching
+- **Unbound generics** (`useQuery<T>` where T is a type parameter) — cannot resolve without call-site context
+- **queryClient mutations across distant files** — requires cross-file queryClient instance tracking (v2 target)
+
+### Integration with Existing Pipeline Phases
+
+| Existing phase | Change |
+|---|---|
+| Phase 3 (parse worker) | Add tree-sitter queries for useQuery, useSWR, createContext, queryClient.*, createSlice, create() store patterns |
+| Phase 3.5 (route registry) | No change — Route nodes stay as-is |
+| Phase 6 (processes) | StateSlot nodes connected to execution flows via producer/consumer functions |
+
+## MCP Tool Layer
+
+### New Tool: `data_flow`
+
+Full picture of data flow through state slots with mismatch detection.
+
+**Input:**
+| Param | Type | Description |
+|-------|------|-------------|
+| `slug` | string | Repository slug |
+| `query` | string? | Filter by cache key, context name, or slice name |
+| `slotKind` | string? | Filter by kind (react-query, redux, etc.) |
+| `mismatchesOnly` | bool? | Only show slots with shape conflicts (default: false) |
+
+**Output per StateSlot:**
+- Cache key / state identifier
+- Producers: function name, file, shape keys, confidence
+- Consumers: function name, file, accessed keys, confidence
+- Mismatch verdict: `ok` | `suspicious` | `conflict` with explanation
+- Linked execution flows (via producer/consumer STEP_IN_PROCESS edges)
+
+### Extensions to Existing Tools
+
+| Tool | Change |
+|------|--------|
+| `shape_check` | Add StateSlot PRODUCES vs CONSUMES comparison. If a Route feeds into a queryFn → StateSlot, trace the full chain. |
+| `api_impact` | Add "State Layer" section: for each route's consumers, if consumer is a queryFn, show the StateSlot and downstream mismatches. Include in risk assessment. |
+| `impact` | When BFS hits a function with PRODUCES edge, follow through to all CONSUMES consumers as additional impact targets. |
+| `context` | Include PRODUCES/CONSUMES edges to StateSlots in 360-degree view alongside CALLS/IMPORTS. |
+
+### Example Output
+
+```
+data_flow --slug fluentiagrant-app --mismatchesOnly true
+
+StateSlot: react-query ['vendor-patterns', slug]
+  Producers:
+    useVendorPatterns()     → keys: [patterns, total, page]  (ast-literal)
+    useVendorPatternCount() → keys: [total]                  (ast-literal)
+  Consumers:
+    VendorList component    → accesses: [patterns, page]     (heuristic)
+    VendorStats component   → accesses: [total]              (heuristic)
+
+  ⚠ CONFLICT: Two producers write different shapes to same cache key.
+    useVendorPatterns returns {patterns, total, page}
+    useVendorPatternCount returns {total}
+    Risk: Consumer expecting array gets object, or vice versa.
+```
+
+## Implementation Phases
+
+### Phase 1 — Foundation
+- StateSlot node type: graph types, LadybugDB schema, CSV generator
+- PRODUCES and CONSUMES relationship types
+- React Query + SWR detectors (items 1-2)
+- Prefix-match cache key comparison
+- AST shape inference (object literals, destructuring, property access)
+- Basic `data_flow` MCP tool
+- Seed-based test fixtures for cache key collision scenarios
+
+### Phase 2 — TypeScript Type Pass + Route Chaining
+- Optional TS compiler API integration for generic type extraction
+- Route-to-cache chaining (connect existing FETCHES → StateSlot)
+- Wrapper hook resolution (trace through 2 levels)
+- queryClient.setQueryData detection
+- Extend `shape_check` and `api_impact` with state layer
+- Real-repo validation: fluentiagrant-app
+
+### Phase 3 — React Context + Redux/Zustand (items 5-6)
+- createContext → Provider → useContext detection
+- Redux createSlice → useSelector detection
+- Zustand store → selector detection
+- Extend `impact` and `context` tools
+- Real-repo validation on projects using these patterns
+
+### Phase 4 — Custom Hooks + GraphQL + tRPC (items 7-9)
+- Custom hook chain shape tracking
+- GraphQL query/fragment field extraction
+- tRPC procedure input/output tracking
+- Cross-framework detection (e.g., tRPC response → React Query cache)
+
+## Testing Strategy
+
+### Seed-Based Tests (per detector)
+- Fixture files with known cache key collisions → assert StateSlot created, edges exist, mismatch detected
+- Fixture files with NO collision → assert no false positive
+- Break a fixture to confirm test catches the change
+
+### Pipeline-Level Tests
+- Full pipeline on synthetic mini-project with React Query, Context, Redux patterns
+- Assert node/edge counts and mismatch verdicts
+
+### Real-Repo Validation
+- fluentiagrant-app (React Query — original bug)
+- collector (PHP — no state slots expected, verify zero false positives)
+- kurz-spj-sk (Next.js — likely React Query patterns)
+- At least 6 projects total
+
+### MCP Tool Smoke Tests
+- After each tool change, invoke via MCP and verify output format
+
+## Post-Implementation Process (every phase)
+
+1. Run /simplify on the branch
+2. Real-repo validation (fluentiagrant-app, collector, etc.)
+3. Squash duplicate commits
+4. Audit PR body for private project references
+5. Push to fork and create PRs

--- a/gitnexus/src/core/graph/types.ts
+++ b/gitnexus/src/core/graph/types.ts
@@ -35,7 +35,8 @@ export type NodeLabel =
   | 'Template'
   | 'Section'
   | 'Route'        // API route endpoint (e.g., /api/grants)
-  | 'Tool';        // MCP tool definition
+  | 'Tool'         // MCP tool definition
+  | 'StateSlot';   // Shared state: React Query cache, Context, Redux slice, etc.
 
 
 import { SupportedLanguages } from '../../config/supported-languages.js';
@@ -77,6 +78,9 @@ export type NodeProperties = {
   errorKeys?: string[],
   // Middleware wrapper chain (outermost first): ['withRateLimit', 'withCSRF', 'withAuth']
   middleware?: string[],
+  // StateSlot-specific
+  slotKind?: string;       // react-query | swr | react-context | redux | zustand | trpc | graphql | custom-hook
+  cacheKey?: string;        // Literal or pattern of cache/state key
 }
 
 export type RelationshipType =
@@ -100,6 +104,8 @@ export type RelationshipType =
   | 'HANDLES_TOOL'   // Function/File → Tool (handler implements this tool)
   | 'ENTRY_POINT_OF'  // Route/Tool → Process (this endpoint starts this execution flow)
   | 'WRAPS'           // Function → Function (middleware wrapper chain) — Reserved: future middleware graph traversal (not yet emitted)
+  | 'PRODUCES'        // Function/Method -> StateSlot (writes data into shared state)
+  | 'CONSUMES';       // Function/Method -> StateSlot (reads data from shared state)
 
 export interface GraphNode {
   id:  string,

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -19,6 +19,9 @@ import { processHeritage, processHeritageFromExtracted } from './heritage-proces
 import { computeMRO } from './mro-processor.js';
 import { processCommunities } from './community-processor.js';
 import { processProcesses } from './process-processor.js';
+import { detectStateSlots } from './state-slot-detectors/index.js';
+import type { ExtractedStateSlot } from './state-slot-detectors/index.js';
+import { processStateSlots } from './state-slot-processor.js';
 import { createResolutionContext } from './resolution-context.js';
 import { createASTCache } from './ast-cache.js';
 import { PipelineProgress, PipelineResult } from '../../types/pipeline.js';
@@ -508,6 +511,7 @@ async function runChunkedParseAndResolve(
   allExtractedRoutes: ExtractedRoute[];
   allDecoratorRoutes: ExtractedDecoratorRoute[];
   allToolDefs: ExtractedToolDef[];
+  allStateSlots: ExtractedStateSlot[];
 }> {
   const symbolTable = ctx.symbols;
 
@@ -628,6 +632,8 @@ async function runChunkedParseAndResolve(
   const allDecoratorRoutes: ExtractedDecoratorRoute[] = [];
   // Accumulate MCP/RPC tool definitions (@mcp.tool(), @app.tool(), etc.)
   const allToolDefs: ExtractedToolDef[] = [];
+  // Accumulate state slot detections for Phase 3.7
+  const allStateSlots: ExtractedStateSlot[] = [];
 
   try {
     for (let chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
@@ -756,6 +762,11 @@ async function runChunkedParseAndResolve(
         if (chunkWorkerData.toolDefs?.length) {
           allToolDefs.push(...chunkWorkerData.toolDefs);
         }
+        // Detect state slots (React Query, SWR, etc.) from file contents
+        for (const [filePath, content] of chunkContents) {
+          const slots = detectStateSlots(content, filePath);
+          if (slots.length > 0) allStateSlots.push(...slots);
+        }
       } else {
         await processImports(graph, chunkFiles, astCache, ctx, undefined, repoPath, allPaths);
         sequentialChunkPaths.push(chunkPaths);
@@ -847,7 +858,7 @@ async function runChunkedParseAndResolve(
   importCtx.index = EMPTY_INDEX; // Release suffix index memory (~30MB for large repos)
   importCtx.normalizedFileList = [];
 
-  return { exportedTypeMap, allFetchCalls, allExtractedRoutes, allDecoratorRoutes, allToolDefs };
+  return { exportedTypeMap, allFetchCalls, allExtractedRoutes, allDecoratorRoutes, allToolDefs, allStateSlots };
 }
 
 /**
@@ -1069,7 +1080,7 @@ export const runPipelineFromRepo = async (
     const { scannedFiles, allPaths, totalFiles } = await runScanAndStructure(repoPath, graph, onProgress);
 
     // Phase 3+4: Chunked parse + resolve (imports, calls, heritage, routes)
-    const { exportedTypeMap, allFetchCalls, allExtractedRoutes, allDecoratorRoutes, allToolDefs } = await runChunkedParseAndResolve(
+    const { exportedTypeMap, allFetchCalls, allExtractedRoutes, allDecoratorRoutes, allToolDefs, allStateSlots } = await runChunkedParseAndResolve(
       graph, ctx, scannedFiles, allPaths, totalFiles, repoPath, pipelineStart, onProgress,
     );
 
@@ -1240,6 +1251,22 @@ export const runPipelineFromRepo = async (
 
       if (isDev) {
         console.log(`🔧 Tool registry: ${toolDefs.length} tools detected`);
+      }
+    }
+
+    // ── Phase 3.7: State Slot Detection ────────────────────────────────────────
+    if (allStateSlots.length > 0) {
+      onProgress({
+        phase: 'state-slots',
+        percent: 89,
+        message: `Processing ${allStateSlots.length} state slot(s)...`,
+        stats: { filesProcessed: totalFiles, totalFiles, nodesCreated: graph.nodeCount },
+      });
+
+      const slotResult = processStateSlots(allStateSlots, graph);
+
+      if (isDev) {
+        console.log(`🗄️ State slots: ${slotResult.slotsCreated} created, ${slotResult.producesEdges} PRODUCES, ${slotResult.consumesEdges} CONSUMES, ${slotResult.overlapWarnings.length} overlap warnings`);
       }
     }
 

--- a/gitnexus/src/core/ingestion/shape-inference.ts
+++ b/gitnexus/src/core/ingestion/shape-inference.ts
@@ -1,0 +1,184 @@
+/**
+ * AST-based shape inference utilities.
+ *
+ * Extracts data shape information from source code using regex patterns
+ * (not tree-sitter — these run on raw text for flexibility across contexts).
+ */
+
+/** Keys that are method-like and should be filtered from property access results */
+const ACCESS_BLOCKLIST = new Set([
+  'length', 'toString', 'valueOf', 'hasOwnProperty', 'constructor',
+  'push', 'pop', 'shift', 'unshift', 'slice', 'splice', 'map', 'filter',
+  'reduce', 'forEach', 'find', 'findIndex', 'includes', 'indexOf',
+  'keys', 'values', 'entries', 'then', 'catch', 'finally',
+  'json', 'text', 'blob', 'arrayBuffer', 'formData', 'clone', 'ok', 'status',
+]);
+
+/**
+ * Extract top-level keys from object literals in .json() or return statements.
+ * Uses brace-depth counting (same approach as response-shapes.ts).
+ */
+export function extractObjectLiteralKeys(code: string): string[] {
+  const keys: string[] = [];
+  const jsonPattern = /\.json\s*\(\s*\{|return\s+\{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = jsonPattern.exec(code)) !== null) {
+    const braceStart = code.indexOf('{', match.index);
+    if (braceStart === -1) continue;
+
+    let depth = 0;
+    let keyStart = -1;
+    for (let i = braceStart; i < code.length; i++) {
+      const ch = code[i];
+      if (ch === '{') {
+        depth++;
+        if (depth === 1) keyStart = i + 1;
+      } else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          // Check for trailing shorthand before closing brace
+          const segment = code.slice(keyStart, i).trim();
+          if (segment && /^\w+$/.test(segment)) {
+            keys.push(segment);
+          }
+          break;
+        }
+      } else if (depth === 1 && ch === ':') {
+        const beforeColon = code.slice(keyStart, i).trim();
+        const keyMatch = beforeColon.match(/(?:['"]([^'"]+)['"]|(\w+))\s*$/);
+        if (keyMatch) {
+          keys.push(keyMatch[1] || keyMatch[2]);
+        }
+      } else if (depth === 1 && ch === ',') {
+        // Shorthand property: { patterns, total }
+        const segment = code.slice(keyStart, i).trim();
+        if (segment && /^\w+$/.test(segment)) {
+          keys.push(segment);
+        }
+        keyStart = i + 1;
+      }
+    }
+  }
+
+  return [...new Set(keys)];
+}
+
+/**
+ * Extract destructured keys from variable declarations.
+ * Matches: const { key1, key2 } = data/response/result/res.json()
+ * Handles nested braces by brace-depth counting to find the outermost block.
+ */
+export function extractDestructuredKeys(code: string): string[] {
+  const keys: string[] = [];
+  const startPattern = /const\s+\{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = startPattern.exec(code)) !== null) {
+    const braceStart = code.indexOf('{', match.index);
+    if (braceStart === -1) continue;
+
+    // Collect the content of the outermost braces using depth counting
+    let depth = 0;
+    let innerStart = braceStart + 1;
+    let innerEnd = -1;
+    for (let i = braceStart; i < code.length; i++) {
+      const ch = code[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          innerEnd = i;
+          break;
+        }
+      }
+    }
+    if (innerEnd === -1) continue;
+
+    const inner = code.slice(innerStart, innerEnd);
+
+    // Split by top-level commas (ignoring commas inside nested braces)
+    const parts: string[] = [];
+    let partStart = 0;
+    let d = 0;
+    for (let i = 0; i < inner.length; i++) {
+      const ch = inner[i];
+      if (ch === '{') d++;
+      else if (ch === '}') d--;
+      else if (ch === ',' && d === 0) {
+        parts.push(inner.slice(partStart, i));
+        partStart = i + 1;
+      }
+    }
+    parts.push(inner.slice(partStart));
+
+    for (const part of parts) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      const keyMatch = trimmed.match(/^(\w+)/);
+      if (keyMatch && keyMatch[1] !== 'rest') {
+        keys.push(keyMatch[1]);
+      }
+    }
+  }
+
+  return [...new Set(keys)];
+}
+
+/**
+ * Extract property access keys from dot-access and optional chaining patterns.
+ * Matches: data.key, response?.key, result.key
+ * Also matches second-level access: result.data?.key, response.data.key
+ */
+export function extractPropertyAccessKeys(code: string): string[] {
+  const keys: string[] = [];
+  const dataVarNames = /(?:data|response|result|res|json|payload|body|state|value)/;
+  // Level-1: data.key or data?.key
+  const pattern = new RegExp(
+    `(?:${dataVarNames.source})\\??\\.([a-zA-Z_]\\w*)`,
+    'g',
+  );
+  // Level-2: result.data?.key or result.data.key (data-var followed by .word?.key)
+  const pattern2 = new RegExp(
+    `(?:${dataVarNames.source})\\??\\.\\w+\\??\\.([a-zA-Z_]\\w*)`,
+    'g',
+  );
+  let match: RegExpExecArray | null;
+
+  for (const pat of [pattern, pattern2]) {
+    while ((match = pat.exec(code)) !== null) {
+      const key = match[1];
+      if (!ACCESS_BLOCKLIST.has(key)) {
+        keys.push(key);
+      }
+    }
+  }
+
+  return [...new Set(keys)];
+}
+
+/**
+ * Extract static prefix from a cache key expression.
+ */
+export function cacheKeyPrefix(cacheKey: string): string {
+  const arrayMatch = cacheKey.match(/\[\s*['"]([^'"]+)['"]/);
+  if (arrayMatch) return arrayMatch[1];
+
+  const stringMatch = cacheKey.match(/^['"]([^'"]+)['"]/);
+  if (stringMatch) return stringMatch[1];
+
+  const templateMatch = cacheKey.match(/^`([^$`]+)/);
+  if (templateMatch) return templateMatch[1];
+
+  return cacheKey;
+}
+
+/**
+ * Check if two cache keys potentially overlap (could point to same slot).
+ * Uses prefix matching — if static prefixes match, keys might collide.
+ */
+export function cacheKeysOverlap(key1: string, key2: string): boolean {
+  const prefix1 = cacheKeyPrefix(key1);
+  const prefix2 = cacheKeyPrefix(key2);
+  return prefix1 === prefix2 && prefix1.length > 0;
+}

--- a/gitnexus/src/core/ingestion/state-slot-detectors/index.ts
+++ b/gitnexus/src/core/ingestion/state-slot-detectors/index.ts
@@ -1,0 +1,32 @@
+/**
+ * State slot detection orchestrator.
+ *
+ * Runs all registered detectors against file content and returns
+ * merged ExtractedStateSlot results.
+ */
+
+import type { ExtractedStateSlot } from './types.js';
+import { detectReactQuerySlots } from './react-query.js';
+import { detectSwrSlots } from './swr.js';
+
+export type { ExtractedStateSlot, SlotKind, ShapeConfidence, ExtractedStateSlotProducer, ExtractedStateSlotConsumer } from './types.js';
+
+type Detector = (code: string, filePath: string) => ExtractedStateSlot[];
+
+const DETECTORS: Detector[] = [
+  detectReactQuerySlots,
+  detectSwrSlots,
+  // Phase 3: detectReactContextSlots, detectReduxSlots, detectZustandSlots
+  // Phase 4: detectTRPCSlots, detectGraphQLSlots
+];
+
+/**
+ * Run all state slot detectors on a file and return merged results.
+ */
+export function detectStateSlots(code: string, filePath: string): ExtractedStateSlot[] {
+  const results: ExtractedStateSlot[] = [];
+  for (const detector of DETECTORS) {
+    results.push(...detector(code, filePath));
+  }
+  return results;
+}

--- a/gitnexus/src/core/ingestion/state-slot-detectors/react-query.ts
+++ b/gitnexus/src/core/ingestion/state-slot-detectors/react-query.ts
@@ -1,0 +1,183 @@
+/**
+ * React Query state slot detector.
+ *
+ * Detects useQuery, useMutation, useInfiniteQuery, useSuspenseQuery calls
+ * and extracts cache key, enclosing function name, and consumer access patterns.
+ */
+
+import type { ExtractedStateSlot, ExtractedStateSlotConsumer, ExtractedStateSlotProducer } from './types.js';
+import { extractDestructuredKeys, extractPropertyAccessKeys } from '../shape-inference.js';
+
+/** The React Query hook names this detector handles */
+const REACT_QUERY_HOOKS = ['useQuery', 'useMutation', 'useInfiniteQuery', 'useSuspenseQuery'] as const;
+type ReactQueryHook = typeof REACT_QUERY_HOOKS[number];
+
+/** The option key used to identify cache key per hook type */
+const CACHE_KEY_OPTION: Record<ReactQueryHook, string> = {
+  useQuery: 'queryKey',
+  useMutation: 'mutationKey',
+  useInfiniteQuery: 'queryKey',
+  useSuspenseQuery: 'queryKey',
+};
+
+/**
+ * Extract the cache key array literal from the options object text.
+ * Matches `queryKey: [...]` or `mutationKey: [...]` patterns.
+ * Uses bracket-depth counting to capture the full array.
+ */
+function extractCacheKey(optionsText: string, keyName: string): string | null {
+  const keyPattern = new RegExp(`${keyName}\\s*:\\s*\\[`);
+  const match = keyPattern.exec(optionsText);
+  if (!match) return null;
+
+  const bracketStart = optionsText.indexOf('[', match.index);
+  if (bracketStart === -1) return null;
+
+  let depth = 0;
+  for (let i = bracketStart; i < optionsText.length; i++) {
+    const ch = optionsText[i];
+    if (ch === '[') depth++;
+    else if (ch === ']') {
+      depth--;
+      if (depth === 0) {
+        return optionsText.slice(bracketStart, i + 1);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the enclosing function name for a given position in source text.
+ * Walks backwards to find the nearest function/arrow/method declaration.
+ */
+function findEnclosingFunctionName(source: string, pos: number): string {
+  const before = source.slice(0, pos);
+
+  // Match function declarations: function Foo(, async function Foo(
+  const funcDecl = /(?:async\s+)?function\s+(\w+)\s*\(/g;
+  // Match arrow functions assigned to variables: const foo = (...) =>
+  const arrowFunc = /(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?(?:\([^)]*\)|[\w]+)\s*=>/g;
+  // Match method definitions: foo(, async foo(
+  const methodDef = /(?:async\s+)?(\w+)\s*\([^)]*\)\s*\{/g;
+
+  let lastMatch: { name: string; index: number } | null = null;
+
+  for (const pattern of [funcDecl, arrowFunc, methodDef]) {
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(before)) !== null) {
+      if (!lastMatch || m.index > lastMatch.index) {
+        const name = m[1];
+        // Skip keywords that look like function names
+        if (!['if', 'for', 'while', 'switch', 'catch', 'return'].includes(name)) {
+          lastMatch = { name, index: m.index };
+        }
+      }
+    }
+  }
+
+  return lastMatch?.name ?? '<anonymous>';
+}
+
+/**
+ * Get the line number (1-based) for a given character position in source text.
+ */
+function lineNumberAt(source: string, pos: number): number {
+  return source.slice(0, pos).split('\n').length;
+}
+
+/**
+ * Extract the options object text for a React Query hook call.
+ * Starting from the opening `(` of the call, finds the matching `)`.
+ * Returns the text inside the parentheses.
+ */
+function extractCallOptions(source: string, openParenPos: number): string | null {
+  let depth = 0;
+  for (let i = openParenPos; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openParenPos + 1, i);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Detect React Query slots in a source file.
+ *
+ * For each useQuery / useMutation / useInfiniteQuery / useSuspenseQuery call:
+ * - Extracts queryKey or mutationKey as the cache key
+ * - Finds the enclosing function name (producer + consumer function name)
+ * - Extracts consumer accessed keys from destructuring and property access
+ *   in the surrounding function body
+ *
+ * @param source  Raw source text of the file
+ * @param filePath  Absolute path to the file (used for slot metadata)
+ * @returns Array of ExtractedStateSlot records
+ */
+export function detectReactQuerySlots(source: string, filePath: string): ExtractedStateSlot[] {
+  const slots: ExtractedStateSlot[] = [];
+
+  for (const hook of REACT_QUERY_HOOKS) {
+    const hookPattern = new RegExp(`\\b${hook}\\s*\\(`, 'g');
+    let match: RegExpExecArray | null;
+
+    while ((match = hookPattern.exec(source)) !== null) {
+      const callStart = match.index;
+      const openParenPos = callStart + match[0].length - 1; // position of '('
+
+      const optionsText = extractCallOptions(source, openParenPos);
+      if (!optionsText) continue;
+
+      const keyName = CACHE_KEY_OPTION[hook];
+      const cacheKey = extractCacheKey(optionsText, keyName);
+      if (!cacheKey) continue;
+
+      const lineNumber = lineNumberAt(source, callStart);
+      const enclosingFn = findEnclosingFunctionName(source, callStart);
+
+      // Determine the surrounding function body for consumer key extraction.
+      // Use a 1500-char window after the hook call as an approximation.
+      const windowEnd = Math.min(source.length, callStart + 1500);
+      const surroundingBody = source.slice(callStart, windowEnd);
+
+      const destructuredKeys = extractDestructuredKeys(surroundingBody);
+      const propertyKeys = extractPropertyAccessKeys(surroundingBody);
+      const accessedKeys = [...new Set([...destructuredKeys, ...propertyKeys])];
+
+      const producer: ExtractedStateSlotProducer = {
+        functionName: enclosingFn,
+        filePath,
+        lineNumber,
+        keys: [],
+        confidence: 'heuristic',
+      };
+
+      const consumer: ExtractedStateSlotConsumer = {
+        functionName: enclosingFn,
+        filePath,
+        lineNumber,
+        accessedKeys,
+        confidence: 'heuristic',
+      };
+
+      const slot: ExtractedStateSlot = {
+        name: cacheKey,
+        slotKind: 'react-query',
+        cacheKey,
+        filePath,
+        lineNumber,
+        producers: [producer],
+        consumers: accessedKeys.length > 0 ? [consumer] : [],
+      };
+
+      slots.push(slot);
+    }
+  }
+
+  return slots;
+}

--- a/gitnexus/src/core/ingestion/state-slot-detectors/swr.ts
+++ b/gitnexus/src/core/ingestion/state-slot-detectors/swr.ts
@@ -1,0 +1,166 @@
+/**
+ * SWR state slot detector.
+ *
+ * Detects `useSWR` and `useSWRMutation` calls and extracts cache keys,
+ * enclosing function names, and consumer access patterns.
+ */
+
+import type { ExtractedStateSlot } from './types.js';
+import { extractPropertyAccessKeys, extractDestructuredKeys } from '../shape-inference.js';
+
+/**
+ * Extract the first argument (cache key) text from a useSWR/useSWRMutation call.
+ * Handles string literals, array literals, and template literals.
+ *
+ * @param code - Full file source
+ * @param callStart - Index of the opening paren of the call
+ */
+function extractFirstArg(code: string, callStart: number): string {
+  let depth = 0;
+  let argStart = -1;
+  let i = callStart;
+
+  // Find the opening paren
+  while (i < code.length && code[i] !== '(') i++;
+  if (i >= code.length) return '';
+
+  i++; // skip '('
+  // Skip whitespace
+  while (i < code.length && /\s/.test(code[i])) i++;
+
+  argStart = i;
+
+  // Walk until we hit a top-level comma or closing paren
+  let inString: string | null = null;
+  let inTemplate = false;
+  let templateDepth = 0;
+
+  for (; i < code.length; i++) {
+    const ch = code[i];
+
+    if (inString) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === inString) inString = null;
+      continue;
+    }
+
+    if (inTemplate) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === '`') { inTemplate = false; continue; }
+      if (ch === '$' && code[i + 1] === '{') { templateDepth++; i++; continue; }
+      if (ch === '}' && templateDepth > 0) { templateDepth--; continue; }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") { inString = ch; continue; }
+    if (ch === '`') { inTemplate = true; continue; }
+    if (ch === '(' || ch === '[' || ch === '{') { depth++; continue; }
+    if (ch === ')' || ch === ']' || ch === '}') {
+      if (depth === 0) break; // end of call
+      depth--;
+      continue;
+    }
+    if (ch === ',' && depth === 0) break; // end of first arg
+  }
+
+  return code.slice(argStart, i).trim();
+}
+
+/**
+ * Find the name of the enclosing function for the given position in source.
+ */
+function findEnclosingFunction(code: string, position: number): string {
+  const before = code.slice(0, position);
+
+  // Try: function Name( or async function Name(
+  const funcDecl = [...before.matchAll(/(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/g)];
+  if (funcDecl.length > 0) {
+    return funcDecl[funcDecl.length - 1][1];
+  }
+
+  // Try: const Name = ( or const Name = async (
+  const arrowDecl = [...before.matchAll(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(?/g)];
+  if (arrowDecl.length > 0) {
+    return arrowDecl[arrowDecl.length - 1][1];
+  }
+
+  return '<anonymous>';
+}
+
+/**
+ * Get a window of source code around a position for consumer analysis.
+ */
+function getContextWindow(code: string, position: number, chars = 800): string {
+  const start = Math.max(0, position - 100);
+  const end = Math.min(code.length, position + chars);
+  return code.slice(start, end);
+}
+
+/**
+ * Count newlines up to a position to get 1-based line number.
+ */
+function lineNumberAt(code: string, position: number): number {
+  let count = 1;
+  for (let i = 0; i < position; i++) {
+    if (code[i] === '\n') count++;
+  }
+  return count;
+}
+
+/**
+ * Detect all useSWR and useSWRMutation calls in a source file and return
+ * extracted state slots.
+ *
+ * @param code - File source text
+ * @param filePath - Absolute path of the file (used in output)
+ */
+export function detectSwrSlots(code: string, filePath: string): ExtractedStateSlot[] {
+  const slots: ExtractedStateSlot[] = [];
+
+  // Match useSWR( and useSWRMutation(
+  const pattern = /\buseSWR(Mutation)?\s*(?:<[^>]*>)?\s*\(/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(code)) !== null) {
+    const isMutation = Boolean(match[1]);
+    const callIndex = match.index;
+
+    const cacheKey = extractFirstArg(code, callIndex);
+    if (!cacheKey) continue;
+
+    const lineNumber = lineNumberAt(code, callIndex);
+    const enclosingFn = findEnclosingFunction(code, callIndex);
+    const contextWindow = getContextWindow(code, callIndex);
+
+    // Collect consumer access patterns from the surrounding context
+    const accessedKeys = [
+      ...extractPropertyAccessKeys(contextWindow),
+      ...extractDestructuredKeys(contextWindow),
+    ];
+    const uniqueKeys = [...new Set(accessedKeys)];
+
+    const slot: ExtractedStateSlot = {
+      name: cacheKey,
+      slotKind: 'swr',
+      cacheKey,
+      filePath,
+      lineNumber,
+      producers: [],
+      consumers: uniqueKeys.length > 0
+        ? [
+            {
+              functionName: enclosingFn,
+              filePath,
+              lineNumber,
+              accessedKeys: uniqueKeys,
+              confidence: 'heuristic',
+            },
+          ]
+        : [],
+    };
+
+    slots.push(slot);
+  }
+
+  return slots;
+}

--- a/gitnexus/src/core/ingestion/state-slot-detectors/types.ts
+++ b/gitnexus/src/core/ingestion/state-slot-detectors/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared types for state slot detection across frameworks.
+ */
+
+export type SlotKind = 'react-query' | 'swr' | 'react-context' | 'redux' | 'zustand' | 'trpc' | 'graphql' | 'custom-hook';
+
+export type ShapeConfidence = 'type-checked' | 'ast-literal' | 'heuristic';
+
+export interface ExtractedStateSlotProducer {
+  /** Function/method name that produces data into this slot */
+  functionName: string;
+  /** File where the producer lives */
+  filePath: string;
+  /** Line number of the producing call */
+  lineNumber: number;
+  /** Top-level keys this producer writes */
+  keys: string[];
+  /** Confidence tier */
+  confidence: ShapeConfidence;
+  /** Raw TS type annotation if available (e.g. 'VendorPattern[]') */
+  sourceType?: string;
+}
+
+export interface ExtractedStateSlotConsumer {
+  /** Function/method name that consumes data from this slot */
+  functionName: string;
+  /** File where the consumer lives */
+  filePath: string;
+  /** Line number of the consuming call */
+  lineNumber: number;
+  /** Properties this consumer accesses */
+  accessedKeys: string[];
+  /** Confidence tier */
+  confidence: ShapeConfidence;
+}
+
+export interface ExtractedStateSlot {
+  /** Human-readable identifier (e.g. "['vendor-patterns', slug]") */
+  name: string;
+  /** Framework that manages this state */
+  slotKind: SlotKind;
+  /** Literal or pattern of the cache/state key */
+  cacheKey: string;
+  /** File where the slot is first defined/configured */
+  filePath: string;
+  /** Line number of the slot definition */
+  lineNumber: number;
+  /** Functions that write data into this slot */
+  producers: ExtractedStateSlotProducer[];
+  /** Functions that read data from this slot */
+  consumers: ExtractedStateSlotConsumer[];
+}

--- a/gitnexus/src/core/ingestion/state-slot-processor.ts
+++ b/gitnexus/src/core/ingestion/state-slot-processor.ts
@@ -1,0 +1,182 @@
+/**
+ * State Slot Processor (Phase 3.7)
+ *
+ * Converts ExtractedStateSlot data into graph nodes and edges.
+ * - Creates StateSlot nodes (deduplicated by cacheKey)
+ * - Creates PRODUCES edges from producer functions to StateSlot nodes
+ * - Creates CONSUMES edges from consumer functions to StateSlot nodes
+ * - Detects overlapping cache key prefixes and emits warnings
+ */
+
+import type { KnowledgeGraph } from '../graph/types.js';
+import type { ExtractedStateSlot } from './state-slot-detectors/index.js';
+import { generateId } from '../../lib/utils.js';
+import { cacheKeysOverlap } from './shape-inference.js';
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+export interface StateSlotProcessorResult {
+  slotsCreated: number;
+  producesEdges: number;
+  consumesEdges: number;
+  overlapWarnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Confidence mapping
+// ---------------------------------------------------------------------------
+
+const CONFIDENCE_MAP: Record<string, number> = {
+  'type-checked': 1.0,
+  'ast-literal': 0.8,
+  'heuristic': 0.6,
+};
+
+function toConfidence(tier: string): number {
+  return CONFIDENCE_MAP[tier] ?? 0.5;
+}
+
+// ---------------------------------------------------------------------------
+// Function node lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to find a Function/Variable/Const node for the given function name
+ * in the given file. Tries the canonical `generateId` pattern first, then
+ * falls back to iterating graph nodes.
+ */
+function findFunctionNodeId(
+  graph: KnowledgeGraph,
+  filePath: string,
+  functionName: string,
+): string | null {
+  // Fast path: canonical ID patterns used by the pipeline
+  for (const label of ['Function', 'Variable', 'Const'] as const) {
+    const candidateId = generateId(label, `${filePath}:${functionName}`);
+    if (graph.getNode(candidateId)) return candidateId;
+  }
+
+  // Slow path: linear scan
+  for (const node of graph.iterNodes()) {
+    if (
+      (node.label === 'Function' || node.label === 'Variable' || node.label === 'Const' || node.label === 'Method') &&
+      node.properties.name === functionName &&
+      node.properties.filePath === filePath
+    ) {
+      return node.id;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main processor
+// ---------------------------------------------------------------------------
+
+/**
+ * Process extracted state slots into the knowledge graph.
+ *
+ * @param slots   - Flat list of ExtractedStateSlot from all detectors
+ * @param graph   - Mutable knowledge graph to write into
+ * @returns       - Summary counts and any overlap warnings
+ */
+export function processStateSlots(
+  slots: ExtractedStateSlot[],
+  graph: KnowledgeGraph,
+): StateSlotProcessorResult {
+  // --- Step 1: Deduplicate slots by cacheKey ---
+  // Multiple detector results for the same key are merged.
+  const byKey = new Map<string, ExtractedStateSlot>();
+  for (const slot of slots) {
+    const existing = byKey.get(slot.cacheKey);
+    if (!existing) {
+      byKey.set(slot.cacheKey, { ...slot });
+    } else {
+      // Merge producers and consumers from duplicate entries
+      existing.producers = [...existing.producers, ...slot.producers];
+      existing.consumers = [...existing.consumers, ...slot.consumers];
+    }
+  }
+
+  const deduped = Array.from(byKey.values());
+
+  // --- Step 2: Detect cache key prefix overlaps ---
+  const overlapWarnings: string[] = [];
+  const keys = deduped.map(s => s.cacheKey);
+  for (let i = 0; i < keys.length; i++) {
+    for (let j = i + 1; j < keys.length; j++) {
+      if (cacheKeysOverlap(keys[i], keys[j])) {
+        overlapWarnings.push(`Cache key overlap: "${keys[i]}" vs "${keys[j]}"`);
+      }
+    }
+  }
+
+  // --- Step 3: Create nodes and edges ---
+  let slotsCreated = 0;
+  let producesEdges = 0;
+  let consumesEdges = 0;
+
+  for (const slot of deduped) {
+    const slotNodeId = generateId('StateSlot', slot.cacheKey);
+
+    // Create the StateSlot node (idempotent — addNode checks by ID)
+    const slotNodeExists = !!graph.getNode(slotNodeId);
+    graph.addNode({
+      id: slotNodeId,
+      label: 'StateSlot',
+      properties: {
+        name: slot.name,
+        filePath: slot.filePath,
+        startLine: slot.lineNumber,
+        slotKind: slot.slotKind,
+        cacheKey: slot.cacheKey,
+      },
+    });
+    if (!slotNodeExists) slotsCreated++;
+
+    // --- PRODUCES edges ---
+    for (const producer of slot.producers) {
+      const srcId = findFunctionNodeId(graph, producer.filePath, producer.functionName);
+      if (!srcId) continue; // no matching function node in graph
+
+      const keysStr = producer.keys.join(',');
+      const reason = `shape-${producer.confidence}|keys:${keysStr}${producer.sourceType ? `|type:${producer.sourceType}` : ''}`;
+      const edgeId = generateId('PRODUCES', `${srcId}->${slotNodeId}`);
+
+      graph.addRelationship({
+        id: edgeId,
+        sourceId: srcId,
+        targetId: slotNodeId,
+        type: 'PRODUCES',
+        confidence: toConfidence(producer.confidence),
+        reason,
+      });
+      producesEdges++;
+    }
+
+    // --- CONSUMES edges ---
+    for (const consumer of slot.consumers) {
+      const srcId = findFunctionNodeId(graph, consumer.filePath, consumer.functionName);
+      if (!srcId) continue;
+
+      const keysStr = consumer.accessedKeys.join(',');
+      const reason = `shape-${consumer.confidence}|keys:${keysStr}`;
+      const edgeId = generateId('CONSUMES', `${srcId}->${slotNodeId}`);
+
+      graph.addRelationship({
+        id: edgeId,
+        sourceId: srcId,
+        targetId: slotNodeId,
+        type: 'CONSUMES',
+        confidence: toConfidence(consumer.confidence),
+        reason,
+      });
+      consumesEdges++;
+    }
+  }
+
+  return { slotsCreated, producesEdges, consumesEdges, overlapWarnings };
+}

--- a/gitnexus/src/core/lbug/csv-generator.ts
+++ b/gitnexus/src/core/lbug/csv-generator.ts
@@ -247,6 +247,9 @@ export const streamAllCSVsToDisk = async (
   // Tool nodes for MCP tool definitions
   const toolWriter = new BufferedCSVWriter(path.join(csvDir, 'tool.csv'), 'id,name,filePath,description');
 
+  // StateSlot nodes for shared state tracking
+  const stateSlotWriter = new BufferedCSVWriter(path.join(csvDir, 'stateslot.csv'), 'id,name,filePath,slotKind,cacheKey');
+
   // Multi-language node types share the same CSV shape (no isExported column)
   const multiLangHeader = 'id,name,filePath,startLine,endLine,content,description';
   const MULTI_LANG_TYPES = ['Struct', 'Enum', 'Macro', 'Typedef', 'Union', 'Namespace', 'Trait', 'Impl',
@@ -374,6 +377,15 @@ export const streamAllCSVsToDisk = async (
           escapeCSVField((node.properties as any).description || ''),
         ].join(','));
         break;
+      case 'StateSlot':
+        await stateSlotWriter.addRow([
+          escapeCSVField(node.id),
+          escapeCSVField(node.properties.name || ''),
+          escapeCSVField(node.properties.filePath || ''),
+          escapeCSVField((node.properties as any).slotKind || ''),
+          escapeCSVField((node.properties as any).cacheKey || ''),
+        ].join(','));
+        break;
       default: {
         // Code element nodes (Function, Class, Interface, CodeElement)
         const writer = codeWriterMap[node.label];
@@ -411,7 +423,7 @@ export const streamAllCSVsToDisk = async (
   }
 
   // Finish all node writers
-  const allWriters = [fileWriter, folderWriter, functionWriter, classWriter, interfaceWriter, methodWriter, codeElemWriter, communityWriter, processWriter, sectionWriter, routeWriter, toolWriter, ...multiLangWriters.values()];
+  const allWriters = [fileWriter, folderWriter, functionWriter, classWriter, interfaceWriter, methodWriter, codeElemWriter, communityWriter, processWriter, sectionWriter, routeWriter, toolWriter, stateSlotWriter, ...multiLangWriters.values()];
   await Promise.all(allWriters.map(w => w.finish()));
 
   // --- Stream relationship CSV ---
@@ -440,6 +452,7 @@ export const streamAllCSVsToDisk = async (
     ['Section' as NodeTableName, sectionWriter],
     ['Route' as NodeTableName, routeWriter],
     ['Tool' as NodeTableName, toolWriter],
+    ['StateSlot' as NodeTableName, stateSlotWriter],
     ...Array.from(multiLangWriters.entries()).map(([name, w]) => [name as NodeTableName, w] as [NodeTableName, BufferedCSVWriter]),
   ];
   for (const [name, writer] of tableMap) {

--- a/gitnexus/src/core/lbug/schema.ts
+++ b/gitnexus/src/core/lbug/schema.ts
@@ -18,7 +18,8 @@ export const NODE_TABLES = [
   'Struct', 'Enum', 'Macro', 'Typedef', 'Union', 'Namespace', 'Trait', 'Impl',
   'TypeAlias', 'Const', 'Static', 'Property', 'Record', 'Delegate', 'Annotation', 'Constructor', 'Template', 'Module',
   'Route',
-  'Tool'
+  'Tool',
+  'StateSlot'
 ] as const;
 export type NodeTableName = typeof NODE_TABLES[number];
 
@@ -29,7 +30,7 @@ export const REL_TABLE_NAME = 'CodeRelation';
 
 // Valid relation types
 // Note: WRAPS is reserved for future middleware graph traversal (not yet emitted)
-export const REL_TYPES = ['CONTAINS', 'DEFINES', 'IMPORTS', 'CALLS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'HAS_PROPERTY', 'ACCESSES', 'OVERRIDES', 'MEMBER_OF', 'STEP_IN_PROCESS', 'HANDLES_ROUTE', 'FETCHES', 'HANDLES_TOOL', 'ENTRY_POINT_OF', 'WRAPS'] as const;
+export const REL_TYPES = ['CONTAINS', 'DEFINES', 'IMPORTS', 'CALLS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'HAS_PROPERTY', 'ACCESSES', 'OVERRIDES', 'MEMBER_OF', 'STEP_IN_PROCESS', 'HANDLES_ROUTE', 'FETCHES', 'HANDLES_TOOL', 'ENTRY_POINT_OF', 'WRAPS', 'PRODUCES', 'CONSUMES'] as const;
 export type RelType = typeof REL_TYPES[number];
 
 // ============================================================================
@@ -217,6 +218,17 @@ CREATE NODE TABLE Tool (
   PRIMARY KEY (id)
 )`;
 
+// Shared state slots (React Query cache, Context, Redux slice, etc.)
+export const STATE_SLOT_SCHEMA = `
+CREATE NODE TABLE StateSlot (
+  id STRING,
+  name STRING,
+  filePath STRING,
+  slotKind STRING,
+  cacheKey STRING,
+  PRIMARY KEY (id)
+)`;
+
 // Markdown heading sections
 export const SECTION_SCHEMA = `
 CREATE NODE TABLE Section (
@@ -336,6 +348,10 @@ CREATE REL TABLE ${REL_TABLE_NAME} (
   FROM File TO Tool,
   FROM Function TO Tool,
   FROM Method TO Tool,
+  FROM Function TO StateSlot,
+  FROM Method TO StateSlot,
+  FROM File TO StateSlot,
+  FROM StateSlot TO Process,
   FROM CodeElement TO Community,
   FROM Interface TO Community,
   FROM Interface TO Function,
@@ -511,6 +527,8 @@ export const NODE_SCHEMA_QUERIES = [
   ROUTE_SCHEMA,
   // MCP tools
   TOOL_SCHEMA,
+  // Shared state slots
+  STATE_SLOT_SCHEMA,
 ];
 
 export const REL_SCHEMA_QUERIES = [

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -46,10 +46,11 @@ export const VALID_NODE_LABELS = new Set([
   'Record', 'Delegate', 'Annotation', 'Constructor', 'Template', 'Module',
   'Route',
   'Tool',
+  'StateSlot',
 ]);
 
 /** Valid relation types for impact analysis filtering */
-export const VALID_RELATION_TYPES = new Set(['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'HAS_PROPERTY', 'OVERRIDES', 'ACCESSES', 'HANDLES_ROUTE', 'FETCHES', 'HANDLES_TOOL', 'ENTRY_POINT_OF', 'WRAPS']);
+export const VALID_RELATION_TYPES = new Set(['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'HAS_PROPERTY', 'OVERRIDES', 'ACCESSES', 'HANDLES_ROUTE', 'FETCHES', 'HANDLES_TOOL', 'ENTRY_POINT_OF', 'WRAPS', 'PRODUCES', 'CONSUMES']);
 
 /**
  * Per-relation-type confidence floor for impact analysis.
@@ -101,6 +102,72 @@ export function isWriteQuery(query: string): boolean {
 function logQueryError(context: string, err: unknown): void {
   const msg = err instanceof Error ? err.message : String(err);
   console.error(`GitNexus [${context}]: ${msg}`);
+}
+
+/**
+ * Parse shape metadata from a PRODUCES/CONSUMES edge reason field.
+ * Format: "shape-{confidence}|keys:k1,k2|type:TypeName"
+ */
+export function parseShapeReason(reason: string | null | undefined): {
+  confidence: number;
+  keys: string[];
+  typeName: string | null;
+} {
+  if (!reason) return { confidence: 0, keys: [], typeName: null };
+  let confidence = 0;
+  let keys: string[] = [];
+  let typeName: string | null = null;
+
+  const confMatch = reason.match(/^shape-([a-z-]+|\d*\.?\d+)/);
+  if (confMatch) {
+    const raw = confMatch[1];
+    // Map string labels to numeric confidence (matches state-slot-processor.ts)
+    const LABEL_MAP: Record<string, number> = { 'type-checked': 1.0, 'ast-literal': 0.8, 'heuristic': 0.6 };
+    confidence = LABEL_MAP[raw] ?? (parseFloat(raw) || 0);
+  }
+
+  const keysMatch = reason.match(/\|keys:([^|]+)/);
+  if (keysMatch) keys = keysMatch[1].split(',').filter(k => k.length > 0);
+
+  const typeMatch = reason.match(/\|type:([^|]+)/);
+  if (typeMatch) typeName = typeMatch[1];
+
+  return { confidence, keys, typeName };
+}
+
+/**
+ * Compute shape mismatch verdict for a state slot.
+ * - 'conflict': Multiple producers write different shapes (key sets differ)
+ * - 'suspicious': Consumer accesses keys not found in any producer
+ * - 'ok': No mismatches detected
+ */
+export function computeShapeVerdict(
+  producers: Array<{ keys: string[]; typeName: string | null }>,
+  consumers: Array<{ keys: string[] }>,
+): 'conflict' | 'suspicious' | 'ok' {
+  // Check for producer conflicts: do producers agree on shape?
+  if (producers.length > 1) {
+    const keySignatures = producers.map(p => [...p.keys].sort().join(','));
+    const uniqueSignatures = new Set(keySignatures);
+    if (uniqueSignatures.size > 1) return 'conflict';
+  }
+
+  // Collect all keys produced
+  const allProducedKeys = new Set<string>();
+  for (const p of producers) {
+    for (const k of p.keys) allProducedKeys.add(k);
+  }
+
+  // Check if any consumer accesses keys not in any producer
+  if (allProducedKeys.size > 0) {
+    for (const c of consumers) {
+      for (const k of c.keys) {
+        if (!allProducedKeys.has(k)) return 'suspicious';
+      }
+    }
+  }
+
+  return 'ok';
 }
 
 export interface CodebaseContext {
@@ -414,6 +481,8 @@ export class LocalBackend {
         return this.toolMap(repo, params);
       case 'api_impact':
         return this.apiImpact(repo, params);
+      case 'data_flow':
+        return this.dataFlow(repo, params);
       default:
         throw new Error(`Unknown tool: ${method}`);
     }
@@ -2105,6 +2174,128 @@ export class LocalBackend {
       steps: steps.map((s: any) => ({
         step: s.step || s[3], name: s.name || s[0], type: s.type || s[1], filePath: s.filePath || s[2],
       })),
+    };
+  }
+
+  private async dataFlow(repo: RepoHandle, params: { query?: string; slotKind?: string; mismatchesOnly?: string | boolean }): Promise<any> {
+    await this.ensureInitialized(repo.id);
+
+    // Build optional filters
+    let slotFilter = '';
+    const queryParams: Record<string, string> = {};
+    if (params.query) {
+      slotFilter += ` AND n.name CONTAINS $query`;
+      queryParams.query = params.query;
+    }
+    if (params.slotKind) {
+      slotFilter += ` AND n.slotKind = $slotKind`;
+      queryParams.slotKind = params.slotKind;
+    }
+
+    // 1. Fetch all StateSlot nodes
+    const slotRows = await executeParameterized(repo.id, `
+      MATCH (n:StateSlot)
+      ${slotFilter ? `WHERE ${slotFilter.replace(/^\s*AND\s*/, '')}` : ''}
+      RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.slotKind AS slotKind, n.cacheKey AS cacheKey
+    `, queryParams);
+
+    if (slotRows.length === 0) {
+      return { slots: [], total: 0, conflicts: 0, suspicious: 0, message: params.query ? `No state slots matching "${params.query}"` : 'No state slots found in this project.' };
+    }
+
+    // 2. Batch-fetch PRODUCES and CONSUMES edges for all slots
+    const slotIds = slotRows.map((r: any) => r.id ?? r[0]);
+
+    const [producerRows, consumerRows] = await Promise.all([
+      executeParameterized(repo.id, `
+        MATCH (fn)-[r:CodeRelation]->(s:StateSlot)
+        WHERE r.type = 'PRODUCES' AND list_contains($slotIds, s.id)
+        RETURN s.id AS slotId, fn.name AS name, fn.filePath AS filePath, r.reason AS reason
+      `, { slotIds }),
+      executeParameterized(repo.id, `
+        MATCH (fn)-[r:CodeRelation]->(s:StateSlot)
+        WHERE r.type = 'CONSUMES' AND list_contains($slotIds, s.id)
+        RETURN s.id AS slotId, fn.name AS name, fn.filePath AS filePath, r.reason AS reason
+      `, { slotIds }),
+    ]);
+
+    // Group producers and consumers by slot ID
+    const producersBySlot = new Map<string, Array<{ name: string; filePath: string; keys: string[]; typeName: string | null; confidence: number }>>();
+    const consumersBySlot = new Map<string, Array<{ name: string; filePath: string; keys: string[]; confidence: number }>>();
+
+    for (const row of producerRows) {
+      const slotId = row.slotId ?? row[0];
+      const name = row.name ?? row[1];
+      const filePath = row.filePath ?? row[2];
+      const reason: string | null = row.reason ?? row[3] ?? null;
+      const shape = parseShapeReason(reason);
+      let list = producersBySlot.get(slotId);
+      if (!list) { list = []; producersBySlot.set(slotId, list); }
+      list.push({ name, filePath, keys: shape.keys, typeName: shape.typeName, confidence: shape.confidence });
+    }
+
+    for (const row of consumerRows) {
+      const slotId = row.slotId ?? row[0];
+      const name = row.name ?? row[1];
+      const filePath = row.filePath ?? row[2];
+      const reason: string | null = row.reason ?? row[3] ?? null;
+      const shape = parseShapeReason(reason);
+      let list = consumersBySlot.get(slotId);
+      if (!list) { list = []; consumersBySlot.set(slotId, list); }
+      list.push({ name, filePath, keys: shape.keys, confidence: shape.confidence });
+    }
+
+    // 3. Build result slots with verdict
+    let conflictCount = 0;
+    let suspiciousCount = 0;
+
+    const slots = slotRows.map((row: any) => {
+      const id = row.id ?? row[0];
+      const name = row.name ?? row[1];
+      const filePath = row.filePath ?? row[2];
+      const slotKind = row.slotKind ?? row[3];
+      const cacheKey = row.cacheKey ?? row[4];
+
+      const producers = producersBySlot.get(id) || [];
+      const consumers = consumersBySlot.get(id) || [];
+      const verdict = computeShapeVerdict(producers, consumers);
+
+      if (verdict === 'conflict') conflictCount++;
+      if (verdict === 'suspicious') suspiciousCount++;
+
+      return {
+        name,
+        filePath,
+        slotKind,
+        ...(cacheKey ? { cacheKey } : {}),
+        verdict,
+        producers: producers.map(p => ({
+          name: p.name,
+          filePath: p.filePath,
+          ...(p.keys.length > 0 ? { keys: p.keys } : {}),
+          ...(p.typeName ? { typeName: p.typeName } : {}),
+          ...(p.confidence > 0 ? { confidence: p.confidence } : {}),
+        })),
+        consumers: consumers.map(c => ({
+          name: c.name,
+          filePath: c.filePath,
+          ...(c.keys.length > 0 ? { accessedKeys: c.keys } : {}),
+          ...(c.confidence > 0 ? { confidence: c.confidence } : {}),
+        })),
+      };
+    });
+
+    // 4. Filter if mismatchesOnly (MCP sends strings, so check both)
+    const filterMismatches = params.mismatchesOnly === true || params.mismatchesOnly === 'true';
+    const filtered = filterMismatches
+      ? slots.filter((s: any) => s.verdict !== 'ok')
+      : slots;
+
+    return {
+      slots: filtered,
+      total: filtered.length,
+      conflicts: conflictCount,
+      suspicious: suspiciousCount,
     };
   }
 

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -64,6 +64,9 @@ function getNextStepHint(toolName: string, args: Record<string, any> | undefined
     case 'cypher':
       return `\n\n---\n**Next:** To explore a result symbol, use context({name: "<name>"${repoParam}}). For schema reference, READ gitnexus://repo/${repoPath}/schema.`;
 
+    case 'data_flow':
+      return '\n\n💡 Next: Use `context` on any producer/consumer to see its full call chain, or `api_impact` to check the upstream API route.';
+
     // Legacy tool names — still return useful hints
     case 'search':
       return `\n\n---\n**Next:** To understand a result in context, use context({name: "<symbol_name>"${repoParam}}).`;

--- a/gitnexus/src/mcp/tools.ts
+++ b/gitnexus/src/mcp/tools.ts
@@ -277,6 +277,26 @@ Returns routes that have both detected response keys AND consumers. Shows top-le
     },
   },
   {
+    name: 'data_flow',
+    description: `Show data flow through shared state slots (React Query cache keys, SWR keys, React Context, Redux slices, Zustand stores).
+
+WHEN TO USE: When you need to understand how data flows through shared state, detect cache key collisions, or find shape mismatches where two hooks/components share a state slot but expect different data shapes.
+
+Returns: state slots with their producers (who writes data), consumers (who reads data), shape comparison, and mismatch verdict (ok/suspicious/conflict).
+
+AFTER THIS: If mismatches are found, use \`context\` on the producer/consumer functions to understand the full call chain.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Filter by cache key, context name, or slice name (substring match)' },
+        slotKind: { type: 'string', description: 'Filter by state slot kind', enum: ['react-query', 'swr', 'react-context', 'redux', 'zustand', 'trpc', 'graphql', 'custom-hook'] },
+        mismatchesOnly: { type: 'string', description: 'Set to "true" to only show slots with shape conflicts' },
+        repo: { type: 'string', description: 'Repository name or path. Omit if only one repo is indexed.' },
+      },
+      required: [],
+    },
+  },
+  {
     name: 'api_impact',
     description: `Pre-change impact report for an API route handler.
 

--- a/gitnexus/src/types/pipeline.ts
+++ b/gitnexus/src/types/pipeline.ts
@@ -2,7 +2,7 @@ import { GraphNode, GraphRelationship, KnowledgeGraph } from '../core/graph/type
 import { CommunityDetectionResult } from '../core/ingestion/community-processor.js';
 import { ProcessDetectionResult } from '../core/ingestion/process-processor.js';
 
-export type PipelinePhase = 'idle' | 'extracting' | 'structure' | 'parsing' | 'imports' | 'calls' | 'heritage' | 'communities' | 'processes' | 'enriching' | 'complete' | 'error';
+export type PipelinePhase = 'idle' | 'extracting' | 'structure' | 'parsing' | 'imports' | 'calls' | 'heritage' | 'state-slots' | 'communities' | 'processes' | 'enriching' | 'complete' | 'error';
 
 export interface PipelineProgress {
   phase: PipelinePhase;

--- a/gitnexus/test/fixtures/state-slot-seed.ts
+++ b/gitnexus/test/fixtures/state-slot-seed.ts
@@ -1,0 +1,65 @@
+import type { FTSIndexDef } from '../helpers/test-indexed-db.js';
+
+/**
+ * Seed data for data_flow E2E tests.
+ *
+ * Simulates what the pipeline would produce for a Next.js project with:
+ * - Two React Query hooks sharing cache key ['vendor-patterns', slug] with DIFFERENT produced shapes (conflict)
+ * - One SWR hook with a different cache key (no conflict)
+ * - Consumer components with different access patterns
+ * - StateSlot nodes representing shared cache keys
+ * - PRODUCES edges (from hooks to StateSlot)
+ * - CONSUMES edges (from components to StateSlot)
+ */
+export const STATE_SLOT_SEED_DATA: string[] = [
+  // ─── Files ─────────────────────────────────────────────────────────
+  `CREATE (f:File {id: 'file:hooks/useVendorPatterns.ts', name: 'useVendorPatterns.ts', filePath: 'hooks/useVendorPatterns.ts', content: 'export function useVendorPatterns(slug) { return useQuery({ queryKey: ["vendor-patterns", slug], ... }) }'})`,
+  `CREATE (f:File {id: 'file:hooks/useVendorPatternsSummary.ts', name: 'useVendorPatternsSummary.ts', filePath: 'hooks/useVendorPatternsSummary.ts', content: 'export function useVendorPatternsSummary(slug) { return useQuery({ queryKey: ["vendor-patterns", slug], ... }) }'})`,
+  `CREATE (f:File {id: 'file:hooks/useVendorStats.ts', name: 'useVendorStats.ts', filePath: 'hooks/useVendorStats.ts', content: 'export function useVendorStats(slug) { return useSWR(["vendor-stats", slug], fetcher) }'})`,
+  `CREATE (f:File {id: 'file:components/VendorDashboard.tsx', name: 'VendorDashboard.tsx', filePath: 'components/VendorDashboard.tsx', content: 'const { data } = useVendorPatterns(slug); data.patterns; data.total; data.page'})`,
+  `CREATE (f:File {id: 'file:components/VendorSidebar.tsx', name: 'VendorSidebar.tsx', filePath: 'components/VendorSidebar.tsx', content: 'const { data } = useVendorPatternsSummary(slug); data.patterns; data.page'})`,
+  `CREATE (f:File {id: 'file:components/VendorStatsWidget.tsx', name: 'VendorStatsWidget.tsx', filePath: 'components/VendorStatsWidget.tsx', content: 'const { data } = useVendorStats(slug); data.count; data.trend'})`,
+
+  // ─── StateSlot nodes ────────────────────────────────────────────────
+  // Conflict slot: two React Query hooks share this key with different shapes
+  `CREATE (ss:StateSlot {id: 'StateSlot:react-query:vendor-patterns-slug', name: '["vendor-patterns", slug]', slotKind: 'react-query', cacheKey: '["vendor-patterns", slug]'})`,
+  // Clean slot: single SWR hook, no conflict
+  `CREATE (ss:StateSlot {id: 'StateSlot:swr:vendor-stats-slug', name: '["vendor-stats", slug]', slotKind: 'swr', cacheKey: '["vendor-stats", slug]'})`,
+
+  // ─── Functions (hooks — producers) ─────────────────────────────────
+  `CREATE (fn:Function {id: 'func:useVendorPatterns', name: 'useVendorPatterns', filePath: 'hooks/useVendorPatterns.ts', startLine: 1, endLine: 8, isExported: true, content: 'export function useVendorPatterns(slug)', description: 'React Query hook — full vendor patterns with pagination'})`,
+  `CREATE (fn:Function {id: 'func:useVendorPatternsSummary', name: 'useVendorPatternsSummary', filePath: 'hooks/useVendorPatternsSummary.ts', startLine: 1, endLine: 6, isExported: true, content: 'export function useVendorPatternsSummary(slug)', description: 'React Query hook — summary shape, omits total field'})`,
+  `CREATE (fn:Function {id: 'func:useVendorStats', name: 'useVendorStats', filePath: 'hooks/useVendorStats.ts', startLine: 1, endLine: 5, isExported: true, content: 'export function useVendorStats(slug)', description: 'SWR hook — vendor stats with count and trend'})`,
+
+  // ─── Functions (components — consumers) ────────────────────────────
+  `CREATE (fn:Function {id: 'func:VendorDashboard', name: 'VendorDashboard', filePath: 'components/VendorDashboard.tsx', startLine: 1, endLine: 20, isExported: true, content: 'export function VendorDashboard()', description: 'Dashboard component — reads patterns, total, page'})`,
+  `CREATE (fn:Function {id: 'func:VendorSidebar', name: 'VendorSidebar', filePath: 'components/VendorSidebar.tsx', startLine: 1, endLine: 15, isExported: true, content: 'export function VendorSidebar()', description: 'Sidebar component — reads patterns, page (omits total)'})`,
+  `CREATE (fn:Function {id: 'func:VendorStatsWidget', name: 'VendorStatsWidget', filePath: 'components/VendorStatsWidget.tsx', startLine: 1, endLine: 12, isExported: true, content: 'export function VendorStatsWidget()', description: 'Stats widget — reads count, trend from SWR slot'})`,
+
+  // ─── PRODUCES edges (hook → StateSlot) ─────────────────────────────
+  // useVendorPatterns produces shape with keys: patterns, total, page
+  `MATCH (fn:Function), (ss:StateSlot) WHERE fn.id = 'func:useVendorPatterns' AND ss.id = 'StateSlot:react-query:vendor-patterns-slug'
+   CREATE (fn)-[:CodeRelation {type: 'PRODUCES', confidence: 1.0, reason: 'shape-ast-literal|keys:patterns,total,page', step: 0}]->(ss)`,
+  // useVendorPatternsSummary produces shape with keys: patterns, page (missing total — CONFLICT)
+  `MATCH (fn:Function), (ss:StateSlot) WHERE fn.id = 'func:useVendorPatternsSummary' AND ss.id = 'StateSlot:react-query:vendor-patterns-slug'
+   CREATE (fn)-[:CodeRelation {type: 'PRODUCES', confidence: 0.9, reason: 'shape-ast-literal|keys:patterns,page', step: 0}]->(ss)`,
+  // useVendorStats produces shape for its own SWR slot
+  `MATCH (fn:Function), (ss:StateSlot) WHERE fn.id = 'func:useVendorStats' AND ss.id = 'StateSlot:swr:vendor-stats-slug'
+   CREATE (fn)-[:CodeRelation {type: 'PRODUCES', confidence: 1.0, reason: 'shape-ast-literal|keys:count,trend', step: 0}]->(ss)`,
+
+  // ─── CONSUMES edges (component → StateSlot) ────────────────────────
+  // VendorDashboard consumes patterns, total, page from the conflict slot
+  `MATCH (fn:Function), (ss:StateSlot) WHERE fn.id = 'func:VendorDashboard' AND ss.id = 'StateSlot:react-query:vendor-patterns-slug'
+   CREATE (fn)-[:CodeRelation {type: 'CONSUMES', confidence: 1.0, reason: 'shape-heuristic|keys:patterns,total,page', step: 0}]->(ss)`,
+  // VendorSidebar consumes patterns, page from the conflict slot
+  `MATCH (fn:Function), (ss:StateSlot) WHERE fn.id = 'func:VendorSidebar' AND ss.id = 'StateSlot:react-query:vendor-patterns-slug'
+   CREATE (fn)-[:CodeRelation {type: 'CONSUMES', confidence: 1.0, reason: 'shape-heuristic|keys:patterns,page', step: 0}]->(ss)`,
+  // VendorStatsWidget consumes count, trend from the clean SWR slot
+  `MATCH (fn:Function), (ss:StateSlot) WHERE fn.id = 'func:VendorStatsWidget' AND ss.id = 'StateSlot:swr:vendor-stats-slug'
+   CREATE (fn)-[:CodeRelation {type: 'CONSUMES', confidence: 1.0, reason: 'shape-heuristic|keys:count,trend', step: 0}]->(ss)`,
+];
+
+export const STATE_SLOT_FTS_INDEXES: FTSIndexDef[] = [
+  { table: 'Function', indexName: 'function_fts', columns: ['name', 'content', 'description'] },
+  { table: 'File', indexName: 'file_fts', columns: ['name', 'content'] },
+];

--- a/gitnexus/test/integration/data-flow-e2e.test.ts
+++ b/gitnexus/test/integration/data-flow-e2e.test.ts
@@ -1,0 +1,189 @@
+/**
+ * E2E Integration Tests: data_flow tool (StateSlot shape conflict detection)
+ *
+ * Tests the full stack: LadybugDB seed → MCP tool call → result verification.
+ * Covers StateSlot listing, filtering by kind/query, shape conflict detection,
+ * and mismatchesOnly filtering.
+ *
+ * Uses hand-crafted Cypher seed data that represents what the pipeline
+ * would produce for a project with React Query and SWR hooks sharing cache keys.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { LocalBackend } from '../../src/mcp/local/local-backend.js';
+import { listRegisteredRepos } from '../../src/storage/repo-manager.js';
+import { withTestLbugDB } from '../helpers/test-indexed-db.js';
+import { STATE_SLOT_SEED_DATA, STATE_SLOT_FTS_INDEXES } from '../fixtures/state-slot-seed.js';
+
+vi.mock('../../src/storage/repo-manager.js', () => ({
+  listRegisteredRepos: vi.fn().mockResolvedValue([]),
+  cleanupOldKuzuFiles: vi.fn().mockResolvedValue({ found: false, needsReindex: false }),
+}));
+
+withTestLbugDB('data-flow-e2e', (handle) => {
+  let backend: LocalBackend;
+
+  beforeAll(async () => {
+    const ext = handle as typeof handle & { _backend?: LocalBackend };
+    if (!ext._backend) {
+      throw new Error('LocalBackend not initialized — afterSetup did not attach _backend to handle');
+    }
+    backend = ext._backend;
+  });
+
+  // ─── Test 1: Returns all state slots when no filter ──────────────
+
+  describe('unfiltered listing', () => {
+    it('returns all state slots when no filter is provided', async () => {
+      const result = await backend.callTool('data_flow', {});
+
+      expect(result).not.toHaveProperty('error');
+      expect(result.slots).toBeDefined();
+      expect(result.slots.length).toBe(2);
+      expect(result.total).toBe(2);
+
+      const names = result.slots.map((s: any) => s.name);
+      expect(names).toContain('["vendor-patterns", slug]');
+      expect(names).toContain('["vendor-stats", slug]');
+    });
+  });
+
+  // ─── Test 2: Filters by slotKind ────────────────────────────────
+
+  describe('slotKind filter', () => {
+    it('returns only react-query slots when filtered by slotKind', async () => {
+      const result = await backend.callTool('data_flow', { slotKind: 'react-query' });
+
+      expect(result.slots.length).toBe(1);
+      expect(result.slots[0].slotKind).toBe('react-query');
+      expect(result.slots[0].name).toBe('["vendor-patterns", slug]');
+    });
+  });
+
+  // ─── Test 3: Filters by query substring ─────────────────────────
+
+  describe('query filter', () => {
+    it('filters by query substring in slot name', async () => {
+      const result = await backend.callTool('data_flow', { query: 'vendor-patterns' });
+
+      expect(result.slots.length).toBe(1);
+      expect(result.slots[0].name).toContain('vendor-patterns');
+    });
+  });
+
+  // ─── Test 4: Detects shape conflict in shared cache key ─────────
+
+  describe('shape conflict detection', () => {
+    it('detects conflict when two producers write different shapes to the same slot', async () => {
+      const result = await backend.callTool('data_flow', { slotKind: 'react-query' });
+
+      const conflictSlot = result.slots.find((s: any) => s.name.includes('vendor-patterns'));
+      expect(conflictSlot).toBeDefined();
+      expect(conflictSlot.verdict).toBe('conflict');
+    });
+
+    it('reports conflict count in summary', async () => {
+      const result = await backend.callTool('data_flow', {});
+
+      expect(result.conflicts).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ─── Test 5: Shows ok verdict for non-conflicting slot ──────────
+
+  describe('ok verdict', () => {
+    it('shows ok verdict for SWR slot with single producer', async () => {
+      const result = await backend.callTool('data_flow', { slotKind: 'swr' });
+
+      expect(result.slots.length).toBe(1);
+      expect(result.slots[0].verdict).toBe('ok');
+    });
+  });
+
+  // ─── Test 6: mismatchesOnly filters to conflicts only ───────────
+
+  describe('mismatchesOnly filter', () => {
+    it('returns only non-ok slots when mismatchesOnly is set', async () => {
+      const result = await backend.callTool('data_flow', { mismatchesOnly: 'true' });
+
+      expect(result.total).toBeLessThan(2);
+      expect(result.slots.length).toBeGreaterThanOrEqual(1);
+      for (const slot of result.slots) {
+        expect(slot.verdict).not.toBe('ok');
+      }
+    });
+  });
+
+  // ─── Test 7: Returns producer and consumer details ──────────────
+
+  describe('producer and consumer details', () => {
+    it('returns correct producer names, files, and keys', async () => {
+      const result = await backend.callTool('data_flow', { slotKind: 'react-query' });
+      const slot = result.slots[0];
+
+      expect(slot.producers.length).toBe(2);
+
+      const producerNames = slot.producers.map((p: any) => p.name);
+      expect(producerNames).toContain('useVendorPatterns');
+      expect(producerNames).toContain('useVendorPatternsSummary');
+
+      const fullProducer = slot.producers.find((p: any) => p.name === 'useVendorPatterns');
+      expect(fullProducer.filePath).toBe('hooks/useVendorPatterns.ts');
+      expect(fullProducer.keys).toEqual(expect.arrayContaining(['patterns', 'total', 'page']));
+
+      const summaryProducer = slot.producers.find((p: any) => p.name === 'useVendorPatternsSummary');
+      expect(summaryProducer.filePath).toBe('hooks/useVendorPatternsSummary.ts');
+      expect(summaryProducer.keys).toEqual(expect.arrayContaining(['patterns', 'page']));
+      // Summary producer should NOT have 'total' key — this is the source of the conflict
+      expect(summaryProducer.keys).not.toContain('total');
+    });
+
+    it('returns correct consumer names and accessed keys', async () => {
+      const result = await backend.callTool('data_flow', { slotKind: 'react-query' });
+      const slot = result.slots[0];
+
+      expect(slot.consumers.length).toBe(2);
+
+      const consumerNames = slot.consumers.map((c: any) => c.name);
+      expect(consumerNames).toContain('VendorDashboard');
+      expect(consumerNames).toContain('VendorSidebar');
+
+      const dashboard = slot.consumers.find((c: any) => c.name === 'VendorDashboard');
+      expect(dashboard.filePath).toBe('components/VendorDashboard.tsx');
+      expect(dashboard.accessedKeys).toEqual(expect.arrayContaining(['patterns', 'total', 'page']));
+    });
+
+    it('returns SWR slot producer and consumer details', async () => {
+      const result = await backend.callTool('data_flow', { slotKind: 'swr' });
+      const slot = result.slots[0];
+
+      expect(slot.producers.length).toBe(1);
+      expect(slot.producers[0].name).toBe('useVendorStats');
+      expect(slot.producers[0].keys).toEqual(expect.arrayContaining(['count', 'trend']));
+
+      expect(slot.consumers.length).toBe(1);
+      expect(slot.consumers[0].name).toBe('VendorStatsWidget');
+      expect(slot.consumers[0].accessedKeys).toEqual(expect.arrayContaining(['count', 'trend']));
+    });
+  });
+
+}, {
+  seed: STATE_SLOT_SEED_DATA,
+  ftsIndexes: STATE_SLOT_FTS_INDEXES,
+  poolAdapter: true,
+  afterSetup: async (handle) => {
+    vi.mocked(listRegisteredRepos).mockResolvedValue([
+      {
+        name: 'test-data-flow-repo',
+        path: '/test/data-flow-repo',
+        storagePath: handle.tmpHandle.dbPath,
+        indexedAt: new Date().toISOString(),
+        lastCommit: 'abc123',
+        stats: { files: 6, nodes: 12, communities: 1, processes: 0 },
+      },
+    ]);
+
+    const backend = new LocalBackend();
+    await backend.init();
+    (handle as any)._backend = backend;
+  },
+});

--- a/gitnexus/test/unit/schema.test.ts
+++ b/gitnexus/test/unit/schema.test.ts
@@ -39,8 +39,8 @@ describe('LadybugDB Schema', () => {
     });
 
     it('has expected total count', () => {
-      // 9 core + 18 multi-language + Route + Tool = 30
-      expect(NODE_TABLES).toHaveLength(30);
+      // 9 core + 18 multi-language + Route + Tool + StateSlot = 31
+      expect(NODE_TABLES).toHaveLength(31);
     });
   });
 
@@ -164,7 +164,7 @@ describe('LadybugDB Schema', () => {
 
   describe('schema query ordering', () => {
     it('NODE_SCHEMA_QUERIES has correct count', () => {
-      expect(NODE_SCHEMA_QUERIES).toHaveLength(30);
+      expect(NODE_SCHEMA_QUERIES).toHaveLength(31);
     });
 
     it('REL_SCHEMA_QUERIES has one relation table', () => {
@@ -172,8 +172,8 @@ describe('LadybugDB Schema', () => {
     });
 
     it('SCHEMA_QUERIES includes all node + rel + embedding schemas', () => {
-      // 30 node + 1 rel + 1 embedding = 32
-      expect(SCHEMA_QUERIES).toHaveLength(32);
+      // 31 node + 1 rel + 1 embedding = 33
+      expect(SCHEMA_QUERIES).toHaveLength(33);
     });
 
     it('node schemas come before relation schemas in SCHEMA_QUERIES', () => {

--- a/gitnexus/test/unit/security.test.ts
+++ b/gitnexus/test/unit/security.test.ts
@@ -96,8 +96,8 @@ describe('isWriteQuery', () => {
 
 describe('VALID_RELATION_TYPES', () => {
   it('contains all expected relation types', () => {
-    expect(VALID_RELATION_TYPES.size).toBe(13);
-    for (const t of ['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'HAS_PROPERTY', 'OVERRIDES', 'ACCESSES', 'HANDLES_ROUTE', 'FETCHES', 'HANDLES_TOOL', 'ENTRY_POINT_OF', 'WRAPS']) {
+    expect(VALID_RELATION_TYPES.size).toBe(15);
+    for (const t of ['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'HAS_PROPERTY', 'OVERRIDES', 'ACCESSES', 'HANDLES_ROUTE', 'FETCHES', 'HANDLES_TOOL', 'ENTRY_POINT_OF', 'WRAPS', 'PRODUCES', 'CONSUMES']) {
       expect(VALID_RELATION_TYPES.has(t)).toBe(true);
     }
   });

--- a/gitnexus/test/unit/shape-inference.test.ts
+++ b/gitnexus/test/unit/shape-inference.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractObjectLiteralKeys,
+  extractDestructuredKeys,
+  extractPropertyAccessKeys,
+  cacheKeyPrefix,
+  cacheKeysOverlap,
+} from '../../src/core/ingestion/shape-inference.js';
+
+describe('shape-inference', () => {
+  describe('extractObjectLiteralKeys', () => {
+    it('extracts top-level keys from JSON return', () => {
+      const code = `return Response.json({ patterns, total, page })`;
+      expect(extractObjectLiteralKeys(code)).toEqual(['patterns', 'total', 'page']);
+    });
+
+    it('extracts keys from NextResponse.json', () => {
+      const code = `return NextResponse.json({ data: items, pagination: { page, limit } })`;
+      expect(extractObjectLiteralKeys(code)).toEqual(['data', 'pagination']);
+    });
+
+    it('returns empty for no object literal', () => {
+      expect(extractObjectLiteralKeys(`return data`)).toEqual([]);
+    });
+  });
+
+  describe('extractDestructuredKeys', () => {
+    it('extracts destructured keys from data variable', () => {
+      const code = `const { patterns, total } = data;`;
+      expect(extractDestructuredKeys(code)).toEqual(['patterns', 'total']);
+    });
+
+    it('extracts from response.json() destructuring', () => {
+      const code = `const { items, count } = await res.json();`;
+      expect(extractDestructuredKeys(code)).toEqual(['items', 'count']);
+    });
+
+    it('extracts from nested destructuring (top level only)', () => {
+      const code = `const { data: { items }, total } = response;`;
+      expect(extractDestructuredKeys(code)).toContain('total');
+    });
+  });
+
+  describe('extractPropertyAccessKeys', () => {
+    it('extracts dot-access keys on data variable', () => {
+      const code = `console.log(data.patterns);\nconst x = data.total;`;
+      expect(extractPropertyAccessKeys(code)).toEqual(expect.arrayContaining(['patterns', 'total']));
+    });
+
+    it('extracts optional chaining keys', () => {
+      const code = `data?.items?.length`;
+      expect(extractPropertyAccessKeys(code)).toContain('items');
+    });
+
+    it('filters out method-like accesses', () => {
+      const keys = extractPropertyAccessKeys(`data.toString(); data.length; data.items`);
+      expect(keys).not.toContain('toString');
+      expect(keys).not.toContain('length');
+      expect(keys).toContain('items');
+    });
+  });
+
+  describe('cacheKeyPrefix', () => {
+    it('extracts static prefix from array key', () => {
+      expect(cacheKeyPrefix(`['vendor-patterns', slug]`)).toBe('vendor-patterns');
+    });
+
+    it('extracts prefix from single-string key', () => {
+      expect(cacheKeyPrefix(`'vendor-patterns'`)).toBe('vendor-patterns');
+    });
+
+    it('extracts prefix from template literal', () => {
+      expect(cacheKeyPrefix('`/api/vendors/${id}`')).toBe('/api/vendors/');
+    });
+  });
+
+  describe('cacheKeysOverlap', () => {
+    it('detects exact match', () => {
+      expect(cacheKeysOverlap(`['vendor-patterns', slug]`, `['vendor-patterns', slug]`)).toBe(true);
+    });
+
+    it('detects prefix match with different dynamic parts', () => {
+      expect(cacheKeysOverlap(`['vendor-patterns', slug]`, `['vendor-patterns', id]`)).toBe(true);
+    });
+
+    it('rejects different prefixes', () => {
+      expect(cacheKeysOverlap(`['vendor-patterns']`, `['grants']`)).toBe(false);
+    });
+  });
+});

--- a/gitnexus/test/unit/state-slot-detectors.test.ts
+++ b/gitnexus/test/unit/state-slot-detectors.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest';
+import { detectSwrSlots } from '../../src/core/ingestion/state-slot-detectors/swr.js';
+import { detectReactQuerySlots } from '../../src/core/ingestion/state-slot-detectors/react-query.js';
+
+describe('state-slot-detectors', () => {
+  describe('detectSwrSlots', () => {
+    it('detects useSWR with string key', () => {
+      const code = `
+        function VendorDetail({ id }) {
+          const { data, error } = useSWR('/api/vendors/' + id, fetcher);
+          return <div>{data?.name}</div>;
+        }
+      `;
+      const slots = detectSwrSlots(code, '/src/components/VendorDetail.tsx');
+      expect(slots).toHaveLength(1);
+      expect(slots[0].slotKind).toBe('swr');
+      expect(slots[0].cacheKey).toBe("'/api/vendors/' + id");
+      expect(slots[0].filePath).toBe('/src/components/VendorDetail.tsx');
+      expect(slots[0].lineNumber).toBeGreaterThan(0);
+    });
+
+    it('detects useSWR with array key', () => {
+      const code = `
+        function useVendor(id) {
+          const { data } = useSWR(['vendors', id], fetchVendor);
+          return data;
+        }
+      `;
+      const slots = detectSwrSlots(code, '/src/hooks/useVendor.ts');
+      expect(slots).toHaveLength(1);
+      expect(slots[0].slotKind).toBe('swr');
+      expect(slots[0].cacheKey).toBe("['vendors', id]");
+      expect(slots[0].name).toBe("['vendors', id]");
+    });
+
+    it('detects useSWRMutation', () => {
+      const code = `
+        function useUpdateVendor() {
+          const { trigger, isMutating } = useSWRMutation('/api/vendors', updateVendor);
+          return { trigger, isMutating };
+        }
+      `;
+      const slots = detectSwrSlots(code, '/src/hooks/useUpdateVendor.ts');
+      expect(slots).toHaveLength(1);
+      expect(slots[0].slotKind).toBe('swr');
+      expect(slots[0].cacheKey).toBe("'/api/vendors'");
+    });
+
+    it('returns empty for files without SWR', () => {
+      const code = `
+        function MyComponent() {
+          const [state, setState] = useState(null);
+          useEffect(() => { setState('hello'); }, []);
+          return <div>{state}</div>;
+        }
+      `;
+      const slots = detectSwrSlots(code, '/src/components/MyComponent.tsx');
+      expect(slots).toHaveLength(0);
+    });
+
+    it('extracts consumer access patterns from context window', () => {
+      const code = `
+        function VendorList() {
+          const { data } = useSWR('/api/vendors', fetcher);
+          return (
+            <ul>
+              {data?.items.map(v => <li key={v.id}>{v.name}</li>)}
+              <span>Total: {data?.total}</span>
+            </ul>
+          );
+        }
+      `;
+      const slots = detectSwrSlots(code, '/src/components/VendorList.tsx');
+      expect(slots).toHaveLength(1);
+      // Consumer access keys should be detected from the context window
+      const consumers = slots[0].consumers;
+      expect(consumers.length).toBeGreaterThan(0);
+      expect(consumers[0].accessedKeys).toContain('items');
+      expect(consumers[0].accessedKeys).toContain('total');
+    });
+
+    it('detects multiple SWR calls in same file', () => {
+      const code = `
+        function useData() {
+          const { data: vendors } = useSWR('/api/vendors', fetchVendors);
+          const { data: grants } = useSWR('/api/grants', fetchGrants);
+          return { vendors, grants };
+        }
+      `;
+      const slots = detectSwrSlots(code, '/src/hooks/useData.ts');
+      expect(slots).toHaveLength(2);
+      const keys = slots.map(s => s.cacheKey);
+      expect(keys).toContain("'/api/vendors'");
+      expect(keys).toContain("'/api/grants'");
+    });
+
+    it('detects useSWR with template literal key', () => {
+      const code = `
+        function useVendorById(id) {
+          const { data } = useSWR(\`/api/vendors/\${id}\`, fetcher);
+          return data;
+        }
+      `;
+      const slots = detectSwrSlots(code, '/src/hooks/useVendorById.ts');
+      expect(slots).toHaveLength(1);
+      expect(slots[0].cacheKey).toBe('`/api/vendors/${id}`');
+    });
+  });
+
+  describe('detectReactQuerySlots', () => {
+    const FILE_PATH = '/project/src/hooks/useVendors.ts';
+
+    it('detects useQuery with array queryKey', () => {
+      const source = `
+        export function useVendorPatterns(slug: string) {
+          return useQuery({
+            queryKey: ['vendor-patterns', slug],
+            queryFn: () => fetchVendorPatterns(slug),
+          });
+        }
+      `;
+      const slots = detectReactQuerySlots(source, FILE_PATH);
+      expect(slots).toHaveLength(1);
+      expect(slots[0].slotKind).toBe('react-query');
+      expect(slots[0].cacheKey).toBe(`['vendor-patterns', slug]`);
+      expect(slots[0].name).toBe(`['vendor-patterns', slug]`);
+      expect(slots[0].filePath).toBe(FILE_PATH);
+      expect(slots[0].lineNumber).toBeGreaterThan(0);
+    });
+
+    it('detects multiple useQuery calls in same file', () => {
+      const source = `
+        export function useVendors() {
+          return useQuery({
+            queryKey: ['vendors-list'],
+            queryFn: fetchVendors,
+          });
+        }
+
+        export function useVendorDetail(id: string) {
+          return useQuery({
+            queryKey: ['vendor-detail', id],
+            queryFn: () => fetchVendorDetail(id),
+          });
+        }
+      `;
+      const slots = detectReactQuerySlots(source, FILE_PATH);
+      expect(slots).toHaveLength(2);
+      const keys = slots.map((s) => s.cacheKey);
+      expect(keys).toContain(`['vendors-list']`);
+      expect(keys).toContain(`['vendor-detail', id]`);
+    });
+
+    it('detects useMutation with mutationKey', () => {
+      const source = `
+        export function useUpdateVendor() {
+          return useMutation({
+            mutationKey: ['update-vendor'],
+            mutationFn: (data: VendorInput) => updateVendor(data),
+          });
+        }
+      `;
+      const slots = detectReactQuerySlots(source, FILE_PATH);
+      expect(slots).toHaveLength(1);
+      expect(slots[0].slotKind).toBe('react-query');
+      expect(slots[0].cacheKey).toBe(`['update-vendor']`);
+    });
+
+    it('detects useInfiniteQuery', () => {
+      const source = `
+        export function useVendorsPaged() {
+          return useInfiniteQuery({
+            queryKey: ['vendors-paged'],
+            queryFn: ({ pageParam }) => fetchVendorsPage(pageParam),
+            getNextPageParam: (last) => last.nextCursor,
+          });
+        }
+      `;
+      const slots = detectReactQuerySlots(source, FILE_PATH);
+      expect(slots).toHaveLength(1);
+      expect(slots[0].slotKind).toBe('react-query');
+      expect(slots[0].cacheKey).toBe(`['vendors-paged']`);
+    });
+
+    it('detects useSuspenseQuery', () => {
+      const source = `
+        export function useVendorSuspense(id: string) {
+          return useSuspenseQuery({
+            queryKey: ['vendor-suspense', id],
+            queryFn: () => fetchVendor(id),
+          });
+        }
+      `;
+      const slots = detectReactQuerySlots(source, FILE_PATH);
+      expect(slots).toHaveLength(1);
+      expect(slots[0].slotKind).toBe('react-query');
+      expect(slots[0].cacheKey).toBe(`['vendor-suspense', id]`);
+    });
+
+    it('returns empty array for files without React Query hooks', () => {
+      const source = `
+        export function fetchVendors() {
+          return fetch('/api/vendors').then((r) => r.json());
+        }
+
+        const data = useState(null);
+      `;
+      const slots = detectReactQuerySlots(source, FILE_PATH);
+      expect(slots).toHaveLength(0);
+    });
+
+    it('extracts consumer accessed keys from destructuring', () => {
+      const source = `
+        export function VendorList() {
+          const { data, isLoading, error } = useQuery({
+            queryKey: ['vendor-list'],
+            queryFn: fetchVendors,
+          });
+          const { patterns, total } = data ?? {};
+          return <div>{total}</div>;
+        }
+      `;
+      const slots = detectReactQuerySlots(source, FILE_PATH);
+      expect(slots).toHaveLength(1);
+      const consumer = slots[0].consumers[0];
+      expect(consumer).toBeDefined();
+      expect(consumer.accessedKeys).toContain('patterns');
+      expect(consumer.accessedKeys).toContain('total');
+    });
+
+    it('extracts consumer accessed keys from property access', () => {
+      // Uses `data.name` so that extractPropertyAccessKeys matches `data` as the var name
+      // and captures `name` as the accessed key (shape-inference only tracks known var names)
+      const source = `
+        export function VendorDetail({ id }: { id: string }) {
+          const { data } = useQuery({
+            queryKey: ['vendor-detail', id],
+            queryFn: () => fetchVendor(id),
+          });
+          return <h1>{data?.name}</h1>;
+        }
+      `;
+      const slots = detectReactQuerySlots(source, FILE_PATH);
+      expect(slots).toHaveLength(1);
+      const consumer = slots[0].consumers[0];
+      expect(consumer).toBeDefined();
+      expect(consumer.accessedKeys).toContain('name');
+    });
+  });
+});

--- a/gitnexus/test/unit/tools.test.ts
+++ b/gitnexus/test/unit/tools.test.ts
@@ -11,8 +11,8 @@ import { describe, it, expect } from 'vitest';
 import { GITNEXUS_TOOLS, type ToolDefinition } from '../../src/mcp/tools.js';
 
 describe('GITNEXUS_TOOLS', () => {
-  it('exports all tools (7 base + 3 route/tool/shape + 1 api_impact)', () => {
-    expect(GITNEXUS_TOOLS).toHaveLength(11);
+  it('exports all tools (7 base + 3 route/tool/shape + 1 api_impact + 1 data_flow)', () => {
+    expect(GITNEXUS_TOOLS).toHaveLength(12);
   });
 
   it('contains all expected tool names', () => {


### PR DESCRIPTION
## Summary

- Adds `StateSlot` node type with `PRODUCES`/`CONSUMES` edges to model shared state (React Query cache keys, SWR keys, etc.)
- New `data_flow` MCP tool that surfaces data-shape mismatches: `ok`, `suspicious`, or `conflict` verdicts
- React Query and SWR detectors extract cache keys and consumer access patterns from source code
- Shape inference via object literal keys, destructuring patterns, property access chains, and cache key prefix matching
- Pipeline phase 3.7 integration — state slot detection runs after route and tool detection

## Motivation

GitNexus tracks symbol call graphs but has no visibility into runtime data shapes. Two hooks sharing a React Query cache key like `['vendor-patterns', slug]` appear as independent functions in the graph — GitNexus cannot detect that one stores `{total: 42}` while the other expects `VendorPattern[]` from the same cache slot. This is a class of bug that is runtime-only, produces no type errors, and is extremely hard to find manually.

## Test plan

- [ ] 15 unit tests for shape inference utilities
- [ ] 15 unit tests for detectors (React Query + SWR)
- [ ] 10 E2E tests for `data_flow` tool with conflict scenario
- [ ] Updated count-based assertions in schema, security, and tools tests
- [ ] Full test suite passes (3922 tests, 109 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)