### PR TITLE
fix(docs): fix codex duplicate typo in main readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ To configure MCP for your editor, run `npx gitnexus setup` once — or set it up
 | **Codex**       | Yes | Yes    | —                   | MCP + Skills   |
 | **Windsurf**    | Yes | —     | —                   | MCP            |
 | **OpenCode**    | Yes | Yes    | —                   | MCP + Skills   |
-| **Codex**       | Yes | —     | —                   | MCP            |
 
 > **Claude Code** gets the deepest integration: MCP tools + agent skills + PreToolUse hooks that enrich searches with graph context + PostToolUse hooks that auto-reindex after commits.
 


### PR DESCRIPTION
## Summary

Removes a duplicated `Codex` row from the README comparison table. This is a docs-only cleanup with no functional changes.

## Motivation / context

The README contained an obvious duplicate entry, which made the comparison table inaccurate and slightly confusing for readers. This PR fixes that typo only.


## Scope & constraints

**In scope**

- Remove the duplicated `Codex` entry from `README.md`
- Keep the comparison table accurate and easier to read

