### PR TITLE
docs: add gitnexus-shared build step before gitnexus-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,8 @@ Or run locally:
 
 ```bash
 git clone https://github.com/abhigyanpatwari/gitnexus.git
-cd gitnexus/gitnexus-web
-npm install
+cd gitnexus/gitnexus-shared && npm install && npm run build
+cd ../gitnexus-web && npm install
 npm run dev
 ```
 


### PR DESCRIPTION
gitnexus-web imports from gitnexus-shared, which requires npm run build to generate dist/. Without this step, npm run dev fails with module resolution errors.

## Summary                                                                                                                                 
                                                                                                                                             
  Adds the missing `gitnexus-shared` build step to the web UI quick start instructions in README.md.                                         
                  
  ## Motivation / context

  Users following the existing docs get this error when running `npm run dev` in `gitnexus-web`:

  src/core/llm/tools.ts:16:39 - error: Module '"gitnexus-shared"' has no exported member 'NODE_TABLES'

  The `gitnexus-shared` package has its `main` entry pointing to `dist/index.js`, but `dist/` doesn't exist until `npm run build` is run.

  ## Areas touched

  - [ ] `gitnexus/` (CLI / core / MCP server)
  - [ ] `gitnexus-web/` (Vite / React UI)
  - [ ] `.github/` (workflows, actions)
  - [ ] `eval/` or other tooling
  - [x] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

  ## Scope & constraints

  **In scope**

  - Update README.md web UI quick start section to include `gitnexus-shared` build step

  **Explicitly out of scope / not done here**

  - CONTRIBUTING.md (development setup section) — can be updated separately if needed

  ## Implementation notes

  Changed the quick start commands from:
```
  cd gitnexus/gitnexus-web
  npm install
  npm run dev
```

  To:
```
  cd gitnexus/gitnexus-shared && npm install && npm run build
  cd ../gitnexus-web && npm install
  npm run dev
```

  Testing & verification

  - cd gitnexus && npm test
  - cd gitnexus && npm run test:integration
  - cd gitnexus && npx tsc --noEmit
  - cd gitnexus-web && npm test
  - cd gitnexus-web && npx tsc -b --noEmit
  - Manual verification — followed updated steps, npm run dev starts successfully

## Risk & rollout

No code changes — documentation only. Zero risk.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed