### PR TITLE
chore: release v1.5.0

### DIFF
--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to GitNexus will be documented in this file.
 
+## [1.5.0] - 2026-04-01
+
+### Added
+- **Repo landing screen** — when the backend detects indexed repositories, the web UI now shows a landing page with selectable repo cards (name, stats, indexed date) instead of auto-loading the first repo; users can also analyze new repos directly from the landing screen (#607)
+- **Unified web & CLI ingestion pipeline** — complete architectural migration of the web app from a self-contained WASM browser app to a thin client backed by the CLI server; new `gitnexus-shared` package for cross-package type unification (#536)
+  - New server endpoints: `/api/heartbeat` (SSE liveness), `/api/info`, `/api/repos`, `/api/file`, `/api/grep`, `/api/analyze` (SSE progress), `/api/embed`, `/api/mcp` (MCP-over-StreamableHTTP)
+  - Onboarding flow: auto-detect server → connect → repo landing or analyze
+  - Header repo dropdown: switch, re-analyze, or delete repos
+- **Azure OpenAI support for wiki command** — fixed broken Azure auth (`api-key` header), `api-version` URL parameter, reasoning model handling (`max_completion_tokens`, no `temperature`), content filter error messages; added interactive setup wizard, `--api-version` and `--reasoning-model` CLI flags (#562)
+- **Java method references & interface dispatch** — `obj::method` treated as call sites, overload selection via typed variable args (not just literals), interface dispatch emits additional CALLS edges to implementing classes (#540)
+- **MethodExtractor abstraction** — structured method metadata extraction (isAbstract, isFinal, annotations, visibility, parameter types) with config-driven factory pattern (#576)
+  - Java and Kotlin configs with overload-safe `methodInfoCache` keyed by `name:line`
+  - C# config with `sealed`, `params`/`out`/`ref`/optional parameters, `[Attribute]` syntax, `internal` visibility (#582)
+- **`--skip-agents-md` CLI flag** — opt out of overwriting GitNexus-managed sections in AGENTS.md and CLAUDE.md during `gitnexus analyze` (#517)
+- **Prettier** — monorepo-wide code formatter with lint-staged + Husky pre-commit hook, `.prettierrc` config, Tailwind CSS v4 plugin, `endOfLine: "lf"` + `.gitattributes` for Windows consistency (#563)
+- **ESLint v9** — flat config with `unused-imports` auto-removal, `@typescript-eslint` rules, React hooks rules, CI `lint` job (#564)
+
+### Fixed
+- **OpenCode MCP configuration** — corrected README MCP setup for OpenCode which requires `command` as an array containing both executable and arguments (#363)
+- **litellm security** — excluded vulnerable versions 1.82.7 and 1.82.8 in eval harness `pyproject.toml` (#580)
+
+### Changed
+- **Reduced explicit `any` types** — 128 `no-explicit-any` warnings eliminated (689 → 561, 19% reduction) across `NodeProperties` index signature, ~80 `SyntaxNode` substitutions, typed worker protocol, and graphology community detection (#566)
+
+### Docs
+- Added `gitnexus-shared` build step to web UI quick start instructions (#585)
+- Added enterprise offering section to README (#579)
+
 ## [1.4.10] - 2026-03-27
 
 ### Fixed

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.4.10",
+      "version": "1.5.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",


### PR DESCRIPTION
## Release v1.5.0

Updates CHANGELOG.md and syncs package-lock.json for the v1.5.0 release. The version in package.json was already bumped in the prior commit on main.

### Release checklist
- [x] `gitnexus/package.json` version → `1.5.0`
- [x] `gitnexus/package-lock.json` version → `1.5.0`
- [x] `gitnexus/CHANGELOG.md` — v1.5.0 entry with all changes since v1.4.10

### What's in v1.5.0 (14 PRs since v1.4.10)

**Features**
- **Repo landing screen** — web UI shows selectable repo cards instead of auto-loading the first repo (#607)
- **Unified web & CLI pipeline** — web app migrated to thin client backed by CLI server; new `gitnexus-shared` package (#536)
- **Azure OpenAI wiki support** — fixed auth, api-version, reasoning models; added setup wizard + CLI flags (#562)
- **Java method references & interface dispatch** — `obj::method` call sites, typed-arg overload selection, interface→impl edges (#540)
- **MethodExtractor** — structured method metadata (abstract, final, annotations, visibility) for Java, Kotlin (#576), and C# (#582)
- **`--skip-agents-md` flag** — opt out of AGENTS.md/CLAUDE.md updates during analyze (#517)
- **Prettier** — monorepo formatter with lint-staged + Husky pre-commit (#563)
- **ESLint v9** — unused import removal, TypeScript rules, React hooks rules, CI lint job (#564)

**Fixes**
- OpenCode MCP config in README (#363)
- Excluded vulnerable litellm versions in eval harness (#580)

**Changed**
- Reduced explicit `any` types by 19% (689 → 561 warnings) (#566)

**Docs**
- Added gitnexus-shared build step to web UI quick start (#585)
- Added enterprise offering section to README (#579)

### Post-merge steps
After merging this PR:
1. `git tag v1.5.0` on the merge commit
2. `git push origin v1.5.0`
3. The "Publish to npm" workflow will run CI → verify version → build → publish → create GitHub Release


Made with [Cursor](https://cursor.com)