### PR TITLE
fix(fts): try local LOAD before INSTALL to avoid network failures

### DIFF
--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -1156,12 +1156,11 @@ export const getEmbeddingTableName = (): string => EMBEDDING_TABLE_NAME;
  */
 export const loadFTSExtension = async (targetConn?: lbug.Connection): Promise<boolean> => {
   const useModuleState = targetConn === undefined;
-  if (useModuleState) {
-    if (ftsLoaded) return true;
-    if (!conn) {
-      throw new Error('LadybugDB not initialized. Call initLbug first.');
-    }
-    targetConn = conn;
+  if (useModuleState && ftsLoaded) return true;
+
+  const c: lbug.Connection | null = targetConn ?? conn;
+  if (!c) {
+    throw new Error('LadybugDB not initialized. Call initLbug first.');
   }
 
   const markLoaded = (): true => {
@@ -1171,13 +1170,13 @@ export const loadFTSExtension = async (targetConn?: lbug.Connection): Promise<bo
 
   try {
     // Try loading locally first (no network required)
-    await targetConn!.query('LOAD EXTENSION fts');
+    await c.query('LOAD EXTENSION fts');
     return markLoaded();
   } catch {
     // Fall back to install + load (requires network)
     try {
-      await targetConn!.query('INSTALL fts');
-      await targetConn!.query('LOAD EXTENSION fts');
+      await c.query('INSTALL fts');
+      await c.query('LOAD EXTENSION fts');
       return markLoaded();
     } catch (err: any) {
       const msg = err?.message || '';

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -1155,8 +1155,14 @@ export const loadFTSExtension = async (): Promise<void> => {
     // Try loading locally first (no network required)
     await conn.query('LOAD EXTENSION fts');
     ftsLoaded = true;
-  } catch {
-    // Fall back to install + load (requires network)
+  } catch (err: any) {
+    // Fall back to install + load (requires network).  Log a breadcrumb so
+    // cache corruption / version mismatches leave a diagnostic trail instead
+    // of a silent fall-through to the (slower, network-bound) INSTALL path.
+    console.debug(
+      'GitNexus: FTS LOAD from cache failed, will attempt INSTALL:',
+      err?.message || '',
+    );
     try {
       await conn.query('INSTALL fts');
       await conn.query('LOAD EXTENSION fts');

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -1144,29 +1144,41 @@ export const getEmbeddingTableName = (): string => EMBEDDING_TABLE_NAME;
 
 /**
  * Load the FTS extension (required before using FTS functions).
- * Safe to call multiple times — tracks loaded state via module-level ftsLoaded.
+ *
+ * Safe to call multiple times — when invoked without arguments, tracks loaded
+ * state via module-level `ftsLoaded`. When invoked with an explicit
+ * connection, loads on that connection and returns whether the load
+ * succeeded — letting callers (e.g. the pool adapter) track their own state.
+ *
+ * Tries `LOAD EXTENSION fts` first so previously-cached installs skip the
+ * network entirely; falls back to `INSTALL` + `LOAD` only when the extension
+ * hasn't been cached yet.
  */
-export const loadFTSExtension = async (): Promise<void> => {
-  if (ftsLoaded) return;
-  if (!conn) {
-    throw new Error('LadybugDB not initialized. Call initLbug first.');
+export const loadFTSExtension = async (targetConn?: lbug.Connection): Promise<boolean> => {
+  const useModuleState = targetConn === undefined;
+  if (useModuleState) {
+    if (ftsLoaded) return true;
+    if (!conn) {
+      throw new Error('LadybugDB not initialized. Call initLbug first.');
+    }
+    targetConn = conn;
   }
+
+  const markLoaded = (): true => {
+    if (useModuleState) ftsLoaded = true;
+    return true;
+  };
+
   try {
     // Try loading locally first (no network required)
-    await conn.query('LOAD EXTENSION fts');
-    ftsLoaded = true;
-  } catch (err: any) {
-    // Fall back to install + load (requires network).  Log a breadcrumb so
-    // cache corruption / version mismatches leave a diagnostic trail instead
-    // of a silent fall-through to the (slower, network-bound) INSTALL path.
-    console.debug(
-      'GitNexus: FTS LOAD from cache failed, will attempt INSTALL:',
-      err?.message || '',
-    );
+    await targetConn!.query('LOAD EXTENSION fts');
+    return markLoaded();
+  } catch {
+    // Fall back to install + load (requires network)
     try {
-      await conn.query('INSTALL fts');
-      await conn.query('LOAD EXTENSION fts');
-      ftsLoaded = true;
+      await targetConn!.query('INSTALL fts');
+      await targetConn!.query('LOAD EXTENSION fts');
+      return markLoaded();
     } catch (err: any) {
       const msg = err?.message || '';
       if (
@@ -1174,10 +1186,10 @@ export const loadFTSExtension = async (): Promise<void> => {
         msg.includes('already installed') ||
         msg.includes('already exists')
       ) {
-        ftsLoaded = true;
-      } else {
-        console.error('GitNexus: FTS extension load failed:', msg);
+        return markLoaded();
       }
+      console.error('GitNexus: FTS extension load failed:', msg);
+      return false;
     }
   }
 };

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -17,6 +17,7 @@
 
 import fs from 'fs/promises';
 import lbug from '@ladybugdb/core';
+import { loadFTSExtension } from './lbug-adapter.js';
 
 /** Per-repo pool: one Database, many Connections */
 interface PoolEntry {
@@ -354,19 +355,7 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
   // Done BEFORE pool registration so no concurrent checkout can grab
   // the connection while the async FTS load is in progress.
   if (!shared.ftsLoaded) {
-    try {
-      await available[0].query('LOAD EXTENSION fts');
-      shared.ftsLoaded = true;
-    } catch {
-      // Extension not cached locally — try INSTALL (downloads from remote) then LOAD
-      try {
-        await available[0].query('INSTALL fts');
-        await available[0].query('LOAD EXTENSION fts');
-        shared.ftsLoaded = true;
-      } catch {
-        // FTS unavailable — queries will fail gracefully
-      }
-    }
+    shared.ftsLoaded = await loadFTSExtension(available[0]);
   }
 
   // Load VECTOR extension once per shared Database for semantic search support.
@@ -440,19 +429,7 @@ export async function initLbugWithDb(
 
   // Load FTS extension if not already loaded on this Database
   if (!shared.ftsLoaded) {
-    try {
-      await available[0].query('LOAD EXTENSION fts');
-      shared.ftsLoaded = true;
-    } catch {
-      // Extension not cached locally — try INSTALL (downloads from remote) then LOAD
-      try {
-        await available[0].query('INSTALL fts');
-        await available[0].query('LOAD EXTENSION fts');
-        shared.ftsLoaded = true;
-      } catch {
-        // FTS unavailable — queries will fail gracefully
-      }
-    }
+    shared.ftsLoaded = await loadFTSExtension(available[0]);
   }
 
   // Load VECTOR extension for semantic search support

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -358,7 +358,14 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
       await available[0].query('LOAD EXTENSION fts');
       shared.ftsLoaded = true;
     } catch {
-      // Extension may not be installed — FTS queries will fail gracefully
+      // Extension not cached locally — try INSTALL (downloads from remote) then LOAD
+      try {
+        await available[0].query('INSTALL fts');
+        await available[0].query('LOAD EXTENSION fts');
+        shared.ftsLoaded = true;
+      } catch {
+        // FTS unavailable — queries will fail gracefully
+      }
     }
   }
 
@@ -437,7 +444,14 @@ export async function initLbugWithDb(
       await available[0].query('LOAD EXTENSION fts');
       shared.ftsLoaded = true;
     } catch {
-      // Extension may already be loaded or not installed
+      // Extension not cached locally — try INSTALL (downloads from remote) then LOAD
+      try {
+        await available[0].query('INSTALL fts');
+        await available[0].query('LOAD EXTENSION fts');
+        shared.ftsLoaded = true;
+      } catch {
+        // FTS unavailable — queries will fail gracefully
+      }
     }
   }
 

--- a/gitnexus/test/integration/lbug-core-adapter.test.ts
+++ b/gitnexus/test/integration/lbug-core-adapter.test.ts
@@ -45,6 +45,31 @@ withTestLbugDB(
         ).resolves.toBeUndefined();
       });
 
+      it('loadFTSExtension(conn): loads on an explicit connection and returns true', async () => {
+        const lbug = (await import('@ladybugdb/core')).default;
+        const { loadFTSExtension, getDatabase } =
+          await import('../../src/core/lbug/lbug-adapter.js');
+
+        const db = getDatabase();
+        expect(db).not.toBeNull();
+
+        // Fresh Connection on the same Database — simulates the pool adapter's
+        // path where loadFTSExtension is called with an explicit connection
+        // rather than the module-level singleton.
+        const freshConn = new lbug.Connection(db!);
+        try {
+          const loaded = await loadFTSExtension(freshConn);
+          expect(loaded).toBe(true);
+
+          // Idempotent on the same connection — calling again still returns true
+          // (exercises the "already loaded" catch branch in the fallback path).
+          const loadedAgain = await loadFTSExtension(freshConn);
+          expect(loadedAgain).toBe(true);
+        } finally {
+          await freshConn.close().catch(() => {});
+        }
+      });
+
       it('getLbugStats: returns correct node and edge counts for seeded data', async () => {
         const { getLbugStats } = await import('../../src/core/lbug/lbug-adapter.js');
 


### PR DESCRIPTION
## Summary

Follow-up to #781 (which landed the `loadFTSExtension` LOAD-first reorder). This PR extends that fix to the two places it was missed:

- **`pool-adapter.ts`** — `initPool` and `initLbugWithDb` only did `LOAD EXTENSION fts` and silently swallowed failures. If the extension was never installed (no prior `gitnexus analyze` run), FTS queries failed at runtime with no diagnostic. Both paths now call `loadFTSExtension(available[0])` so the core adapter's LOAD→INSTALL fallback applies here too.
- **`lbug-adapter.ts`** — `loadFTSExtension` now accepts an optional `Connection` and returns a success boolean, letting the pool adapter track `shared.ftsLoaded` without duplicating the error-handling chain.

Fixes the residual case from #712 for MCP pool users who haven't run `gitnexus analyze` locally.

**Contract change:** `loadFTSExtension` return type changed from `Promise<void>` to `Promise<boolean>`; existing callers that discard the result are unaffected.

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] `lbug-core-adapter` integration tests pass — now includes a targeted test for the `loadFTSExtension(conn)` path on a fresh Connection
- [x] `search-pool` / `search-core` integration tests pass
- [ ] Verify MCP pool path: connect against a repo where FTS extension was never installed — should now install + load instead of failing silently