### PR TITLE
fix(symbol-table): index constructors in methodByOwner

### DIFF
--- a/gitnexus/src/core/ingestion/symbol-table.ts
+++ b/gitnexus/src/core/ingestion/symbol-table.ts
@@ -183,8 +183,9 @@ export const createSymbolTable = (): SymbolTable => {
     }
     globalIndex.get(name)!.push(def);
 
-    // C2. Methods with ownerId go to methodByOwner index (in addition to globalIndex).
-    if (type === 'Method' && metadata?.ownerId) {
+    // C2. Methods and constructors with ownerId go to methodByOwner index
+    // (in addition to globalIndex).
+    if ((type === 'Method' || type === 'Constructor') && metadata?.ownerId) {
       const key = `${metadata.ownerId}\0${name}`;
       const existing = methodByOwner.get(key);
       if (existing) {

--- a/gitnexus/test/unit/symbol-table.test.ts
+++ b/gitnexus/test/unit/symbol-table.test.ts
@@ -383,12 +383,18 @@ describe('SymbolTable', () => {
       expect(table.lookupMethodByOwner('class:Handler', 'process')).toBeUndefined();
     });
 
-    it('does NOT index Constructor in methodByOwner', () => {
+    it('indexes Constructor in methodByOwner', () => {
       table.add('src/models.ts', 'User', 'ctor:User', 'Constructor', {
         parameterCount: 0,
         ownerId: 'class:User',
       });
-      expect(table.lookupMethodByOwner('class:User', 'User')).toBeUndefined();
+      expect(table.lookupMethodByOwner('class:User', 'User')).toEqual({
+        nodeId: 'ctor:User',
+        filePath: 'src/models.ts',
+        type: 'Constructor',
+        parameterCount: 0,
+        ownerId: 'class:User',
+      });
       // But it should be in lookupFuzzyCallable
       expect(table.lookupFuzzyCallable('User')).toHaveLength(1);
     });


### PR DESCRIPTION
## Summary
- index constructor symbols in `methodByOwner`
- update the symbol table unit test to assert owner-scoped constructor lookup

Closes #671

## Validation
- `npx vitest run --project default test/unit/symbol-table.test.ts`
- `npm run build`