### PR TITLE
[cli] Add fuzzy lookup counters 

### DIFF
--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -1041,6 +1041,9 @@ async function runChunkedParseAndResolve(
     console.log(
       `🔍 Resolution cache: ${rcStats.cacheHits} hits, ${rcStats.cacheMisses} misses (${hitRate}% hit rate)`,
     );
+    console.log(
+      `🔍 Fuzzy Lookups: ${rcStats.fuzzyCallCount} total, ${rcStats.fuzzyCallableCallCount} callable`,
+    );
   }
 
   // ── Worker path quality enrichment: merge TypeEnv file-scope bindings into ExportedTypeMap ──

--- a/gitnexus/src/core/ingestion/resolution-context.ts
+++ b/gitnexus/src/core/ingestion/resolution-context.ts
@@ -70,6 +70,8 @@ export interface ResolutionContext {
   getStats(): {
     fileCount: number;
     globalSymbolCount: number;
+    fuzzyCallCount: number;
+    fuzzyCallableCallCount: number;
     cacheHits: number;
     cacheMisses: number;
   };

--- a/gitnexus/src/core/ingestion/symbol-table.ts
+++ b/gitnexus/src/core/ingestion/symbol-table.ts
@@ -114,7 +114,12 @@ export interface SymbolTable {
   /**
    * Debugging: See how many symbols are tracked
    */
-  getStats: () => { fileCount: number; globalSymbolCount: number };
+  getStats: () => {
+    fileCount: number;
+    globalSymbolCount: number;
+    fuzzyCallCount: number;
+    fuzzyCallableCallCount: number;
+  };
 
   /**
    * Cleanup memory
@@ -149,6 +154,10 @@ export const createSymbolTable = (): SymbolTable => {
   // Only Class, Struct, Interface, Enum, Record symbols are indexed.
   const classByName = new Map<string, SymbolDefinition[]>();
   const classByQualifiedName = new Map<string, SymbolDefinition[]>();
+
+  let fuzzyCallCount = 0;
+
+  let fuzzyCallableCallCount = 0;
 
   const CALLABLE_TYPES = new Set(['Function', 'Method', 'Constructor']);
 
@@ -267,10 +276,12 @@ export const createSymbolTable = (): SymbolTable => {
   };
 
   const lookupFuzzy = (name: string): SymbolDefinition[] => {
+    fuzzyCallCount++;
     return globalIndex.get(name) || [];
   };
 
   const lookupFuzzyCallable = (name: string): SymbolDefinition[] => {
+    fuzzyCallableCallCount++;
     if (!callableIndex) {
       // Build the callable index lazily on first use
       callableIndex = new Map();
@@ -317,6 +328,8 @@ export const createSymbolTable = (): SymbolTable => {
   const getStats = () => ({
     fileCount: fileIndex.size,
     globalSymbolCount: globalIndex.size,
+    fuzzyCallableCallCount: fuzzyCallableCallCount,
+    fuzzyCallCount: fuzzyCallCount,
   });
 
   const clear = () => {
@@ -327,6 +340,8 @@ export const createSymbolTable = (): SymbolTable => {
     methodByOwner.clear();
     classByName.clear();
     classByQualifiedName.clear();
+    fuzzyCallCount = 0;
+    fuzzyCallableCallCount = 0;
   };
 
   return {

--- a/gitnexus/test/unit/symbol-table.test.ts
+++ b/gitnexus/test/unit/symbol-table.test.ts
@@ -88,7 +88,12 @@ describe('SymbolTable', () => {
 
   describe('getStats', () => {
     it('returns zero counts for empty table', () => {
-      expect(table.getStats()).toEqual({ fileCount: 0, globalSymbolCount: 0 });
+      expect(table.getStats()).toEqual({
+        fileCount: 0,
+        globalSymbolCount: 0,
+        fuzzyCallCount: 0,
+        fuzzyCallableCallCount: 0,
+      });
     });
 
     it('tracks unique file count correctly', () => {
@@ -484,7 +489,12 @@ describe('SymbolTable', () => {
       });
       table.add('src/models.ts', 'User', 'class:User', 'Class');
       table.clear();
-      expect(table.getStats()).toEqual({ fileCount: 0, globalSymbolCount: 0 });
+      expect(table.getStats()).toEqual({
+        fileCount: 0,
+        globalSymbolCount: 0,
+        fuzzyCallCount: 0,
+        fuzzyCallableCallCount: 0,
+      });
       expect(table.lookupExact('src/a.ts', 'foo')).toBeUndefined();
       expect(table.lookupFuzzy('foo')).toEqual([]);
       expect(table.lookupFieldByOwner('class:User', 'address')).toBeUndefined();
@@ -497,7 +507,12 @@ describe('SymbolTable', () => {
       table.add('src/a.ts', 'foo', 'func:foo', 'Function');
       table.clear();
       table.add('src/b.ts', 'bar', 'func:bar', 'Function');
-      expect(table.getStats()).toEqual({ fileCount: 1, globalSymbolCount: 1 });
+      expect(table.getStats()).toEqual({
+        fileCount: 1,
+        globalSymbolCount: 1,
+        fuzzyCallCount: 0,
+        fuzzyCallableCallCount: 0,
+      });
     });
 
     it('resets callableIndex so first lookup after clear rebuilds from scratch', () => {


### PR DESCRIPTION
 # Summary

<!-- One or two sentences: what does this PR change? -->

Add fuzzyCallCount and fuzzyCallableCallCount counters to SymbolTable to track fuzzy lookup usage during ingestion. Establishes baseline metric for measuring Phases 1-5 resolution optimization progress.

## Motivation / context
Fixes #672 
<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Add `fuzzyCallCount` counter to track all `lookupFuzzy` calls
- Add `fuzzyCallableCallCount` counter to track all `lookupFuzzyCallable` calls
- Expose both counters via  `ResolutionContext`
- Log fuzzy lookup metrics in dev mode at end of ingestion (pipeline.ts)
- Update test cases to match new `getStats()` object shape

**Explicitly out of scope / not done here**



- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes
**Files modified:**
- `gitnexus/src/core/ingestion/symbol-table.ts` - Counter declarations, increments, getStats() update, clear() update
- `gitnexus/src/core/ingestion/resolution-context.ts` - ResolutionContext.getStats() interface update
- `gitnexus/src/core/ingestion/pipeline.ts` - Dev mode logging after chunk processing
- `gitnexus/test/unit/symbol-table.test.ts` - Updated object shape expectations (lines 91, 485, 502)
<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [x] `cd gitnexus && npm test`
- [x] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [x] `cd gitnexus && npx tsc --noEmit`
- [x] `cd gitnexus-web && npm test` *(if web changed)*
- [x] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [x] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

### **Baseline captured on GitNexus monorepo**
Commands:
`cd gitnexus && npm run build`
For Windows PowerShell:
`$env:NODE_ENV="development"; node dist/cli/index.js analyze ..`

Output:

```
  GitNexus Analyzer

  Markdown: 593 sections, 25 cross-links from 42 files
📂 Scan: 545 paths, 456 parseable (5MB), 1 chunks @ 20MB budget
📊 Import processing (fast path): 150/1887 imports resolved to graph edges
🔍 Resolution cache: 53341 hits, 8327 misses (86.5% hit rate)
🔍 Fuzzy Lookups: 28028 total, 0 callable
🔗 Worker TypeEnv enrichment: 17 fixpoint-inferred exports added to ExportedTypeMap
🗺️ Route registry: 18 routes (3 duplicate URLs skipped)
🔗 Processed 8 fetch() calls against 18 routes
🔧 Tool registry: 16 tools detected
⏭️ Cross-file re-resolution skipped (13/545 files, 2.4% < 3% threshold)
🔀 MRO: 11 classes analyzed, 0 ambiguities, 0 METHOD_OVERRIDES, 6 METHOD_IMPLEMENTS
🏘️ Community detection: 309 communities found (modularity: 0.708)

...
  Repository indexed successfully (11.7s)

  3,899 nodes | 9,026 edges | 309 clusters | 300 flows

```


## Risk & rollout

Risk level: Low
- Observability-only change, no behavior modifications
- No breaking API changes
- Counters properly reset in clear()
<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed
