### PR TITLE
fix(pipeline): avoid spread push for large deferred call batches

### DIFF
--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -873,7 +873,9 @@ async function runChunkedParseAndResolve(
             );
           }
         }
-        deferredWorkerCalls.push(...chunkWorkerData.calls);
+        for (const c of chunkWorkerData.calls) {
+          deferredWorkerCalls.push(c)
+        }
         deferredWorkerHeritage.push(...chunkWorkerData.heritage);
         deferredConstructorBindings.push(...chunkWorkerData.constructorBindings);
         if (chunkWorkerData.assignments?.length) {


### PR DESCRIPTION
## Summary

This PR replaces spread-based append for deferred worker calls with iterative append in the ingestion pipeline.  
The change preserves behavior/order while avoiding argument-list overflow when a chunk produces a very large call array.

## Motivation / context

`Array.prototype.push(...largeArray)` can fail with a `RangeError` in high-volume scenarios due to argument-list limits.  
This fix hardens chunked parsing/call-resolution flow against large repositories and high call density inputs.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Replace `deferredWorkerCalls.push(...chunkWorkerData.calls)` with iterative append in `runChunkedParseAndResolve`.
- Keep aggregation semantics unchanged (same element order, same downstream behavior).

**Explicitly out of scope / not done here**

- No broad refactor of other spread-based `push(...arr)` usages in the file/codebase.
- No changes to ingestion algorithm, chunking strategy, or resolver logic.
- No UI/docs/workflow updates.

## Implementation notes

- Previous:
  - `deferredWorkerCalls.push(...chunkWorkerData.calls)`
- New:
  - Iterate and `push` one item at a time.
- Rationale: iterative append avoids large variadic argument expansion while maintaining identical output ordering.

## Testing & verification

- [x] `cd gitnexus && npm test`
- [x] `cd gitnexus && npm run test:integration`
- [x] `cd gitnexus && npx tsc --noEmit`
- [x] `cd gitnexus-web && npm test` 
- [x] `cd gitnexus-web && npx tsc -b --noEmit`
- [x] Manual / Playwright E2E

Additional focused verification:

- [x] `cd gitnexus && npx vitest run test/integration/pipeline.test.ts`  
  Result: `1 file passed, 7 tests passed`.

## Risk & rollout

- Risk level: low.
- Change is local to deferred call aggregation and does not alter functional flow.
- No migration needed.
- No breaking API changes.
- Standard rollout; monitor ingestion on large repos for absence of overflow regressions.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions *(not applicable; no such files changed)*
- [x] No secrets, tokens, or machine-specific paths committed