### PR TITLE
ci: use CHANGELOG.md for GitHub Release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,24 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          # Extract everything between ## [VERSION] and the next ## [
+          NOTES=$(awk "/^## \\[$VERSION\\]/{found=1; next} /^## \\[/{if(found) exit} found" gitnexus/CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            echo "::warning::No CHANGELOG entry found for v$VERSION, falling back to auto-generated notes"
+            echo "fallback=true" >> "$GITHUB_OUTPUT"
+          else
+            # Write to file (handles multi-line content safely)
+            echo "$NOTES" > /tmp/release-notes.md
+            echo "fallback=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
-          generate_release_notes: true
+          body_path: ${{ steps.changelog.outputs.fallback == 'false' && '/tmp/release-notes.md' || '' }}
+          generate_release_notes: ${{ steps.changelog.outputs.fallback == 'true' }}


### PR DESCRIPTION
## Summary

Replaces `generate_release_notes: true` in the publish workflow with a step that extracts the current version's section from `gitnexus/CHANGELOG.md` and uses it as the GitHub Release body.

## Problem

The auto-generated release notes just list PR titles grouped by label — not useful for announcements and requires manual editing after every release.

## Solution

Since we already write a thorough, reviewed CHANGELOG entry as part of every release PR, the publish workflow now:

1. Extracts the section between `## [X.Y.Z]` and the next `## [` from `CHANGELOG.md`
2. Uses that as the GitHub Release body via `body_path`
3. Falls back to auto-generated notes if no CHANGELOG entry is found (safety net)

**Before:** Tag push → publish → auto-generated PR list → maintainer manually edits release notes
**After:** Tag push → publish → CHANGELOG section used automatically → done

## How it works

```bash
# awk extracts lines between ## [1.5.0] and the next ## [
awk '/^## \[1.5.0\]/{found=1; next} /^## \[/{if(found) exit} found' gitnexus/CHANGELOG.md
```

The CHANGELOG.md becomes the single source of truth — written and reviewed during the release PR, automatically used by the publish workflow.


Made with [Cursor](https://cursor.com)