### PR TITLE
docs: include --skip-git in README command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ gitnexus analyze --force         # Force full re-index
 gitnexus analyze --skills        # Generate repo-specific skill files from detected communities
 gitnexus analyze --skip-embeddings  # Skip embedding generation (faster)
 gitnexus analyze --skip-agents-md  # Preserve custom AGENTS.md/CLAUDE.md gitnexus section edits
+gitnexus analyze --skip-git        # Index folders that are not Git repositories
 gitnexus analyze --embeddings    # Enable embedding generation (slower, better search)
 gitnexus analyze --verbose       # Log skipped files when parsers are unavailable
 gitnexus mcp                     # Start MCP server (stdio) — serves all indexed repos


### PR DESCRIPTION
## Summary
Adds the missing `--skip-git` option to the README CLI command reference.

This flag already exists in the CLI implementation and tests, but it was missing from the top-level docs command list.

Fixes #724
