### PR TITLE
fix: map diff hunks to symbol line ranges in detect_changes

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -21,6 +21,7 @@ export { isWriteQuery };
 // at MCP server startup — crashes on unsupported Node ABI versions (#89)
 // git utilities available if needed
 // import { isGitRepo, getCurrentCommit, getGitRoot } from '../../storage/git.js';
+import { parseDiffHunks, type FileDiff } from '../../storage/git.js';
 import {
   listRegisteredRepos,
   cleanupOldKuzuFiles,
@@ -1528,33 +1529,31 @@ export class LocalBackend {
     let diffArgs: string[];
     switch (scope) {
       case 'staged':
-        diffArgs = ['diff', '--staged', '--name-only'];
+        diffArgs = ['diff', '--staged', '-U0'];
         break;
       case 'all':
-        diffArgs = ['diff', 'HEAD', '--name-only'];
+        diffArgs = ['diff', 'HEAD', '-U0'];
         break;
       case 'compare':
         if (!params.base_ref) return { error: 'base_ref is required for "compare" scope' };
-        diffArgs = ['diff', params.base_ref, '--name-only'];
+        diffArgs = ['diff', params.base_ref, '-U0'];
         break;
       case 'unstaged':
       default:
-        diffArgs = ['diff', '--name-only'];
+        diffArgs = ['diff', '-U0'];
         break;
     }
 
-    let changedFiles: string[];
+    let diffOutput: string;
     try {
-      const output = execFileSync('git', diffArgs, { cwd: repo.repoPath, encoding: 'utf-8' });
-      changedFiles = output
-        .trim()
-        .split('\n')
-        .filter((f) => f.length > 0);
+      diffOutput = execFileSync('git', diffArgs, { cwd: repo.repoPath, encoding: 'utf-8' });
     } catch (err: any) {
       return { error: `Git diff failed: ${err.message}` };
     }
 
-    if (changedFiles.length === 0) {
+    const fileDiffs: FileDiff[] = parseDiffHunks(diffOutput);
+
+    if (fileDiffs.length === 0) {
       return {
         summary: {
           changed_count: 0,
@@ -1567,27 +1566,39 @@ export class LocalBackend {
       };
     }
 
-    // Map changed files to indexed symbols
+    // Map diff hunks to indexed symbols via range overlap
     const changedSymbols: any[] = [];
-    for (const file of changedFiles) {
-      const normalizedFile = file.replace(/\\/g, '/');
+    for (const fileDiff of fileDiffs) {
+      if (fileDiff.hunks.length === 0) continue;
+
+      // Build range overlap conditions for all hunks in this file
+      const overlapConditions = fileDiff.hunks
+        .map((_, i) => `(n.startLine <= $hunkEnd${i} AND n.endLine >= $hunkStart${i})`)
+        .join(' OR ');
+
+      const params: Record<string, any> = { filePath: fileDiff.filePath };
+      fileDiff.hunks.forEach((hunk, i) => {
+        params[`hunkStart${i}`] = hunk.startLine;
+        params[`hunkEnd${i}`] = hunk.endLine;
+      });
+
+      const symbolQuery = `
+        MATCH (n) WHERE n.filePath ENDS WITH $filePath
+          AND n.startLine IS NOT NULL AND n.endLine IS NOT NULL
+          AND (${overlapConditions})
+        RETURN n.id AS id, n.name AS name, labels(n)[0] AS type,
+               n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine
+      `;
+
       try {
-        const symbols = await executeParameterized(
-          repo.id,
-          `
-          MATCH (n) WHERE n.filePath CONTAINS $filePath
-          RETURN n.id AS id, n.name AS name, labels(n)[0] AS type, n.filePath AS filePath
-          LIMIT 20
-        `,
-          { filePath: normalizedFile },
-        );
-        for (const sym of symbols) {
+        const rows = await executeParameterized(repo.id, symbolQuery, params);
+        for (const sym of rows) {
           changedSymbols.push({
             id: sym.id || sym[0],
             name: sym.name || sym[1],
             type: sym.type || sym[2],
             filePath: sym.filePath || sym[3],
-            change_type: 'Modified',
+            change_type: 'touched',
           });
         }
       } catch (e) {
@@ -1642,7 +1653,7 @@ export class LocalBackend {
       summary: {
         changed_count: changedSymbols.length,
         affected_count: processCount,
-        changed_files: changedFiles.length,
+        changed_files: fileDiffs.length,
         risk_level: risk,
       },
       changed_symbols: changedSymbols,

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1576,10 +1576,10 @@ export class LocalBackend {
         .map((_, i) => `(n.startLine <= $hunkEnd${i} AND n.endLine >= $hunkStart${i})`)
         .join(' OR ');
 
-      const params: Record<string, any> = { filePath: fileDiff.filePath };
+      const queryParams: Record<string, any> = { filePath: fileDiff.filePath };
       fileDiff.hunks.forEach((hunk, i) => {
-        params[`hunkStart${i}`] = hunk.startLine;
-        params[`hunkEnd${i}`] = hunk.endLine;
+        queryParams[`hunkStart${i}`] = hunk.startLine;
+        queryParams[`hunkEnd${i}`] = hunk.endLine;
       });
 
       const symbolQuery = `
@@ -1591,7 +1591,7 @@ export class LocalBackend {
       `;
 
       try {
-        const rows = await executeParameterized(repo.id, symbolQuery, params);
+        const rows = await executeParameterized(repo.id, symbolQuery, queryParams);
         for (const sym of rows) {
           changedSymbols.push({
             id: sym.id || sym[0],
@@ -1606,32 +1606,37 @@ export class LocalBackend {
       }
     }
 
-    // Find affected processes
+    // Find affected processes -- single batched query instead of N+1
     const affectedProcesses = new Map<string, any>();
-    for (const sym of changedSymbols) {
+    if (changedSymbols.length > 0) {
+      const symIds = changedSymbols.map((s) => s.id);
+      const symNameById = new Map(changedSymbols.map((s) => [s.id, s.name]));
       try {
         const procs = await executeParameterized(
           repo.id,
           `
-          MATCH (n {id: $nodeId})-[r:CodeRelation {type: 'STEP_IN_PROCESS'}]->(p:Process)
-          RETURN p.id AS pid, p.heuristicLabel AS label, p.processType AS processType, p.stepCount AS stepCount, r.step AS step
+          MATCH (n)-[r:CodeRelation {type: 'STEP_IN_PROCESS'}]->(p:Process)
+          WHERE n.id IN $ids
+          RETURN n.id AS nodeId, p.id AS pid, p.heuristicLabel AS label,
+                 p.processType AS processType, p.stepCount AS stepCount, r.step AS step
         `,
-          { nodeId: sym.id },
+          { ids: symIds },
         );
         for (const proc of procs) {
-          const pid = proc.pid || proc[0];
+          const nodeId = proc.nodeId || proc[0];
+          const pid = proc.pid || proc[1];
           if (!affectedProcesses.has(pid)) {
             affectedProcesses.set(pid, {
               id: pid,
-              name: proc.label || proc[1],
-              process_type: proc.processType || proc[2],
-              step_count: proc.stepCount || proc[3],
+              name: proc.label || proc[2],
+              process_type: proc.processType || proc[3],
+              step_count: proc.stepCount || proc[4],
               changed_steps: [],
             });
           }
           affectedProcesses.get(pid)!.changed_steps.push({
-            symbol: sym.name,
-            step: proc.step || proc[4],
+            symbol: symNameById.get(nodeId) ?? nodeId,
+            step: proc.step || proc[5],
           });
         }
       } catch (e) {

--- a/gitnexus/src/storage/git.ts
+++ b/gitnexus/src/storage/git.ts
@@ -52,3 +52,38 @@ export const hasGitDir = (dirPath: string): boolean => {
     return false;
   }
 };
+
+export interface DiffHunk {
+  startLine: number;
+  endLine: number;
+}
+
+export interface FileDiff {
+  filePath: string;
+  hunks: DiffHunk[];
+}
+
+/**
+ * Parse unified diff output (with -U0) into per-file hunk ranges.
+ * Extracts the new-file line ranges from @@ hunk headers.
+ */
+export function parseDiffHunks(diffOutput: string): FileDiff[] {
+  const files: FileDiff[] = [];
+  let current: FileDiff | null = null;
+  for (const line of diffOutput.split('\n')) {
+    if (line.startsWith('+++ b/')) {
+      current = { filePath: line.slice(6), hunks: [] };
+      files.push(current);
+    } else if (line.startsWith('@@') && current) {
+      const match = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+      if (match) {
+        const start = parseInt(match[1], 10);
+        const count = match[2] !== undefined ? parseInt(match[2], 10) : 1;
+        if (count > 0) {
+          current.hunks.push({ startLine: start, endLine: start + count - 1 });
+        }
+      }
+    }
+  }
+  return files;
+}

--- a/gitnexus/test/unit/parse-diff-hunks.test.ts
+++ b/gitnexus/test/unit/parse-diff-hunks.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { parseDiffHunks } from '../../src/storage/git.js';
+
+describe('parseDiffHunks', () => {
+  it('parses a single file with one hunk', () => {
+    const diff = [
+      'diff --git a/src/foo.ts b/src/foo.ts',
+      '--- a/src/foo.ts',
+      '+++ b/src/foo.ts',
+      '@@ -10,0 +11,3 @@ some context',
+      '+line1',
+      '+line2',
+      '+line3',
+    ].join('\n');
+    const result = parseDiffHunks(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0].filePath).toBe('src/foo.ts');
+    expect(result[0].hunks).toEqual([{ startLine: 11, endLine: 13 }]);
+  });
+
+  it('parses multiple hunks in a single file', () => {
+    const diff = [
+      'diff --git a/src/bar.ts b/src/bar.ts',
+      '--- a/src/bar.ts',
+      '+++ b/src/bar.ts',
+      '@@ -5,2 +5,4 @@ context',
+      ' unchanged',
+      '+added',
+      '@@ -20,0 +22,1 @@ more context',
+      '+another line',
+    ].join('\n');
+    const result = parseDiffHunks(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0].hunks).toHaveLength(2);
+    expect(result[0].hunks[0]).toEqual({ startLine: 5, endLine: 8 });
+    expect(result[0].hunks[1]).toEqual({ startLine: 22, endLine: 22 });
+  });
+
+  it('parses multiple files', () => {
+    const diff = [
+      'diff --git a/a.ts b/a.ts',
+      '--- a/a.ts',
+      '+++ b/a.ts',
+      '@@ -1,0 +1,2 @@',
+      '+line',
+      'diff --git a/b.ts b/b.ts',
+      '--- a/b.ts',
+      '+++ b/b.ts',
+      '@@ -10,3 +10,5 @@',
+      ' ctx',
+    ].join('\n');
+    const result = parseDiffHunks(diff);
+    expect(result).toHaveLength(2);
+    expect(result[0].filePath).toBe('a.ts');
+    expect(result[0].hunks).toEqual([{ startLine: 1, endLine: 2 }]);
+    expect(result[1].filePath).toBe('b.ts');
+    expect(result[1].hunks).toEqual([{ startLine: 10, endLine: 14 }]);
+  });
+
+  it('handles single-line hunks without count', () => {
+    // When count is omitted from @@ header, it defaults to 1
+    const diff = [
+      '+++ b/src/single.ts',
+      '@@ -5,0 +6 @@ context',
+      '+one line',
+    ].join('\n');
+    const result = parseDiffHunks(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0].hunks).toEqual([{ startLine: 6, endLine: 6 }]);
+  });
+
+  it('skips pure-deletion hunks (count=0)', () => {
+    const diff = [
+      '+++ b/src/del.ts',
+      '@@ -10,3 +10,0 @@ context',
+    ].join('\n');
+    const result = parseDiffHunks(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0].hunks).toHaveLength(0);
+  });
+
+  it('returns empty array for empty diff output', () => {
+    expect(parseDiffHunks('')).toEqual([]);
+  });
+
+  it('returns empty array for diff with no file headers', () => {
+    expect(parseDiffHunks('nothing useful here\n')).toEqual([]);
+  });
+
+  it('assigns hunks to the correct file when files are interleaved', () => {
+    // Realistic multi-file diff with context lines between
+    const diff = [
+      'diff --git a/src/alpha.ts b/src/alpha.ts',
+      'index abc..def 100644',
+      '--- a/src/alpha.ts',
+      '+++ b/src/alpha.ts',
+      '@@ -100,0 +101,2 @@ export function alpha() {',
+      '+  const x = 1;',
+      '+  return x;',
+      'diff --git a/src/beta.ts b/src/beta.ts',
+      'index 111..222 100644',
+      '--- a/src/beta.ts',
+      '+++ b/src/beta.ts',
+      '@@ -50,0 +51,1 @@ export class Beta {',
+      '+  private val = 0;',
+      '@@ -80,0 +82,3 @@ export class Beta {',
+      '+  doStuff() {',
+      '+    return this.val;',
+      '+  }',
+    ].join('\n');
+    const result = parseDiffHunks(diff);
+    expect(result).toHaveLength(2);
+
+    expect(result[0].filePath).toBe('src/alpha.ts');
+    expect(result[0].hunks).toEqual([{ startLine: 101, endLine: 102 }]);
+
+    expect(result[1].filePath).toBe('src/beta.ts');
+    expect(result[1].hunks).toHaveLength(2);
+    expect(result[1].hunks[0]).toEqual({ startLine: 51, endLine: 51 });
+    expect(result[1].hunks[1]).toEqual({ startLine: 82, endLine: 84 });
+  });
+});

--- a/gitnexus/test/unit/parse-diff-hunks.test.ts
+++ b/gitnexus/test/unit/parse-diff-hunks.test.ts
@@ -59,21 +59,14 @@ describe('parseDiffHunks', () => {
 
   it('handles single-line hunks without count', () => {
     // When count is omitted from @@ header, it defaults to 1
-    const diff = [
-      '+++ b/src/single.ts',
-      '@@ -5,0 +6 @@ context',
-      '+one line',
-    ].join('\n');
+    const diff = ['+++ b/src/single.ts', '@@ -5,0 +6 @@ context', '+one line'].join('\n');
     const result = parseDiffHunks(diff);
     expect(result).toHaveLength(1);
     expect(result[0].hunks).toEqual([{ startLine: 6, endLine: 6 }]);
   });
 
   it('skips pure-deletion hunks (count=0)', () => {
-    const diff = [
-      '+++ b/src/del.ts',
-      '@@ -10,3 +10,0 @@ context',
-    ].join('\n');
+    const diff = ['+++ b/src/del.ts', '@@ -10,3 +10,0 @@ context'].join('\n');
     const result = parseDiffHunks(diff);
     expect(result).toHaveLength(1);
     expect(result[0].hunks).toHaveLength(0);


### PR DESCRIPTION
## Problem

The `detect_changes` tool reports inaccurate results (issue #758):

- **False positives**: Reports unchanged symbols as modified because it grabs the first 20 arbitrary symbols from any changed file
- **False negatives**: Actually changed symbols get dropped by the `LIMIT 20` if they are not in the first 20 returned by the DB
- **Cross-file matches**: `CONTAINS` on filePath can match partial paths, pulling in symbols from wrong files

## Fix

1. Replaced `git diff --name-only` with `git diff -U0` to get unified diff output with hunk headers
2. Added a `parseDiffHunks()` utility that extracts per-file `[startLine, endLine]` ranges from `@@ @@` headers
3. Replaced the "grab 20 arbitrary symbols" query with a range-intersect query: `WHERE n.startLine <= hunkEnd AND n.endLine >= hunkStart`
4. Changed `CONTAINS` to `ENDS WITH` for path matching
5. Removed the arbitrary `LIMIT 20`

The symbol `startLine` and `endLine` fields are already populated during indexing, so no schema changes are needed.

## Result

Only symbols whose definition actually overlaps a diff hunk are reported. Zero false positives from unchanged symbols, zero false negatives from the arbitrary limit.

Fixes #758