### PR TITLE
docs: add missing --skip-git option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ gitnexus setup                   # Configure MCP for your editors (one-time)
 gitnexus analyze [path]          # Index a repository (or update stale index)
 gitnexus analyze --force         # Force full re-index
 gitnexus analyze --skills        # Generate repo-specific skill files from detected communities
+gitnexus analyze --skip-git        # Index a folder without requiring a .git directory
 gitnexus analyze --skip-embeddings  # Skip embedding generation (faster)
 gitnexus analyze --skip-agents-md  # Preserve custom AGENTS.md/CLAUDE.md gitnexus section edits
 gitnexus analyze --embeddings    # Enable embedding generation (slower, better search)


### PR DESCRIPTION
## Summary
- Added the `--skip-git` CLI option to the README command reference table
- This option allows indexing folders that don't have a `.git` directory, which is already implemented in the CLI (`src/cli/index.ts`) but was missing from documentation

Fixes #724