### PR TITLE
fix(c): detect function calls inside cast expressions

### DIFF
--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -399,6 +399,9 @@ export const C_QUERIES = `
 ; Calls
 (call_expression function: (identifier) @call.name) @call
 (call_expression function: (field_expression field: (field_identifier) @call.name)) @call
+; Calls inside cast expressions - e.g. (float)func(args)
+(cast_expression value: (call_expression function: (identifier) @call.name)) @call
+(cast_expression value: (call_expression function: (field_expression field: (field_identifier) @call.name))) @call
 `;
 
 // Go queries - works with tree-sitter-go


### PR DESCRIPTION
## Summary

- **Add tree-sitter query patterns for `call_expression` nested inside `cast_expression`** — Ghidra-decompiled C code frequently produces `(float)func(args)`, `(longlong)func(args)`, `(char)func(args)` patterns where the type cast wraps the function call
- **Without this fix, ~30% of C function calls are missed** — the existing C queries only match top-level `call_expression` nodes, not those wrapped in `cast_expression`

Two new patterns added to `C_QUERIES` in `tree-sitter-queries.ts`:
```
(cast_expression value: (call_expression function: (identifier) @call.name)) @call
(cast_expression value: (call_expression function: (field_expression field: (field_identifier) @call.name))) @call
```

**Note:** `CPP_QUERIES` has the same gap for C-style casts in C++ code — out of scope for this PR, can be addressed in a follow-up.

## Test plan

- [x] `npx tsc --noEmit` passes (zero errors)
- [x] `npm test` — 5,089 passed, 10 failed (pre-existing Python resolver failures, unrelated to this change)
- [x] Query compilation smoke test (`query-compilation.test.ts`) — 12/12 pass, confirms new patterns compile against tree-sitter C grammar
- [x] Index a decompiled C codebase (78K files) with cast-heavy function calls — CALLS edges increased from 69,649 to 94,035 (+35%)