### PR TITLE
fix: convert recursive AST traversal to iterative to prevent stack overflow

### DIFF
--- a/gitnexus/src/core/ingestion/type-env.ts
+++ b/gitnexus/src/core/ingestion/type-env.ts
@@ -1088,9 +1088,20 @@ export const buildTypeEnv = (
     }
   };
 
-  const walk = (node: SyntaxNode, currentScope: string): void => {
+  // Iterative traversal with explicit stack to prevent V8 call stack overflow
+  // on deeply nested ASTs (fixes #776, #772, #752, #706)
+  interface WalkFrame {
+    node: SyntaxNode;
+    scope: string;
+  }
+
+  const walkStack: WalkFrame[] = [{ node: tree.rootNode, scope: FILE_SCOPE }];
+
+  while (walkStack.length > 0) {
+    const { node, scope: currentScope } = walkStack.pop()!;
+
     // Fast skip: subtrees that can never contain type-relevant nodes (leaf-like literals).
-    if (SKIP_SUBTREE_TYPES.has(node.type)) return;
+    if (SKIP_SUBTREE_TYPES.has(node.type)) continue;
 
     // Collect class/struct names as we encounter them (used by extractInitializer
     // to distinguish constructor calls from function calls, e.g. C++ `User()` vs `getUser()`)
@@ -1205,14 +1216,12 @@ export const buildTypeEnv = (
       }
     }
 
-    // Recurse into children
-    for (let i = 0; i < node.childCount; i++) {
+    // Push children in reverse order so leftmost child is processed first (pre-order DFS)
+    for (let i = node.childCount - 1; i >= 0; i--) {
       const child = node.child(i);
-      if (child) walk(child, scope);
+      if (child) walkStack.push({ node: child, scope });
     }
-  };
-
-  walk(tree.rootNode, FILE_SCOPE);
+  }
 
   // Phase 14: Seed cross-file bindings from upstream files AFTER walk
   // (local declarations from walk() take precedence — first-writer-wins)

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -413,10 +413,15 @@ export const CALL_ARGUMENT_LIST_TYPES = new Set(['arguments', 'argument_list', '
 
 /** Walk an AST node depth-first, returning the first descendant with the given type. */
 export function findDescendant(node: SyntaxNode, type: string): SyntaxNode | null {
-  if (node.type === type) return node;
-  for (const child of node.children ?? []) {
-    const found = findDescendant(child, type);
-    if (found) return found;
+  // Iterative DFS to avoid stack overflow on deeply nested ASTs
+  const stack: SyntaxNode[] = [node];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.type === type) return current;
+    for (let i = current.childCount - 1; i >= 0; i--) {
+      const child = current.child(i);
+      if (child) stack.push(child);
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Problem

GitNexus crashes with `Maximum call stack size exceeded` on large codebases:
- Go stdlib (~10K files) -- #706
- Laravel apps (~373 PHP files) -- #776  
- Large iOS/Android projects -- #772
- Various repos on Windows -- #752

The root cause is `walk()` in `type-env.ts`, which performs **unbounded recursive** depth-first traversal of tree-sitter ASTs. Files with deeply nested structures (switch/case blocks, chained callbacks, builder patterns) exceed V8's ~10K call stack limit.

`findDescendant()` in `ast-helpers.ts` has the same issue for PHP/Laravel files.

## Fix

Converted both functions to **iterative traversal using an explicit stack array**. This is the same pattern already used in `extractLaravelRoutes` (parse-worker.ts line 1195), so the approach is consistent with the codebase.

The iterative version:
- Eliminates the call stack depth constraint entirely
- Preserves identical traversal order (pre-order DFS, left-to-right)
- Carries scope state in stack frames (for `walk()`)
- Has zero behavioral difference -- same nodes visited, same bindings extracted

## Testing

The fix is a mechanical refactor of the traversal strategy. The binding extraction logic, scope computation, and skip conditions are unchanged. The only difference is memory allocation: heap (explicit stack array) instead of call stack (function frames).

Fixes #776, #772, #752, #706