### PR TITLE
feat(cli): add --no-stats flag to suppress stats from CLAUDE.md/AGENTS.md

### DIFF
--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -26,6 +26,8 @@ interface RepoStats {
 
 export interface AIContextOptions {
   skipAgentsMd?: boolean;
+  /** When true, omit stats numbers from the introductory line to reduce git noise. */
+  noStats?: boolean;
 }
 
 const GITNEXUS_START_MARKER = '<!-- gitnexus:start -->';
@@ -64,6 +66,7 @@ function generateGitNexusContent(
   stats: RepoStats,
   generatedSkills?: GeneratedSkillInfo[],
   groupNames?: string[],
+  noStats?: boolean,
 ): string {
   const generatedRows =
     generatedSkills && generatedSkills.length > 0
@@ -84,10 +87,14 @@ function generateGitNexusContent(
 | Tools, resources, schema reference | \`.claude/skills/gitnexus/gitnexus-guide/SKILL.md\` |
 | Index, status, clean, wiki CLI commands | \`.claude/skills/gitnexus/gitnexus-cli/SKILL.md\` |${generatedRows ? '\n' + generatedRows : ''}`;
 
+  const statsStr = noStats
+    ? ''
+    : ` (${stats.nodes || 0} symbols, ${stats.edges || 0} relationships, ${stats.processes || 0} execution flows)`;
+
   return `${GITNEXUS_START_MARKER}
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **${projectName}** (${stats.nodes || 0} symbols, ${stats.edges || 0} relationships, ${stats.processes || 0} execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **${projectName}**${statsStr}. Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run \`npx gitnexus analyze\` in terminal first.
 
@@ -332,7 +339,7 @@ export async function generateAIContextFiles(
   options?: AIContextOptions,
 ): Promise<{ files: string[] }> {
   const groupNames = await findGroupsContainingRegistryName(projectName);
-  const content = generateGitNexusContent(projectName, stats, generatedSkills, groupNames);
+  const content = generateGitNexusContent(projectName, stats, generatedSkills, groupNames, options?.noStats);
   const createdFiles: string[] = [];
 
   if (!options?.skipAgentsMd) {

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -47,6 +47,8 @@ export interface AnalyzeOptions {
   verbose?: boolean;
   /** Skip AGENTS.md and CLAUDE.md gitnexus block updates. */
   skipAgentsMd?: boolean;
+  /** Omit stats numbers from CLAUDE.md/AGENTS.md to reduce git noise. */
+  noStats?: boolean;
   /** Index the folder even when no .git directory is present. */
   skipGit?: boolean;
 }
@@ -177,6 +179,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
         embeddings: options?.embeddings,
         skipGit: options?.skipGit,
         skipAgentsMd: options?.skipAgentsMd,
+        noStats: options?.noStats,
       },
       {
         onProgress: (_phase, percent, message) => {
@@ -240,7 +243,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
               processes: s.processes,
             },
             skillResult.skills,
-            { skipAgentsMd: options?.skipAgentsMd },
+            { skipAgentsMd: options?.skipAgentsMd, noStats: options?.noStats },
           );
         }
       } catch {

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -26,6 +26,7 @@ program
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
   .option('--skills', 'Generate repo-specific skill files from detected communities')
   .option('--skip-agents-md', 'Skip updating the gitnexus section in AGENTS.md and CLAUDE.md')
+  .option('--no-stats', 'Omit stats numbers from CLAUDE.md and AGENTS.md to reduce git noise')
   .option('--skip-git', 'Index a folder without requiring a .git directory')
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
   .addHelpText(

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -48,6 +48,8 @@ export interface AnalyzeOptions {
   skipGit?: boolean;
   /** Skip AGENTS.md and CLAUDE.md gitnexus block updates. */
   skipAgentsMd?: boolean;
+  /** Omit stats numbers from CLAUDE.md/AGENTS.md to reduce git noise. */
+  noStats?: boolean;
 }
 
 export interface AnalyzeResult {
@@ -327,7 +329,7 @@ export async function runFullAnalysis(
           processes: pipelineResult.processResult?.stats.totalProcesses,
         },
         undefined,
-        { skipAgentsMd: options.skipAgentsMd },
+        { skipAgentsMd: options.skipAgentsMd, noStats: options.noStats },
       );
     } catch {
       // Best-effort — don't fail the entire analysis for context file issues

--- a/gitnexus/test/unit/ai-context.test.ts
+++ b/gitnexus/test/unit/ai-context.test.ts
@@ -80,6 +80,41 @@ describe('generateAIContextFiles', () => {
     }
   });
 
+  it('omits stats numbers when noStats is enabled', async () => {
+    const noStatsTmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-ai-ctx-nostats-'));
+    const noStatsStoragePath = path.join(noStatsTmpDir, '.gitnexus');
+    await fs.mkdir(noStatsStoragePath, { recursive: true });
+
+    const stats = { nodes: 100, edges: 200, processes: 10 };
+    await generateAIContextFiles(noStatsTmpDir, noStatsStoragePath, 'TestProject', stats, undefined, {
+      noStats: true,
+    });
+
+    const claudeMdPath = path.join(noStatsTmpDir, 'CLAUDE.md');
+    const content = await fs.readFile(claudeMdPath, 'utf-8');
+    expect(content).toContain('indexed by GitNexus as **TestProject**.');
+    expect(content).not.toContain('100 symbols');
+    expect(content).not.toContain('200 relationships');
+    expect(content).not.toContain('10 execution flows');
+
+    await fs.rm(noStatsTmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('includes stats numbers by default', async () => {
+    const defaultTmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-ai-ctx-stats-'));
+    const defaultStoragePath = path.join(defaultTmpDir, '.gitnexus');
+    await fs.mkdir(defaultStoragePath, { recursive: true });
+
+    const stats = { nodes: 100, edges: 200, processes: 10 };
+    await generateAIContextFiles(defaultTmpDir, defaultStoragePath, 'TestProject', stats);
+
+    const claudeMdPath = path.join(defaultTmpDir, 'CLAUDE.md');
+    const content = await fs.readFile(claudeMdPath, 'utf-8');
+    expect(content).toContain('100 symbols, 200 relationships, 10 execution flows');
+
+    await fs.rm(defaultTmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
   it('preserves manual AGENTS.md and CLAUDE.md edits when skipAgentsMd is enabled', async () => {
     const stats = { nodes: 42, edges: 84, processes: 3 };
     const agentsPath = path.join(tmpDir, 'AGENTS.md');


### PR DESCRIPTION
## Summary

Fixes #704

- Adds `--no-stats` CLI flag to `gitnexus analyze` that omits the stats parenthetical `(N symbols, N relationships, N execution flows)` from CLAUDE.md and AGENTS.md
- When set, the intro line becomes: `This project is indexed by GitNexus as **ProjectName**. Use the GitNexus MCP tools...`
- Stats remain available in `.gitnexus/meta.json` and MCP resource responses (unaffected)

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 8 unit tests pass (`npx vitest run test/unit/ai-context.test.ts`)
- [ ] Manual: `npx gitnexus analyze --no-stats` then verify CLAUDE.md has no stats numbers
- [ ] Manual: `npx gitnexus analyze` (without flag) still includes stats as before