### PR TITLE
fix(mcp): unify stdout silencing to prevent embedder/pool-adapter conflicts

### DIFF
--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -58,8 +58,9 @@ const MAX_CONNS_PER_REPO = 8;
 
 let idleTimer: ReturnType<typeof setInterval> | null = null;
 
-/** Saved real stdout.write — used to silence LadybugDB native output without race conditions */
+/** Saved real stdout/stderr write — used to silence native module output without race conditions */
 export const realStdoutWrite = process.stdout.write.bind(process.stdout);
+export const realStderrWrite = process.stderr.write.bind(process.stderr);
 let stdoutSilenceCount = 0;
 /** True while pre-warming connections — prevents watchdog from prematurely restoring stdout */
 let preWarmActive = false;
@@ -163,13 +164,19 @@ function closeOne(repoId: string): void {
  */
 let activeQueryCount = 0;
 
-function silenceStdout(): void {
+/**
+ * Silence stdout by replacing process.stdout.write with a no-op.
+ * Uses a reference counter so nested silence/restore pairs are safe.
+ * Exported so other modules (e.g. embedder) use the same mechanism instead
+ * of independently patching stdout, which causes restore-order conflicts.
+ */
+export function silenceStdout(): void {
   if (stdoutSilenceCount++ === 0) {
     process.stdout.write = (() => true) as any;
   }
 }
 
-function restoreStdout(): void {
+export function restoreStdout(): void {
   if (--stdoutSilenceCount <= 0) {
     stdoutSilenceCount = 0;
     process.stdout.write = realStdoutWrite;

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -11,6 +11,7 @@ import {
   getHttpDimensions,
   httpEmbedQuery,
 } from '../../core/embeddings/http-client.js';
+import { silenceStdout, restoreStdout, realStderrWrite } from '../../core/lbug/pool-adapter.js';
 
 // Model config
 const MODEL_ID = 'Snowflake/snowflake-arctic-embed-xs';
@@ -54,9 +55,9 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
           // Silence stdout and stderr during model load — ONNX Runtime and transformers.js
           // may write progress/init messages that corrupt MCP stdio protocol or produce
           // noisy warnings (e.g. node assignment to execution providers).
-          const origStdout = process.stdout.write;
-          const origStderr = process.stderr.write;
-          process.stdout.write = (() => true) as any;
+          // Use the centralized silenceStdout() to avoid conflicts with pool-adapter's
+          // own stdout patching (independent patching caused restore-order bugs).
+          silenceStdout();
           process.stderr.write = (() => true) as any;
           try {
             embedderInstance = await (pipeline as any)('feature-extraction', MODEL_ID, {
@@ -64,8 +65,8 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
               dtype: 'fp32',
             });
           } finally {
-            process.stdout.write = origStdout;
-            process.stderr.write = origStderr;
+            restoreStdout();
+            process.stderr.write = realStderrWrite;
           }
           console.error(`GitNexus: Embedding model loaded (${device})`);
           return embedderInstance!;

--- a/gitnexus/test/unit/stdout-silence.test.ts
+++ b/gitnexus/test/unit/stdout-silence.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  silenceStdout,
+  restoreStdout,
+  realStdoutWrite,
+  realStderrWrite,
+} from '../../src/core/lbug/pool-adapter.js';
+
+afterEach(() => {
+  // Safety: always restore in case a test fails mid-silence
+  process.stdout.write = realStdoutWrite;
+});
+
+describe('stdout silencing', () => {
+  it('exports realStdoutWrite and realStderrWrite as bound functions', () => {
+    expect(typeof realStdoutWrite).toBe('function');
+    expect(typeof realStderrWrite).toBe('function');
+  });
+
+  it('silenceStdout replaces process.stdout.write with a no-op', () => {
+    const before = process.stdout.write;
+    silenceStdout();
+    expect(process.stdout.write).not.toBe(before);
+    // The no-op returns true
+    expect((process.stdout.write as any)('test')).toBe(true);
+    restoreStdout();
+  });
+
+  it('restoreStdout puts back the real write function', () => {
+    silenceStdout();
+    restoreStdout();
+    expect(process.stdout.write).toBe(realStdoutWrite);
+  });
+
+  it('handles nested silence/restore (reference counting)', () => {
+    silenceStdout(); // count = 1
+    silenceStdout(); // count = 2
+
+    // Still silenced after first restore
+    restoreStdout(); // count = 1
+    expect(process.stdout.write).not.toBe(realStdoutWrite);
+
+    // Restored after second
+    restoreStdout(); // count = 0
+    expect(process.stdout.write).toBe(realStdoutWrite);
+  });
+
+  it('does not go negative on extra restores', () => {
+    silenceStdout();
+    restoreStdout();
+    restoreStdout(); // extra — should not break
+    restoreStdout(); // extra — should not break
+    expect(process.stdout.write).toBe(realStdoutWrite);
+
+    // Next silence/restore cycle still works
+    silenceStdout();
+    expect(process.stdout.write).not.toBe(realStdoutWrite);
+    restoreStdout();
+    expect(process.stdout.write).toBe(realStdoutWrite);
+  });
+
+  it('simulates embedder + pool-adapter concurrent usage without conflict', () => {
+    // Pool-adapter silences for a query
+    silenceStdout(); // count = 1
+
+    // Embedder starts loading while pool-adapter has silenced
+    silenceStdout(); // count = 2 (embedder uses centralized silence)
+
+    // Pool-adapter query finishes
+    restoreStdout(); // count = 1 — still silenced (embedder still loading)
+    expect(process.stdout.write).not.toBe(realStdoutWrite);
+
+    // Embedder finishes loading
+    restoreStdout(); // count = 0 — fully restored
+    expect(process.stdout.write).toBe(realStdoutWrite);
+  });
+});


### PR DESCRIPTION
## Summary
- Export `silenceStdout()`/`restoreStdout()` from pool-adapter so all modules use the same ref-counted mechanism
- Embedder now uses centralized silencing instead of independent stdout patching
- Export `realStderrWrite` for safe stderr restore in embedder
- Added 6 unit tests including a concurrent-usage simulation

## Root Cause
The embedder and pool-adapter independently patched `process.stdout.write`. When both ran concurrently (e.g. a DB query during model load), the embedder could capture a stale no-op reference while pool-adapter had stdout silenced. On restore, it put back the no-op instead of the real write function, permanently breaking stdout and corrupting the MCP JSON-RPC stream.

**Note:** This fixes the Node-level race condition between pool-adapter and embedder. If KuzuDB's native C++ addon writes directly to fd 1 (bypassing Node's `process.stdout.write`), that would require fd-level redirection or a different transport — a separate issue.

## Changed Files
- `gitnexus/src/core/lbug/pool-adapter.ts` — export `silenceStdout`, `restoreStdout`, `realStderrWrite`
- `gitnexus/src/mcp/core/embedder.ts` — use centralized silencing instead of independent patching
- `gitnexus/test/unit/stdout-silence.test.ts` — 6 new tests

## Test plan
- [x] All 4809 core tests pass (+ 6 new)
- [x] TypeScript compilation clean
- [x] Pre-commit hooks pass
- [x] Real runtime test: proved old bug manifests (stale capture breaks stdout), new code avoids it
- [x] Verified nested concurrent silence/restore ref-counts correctly
- [ ] Manual: run `gitnexus mcp` in VS Code, verify tools are discoverable

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)