### PR TITLE
Fix HTTP client vs Express route detection and Spring interface attribution

### DIFF
--- a/gitnexus/src/core/group/extractors/http-route-extractor.ts
+++ b/gitnexus/src/core/group/extractors/http-route-extractor.ts
@@ -259,8 +259,10 @@ export class HttpRouteExtractor implements ContractExtractor {
     const out: ExtractedContract[] = [];
 
     // Skip Feign/client interfaces — annotated methods in interfaces are
-    // consumers (Feign, JAX-RS proxies), not provider endpoints
-    if (/\binterface\s+\w+/.test(content) && !/@(?:Rest)?Controller\b/.test(content)) {
+    // consumers (Feign, JAX-RS proxies), not provider endpoints.
+    // Anchored to line start (with optional access modifier) so we do not
+    // match "interface" inside comments or string literals.
+    if (/^\s*(?:public\s+)?interface\s+\w+/m.test(content) && !/@(?:Rest)?Controller\b/.test(content)) {
       return out;
     }
 

--- a/gitnexus/src/core/group/extractors/http-route-extractor.ts
+++ b/gitnexus/src/core/group/extractors/http-route-extractor.ts
@@ -257,6 +257,13 @@ export class HttpRouteExtractor implements ContractExtractor {
 
   private scanSpringProviders(content: string, filePath: string): ExtractedContract[] {
     const out: ExtractedContract[] = [];
+
+    // Skip Feign/client interfaces — annotated methods in interfaces are
+    // consumers (Feign, JAX-RS proxies), not provider endpoints
+    if (/\binterface\s+\w+/.test(content) && !/@(?:Rest)?Controller\b/.test(content)) {
+      return out;
+    }
+
     let classPrefix = '';
     const classRm = content.match(/@RequestMapping\s*\(\s*"([^"]+)"/);
     if (classRm) classPrefix = classRm[1].replace(/\/+$/, '');

--- a/gitnexus/src/core/group/extractors/http-route-extractor.ts
+++ b/gitnexus/src/core/group/extractors/http-route-extractor.ts
@@ -262,7 +262,10 @@ export class HttpRouteExtractor implements ContractExtractor {
     // consumers (Feign, JAX-RS proxies), not provider endpoints.
     // Anchored to line start (with optional access modifier) so we do not
     // match "interface" inside comments or string literals.
-    if (/^\s*(?:public\s+)?interface\s+\w+/m.test(content) && !/@(?:Rest)?Controller\b/.test(content)) {
+    if (
+      /^\s*(?:public\s+)?interface\s+\w+/m.test(content) &&
+      !/@(?:Rest)?Controller\b/.test(content)
+    ) {
       return out;
     }
 

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -2013,6 +2013,22 @@ const processFileGroup = (
         ? detectFrameworkFromAST(language, (definitionNode.text || '').slice(0, 300))
         : null;
 
+      // Suppress Spring framework hint for methods inside interfaces
+      // (Feign clients, JAX-RS proxies are consumers, not providers)
+      if (frameworkHint && definitionNode) {
+        let classCheck = definitionNode.parent;
+        while (classCheck) {
+          if (classCheck.type === 'interface_declaration') {
+            frameworkHint = null;
+            break;
+          }
+          if (classCheck.type === 'class_declaration' || classCheck.type === 'program') {
+            break;
+          }
+          classCheck = classCheck.parent;
+        }
+      }
+
       // Decorators appear on lines immediately before their definition; allow up to
       // MAX_DECORATOR_SCAN_LINES gap for blank lines / multi-line decorator stacks.
       const MAX_DECORATOR_SCAN_LINES = 5;

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -1593,15 +1593,33 @@ const processFileGroup = (
           // as Express route registrations.
           const callNode = captureMap['express_route'];
           const funcNode = callNode.childForFieldName?.('function') ?? callNode.children?.[0];
-          // Walk through nested member_expressions to get the innermost receiver name
+          // Walk through nested member_expressions and call_expressions to
+          // reach the innermost receiver identifier.  Handles chains like:
+          //   this.httpService.get('/path')   -> member chain    -> 'httpservice'
+          //   getClient().get('/path')         -> call_expression -> 'getclient'
+          //   axios.get('/path')               -> bare identifier -> 'axios'
           let receiverNode = funcNode?.childForFieldName?.('object') ?? funcNode?.children?.[0];
-          while (receiverNode?.type === 'member_expression') {
-            // Get the property (rightmost part) of the member expression
-            const propNode = receiverNode.childForFieldName?.('property');
-            if (propNode) {
-              receiverNode = propNode;
+          while (
+            receiverNode?.type === 'member_expression' ||
+            receiverNode?.type === 'call_expression'
+          ) {
+            if (receiverNode.type === 'member_expression') {
+              // Drill into the property (rightmost part) of the member expression
+              const propNode = receiverNode.childForFieldName?.('property');
+              if (propNode) {
+                receiverNode = propNode;
+              } else {
+                break;
+              }
             } else {
-              break;
+              // call_expression: unwrap to the function being called
+              const innerFunc =
+                receiverNode.childForFieldName?.('function') ?? receiverNode.children?.[0];
+              if (innerFunc && innerFunc !== receiverNode) {
+                receiverNode = innerFunc;
+              } else {
+                break;
+              }
             }
           }
           const receiverText = receiverNode?.text?.toLowerCase() ?? '';

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -853,6 +853,11 @@ const HTTP_CLIENT_RECEIVERS = new Set([
   'apiclient',
   'client',
   'httpclient',
+  'api',
+  '$http',
+  'session',
+  'httpservice',
+  'conn',
 ]);
 
 // Decorator names that indicate HTTP route handlers (NestJS, Flask, FastAPI, Spring)
@@ -1588,7 +1593,17 @@ const processFileGroup = (
           // as Express route registrations.
           const callNode = captureMap['express_route'];
           const funcNode = callNode.childForFieldName?.('function') ?? callNode.children?.[0];
-          const receiverNode = funcNode?.childForFieldName?.('object') ?? funcNode?.children?.[0];
+          // Walk through nested member_expressions to get the innermost receiver name
+          let receiverNode = funcNode?.childForFieldName?.('object') ?? funcNode?.children?.[0];
+          while (receiverNode?.type === 'member_expression') {
+            // Get the property (rightmost part) of the member expression
+            const propNode = receiverNode.childForFieldName?.('property');
+            if (propNode) {
+              receiverNode = propNode;
+            } else {
+              break;
+            }
+          }
           const receiverText = receiverNode?.text?.toLowerCase() ?? '';
 
           if (HTTP_CLIENT_RECEIVERS.has(receiverText)) {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -326,6 +326,70 @@ async def create_user(user: UserCreate):
     });
   });
 
+  describe('interface regex anchoring', () => {
+    it('skips Feign client interfaces (no @Controller)', async () => {
+      const dir = path.join(tmpDir, 'feign-skip');
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'src/UserClient.java'),
+`
+package com.example;
+@FeignClient(name = "user-service")
+public interface UserClient {
+    @GetMapping("/users")
+    List<User> getUsers();
+}
+`);
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      expect(contracts.filter(c => c.role === 'provider')).toHaveLength(0);
+    });
+
+    it('does NOT skip when @RestController is present', async () => {
+      const dir = path.join(tmpDir, 'ctrl-iface');
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'src/UserController.java'),
+`
+@RestController
+@RequestMapping("/api")
+public class UserController {
+    @GetMapping("/users")
+    public List<User> list() { return null; }
+}
+`);
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      expect(contracts.filter(c => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does NOT false-positive on interface in comments', async () => {
+      const dir = path.join(tmpDir, 'iface-comment');
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'src/Api.java'),
+`
+// implements the interface UserApi
+public class Api {
+    @GetMapping("/health")
+    public String health() { return "ok"; }
+}
+`);
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      expect(contracts.filter(c => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does NOT false-positive on interface in a string', async () => {
+      const dir = path.join(tmpDir, 'iface-str');
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'src/Svc.java'),
+`
+public class Svc {
+    String desc = "implements interface Foo";
+    @GetMapping("/status")
+    public String status() { return desc; }
+}
+`);
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      expect(contracts.filter(c => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
   describe('path normalization', () => {
     it('strips trailing slash', async () => {
       const dir = path.join(tmpDir, 'trailing');

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -330,63 +330,71 @@ async def create_user(user: UserCreate):
     it('skips Feign client interfaces (no @Controller)', async () => {
       const dir = path.join(tmpDir, 'feign-skip');
       fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
-      fs.writeFileSync(path.join(dir, 'src/UserClient.java'),
-`
+      fs.writeFileSync(
+        path.join(dir, 'src/UserClient.java'),
+        `
 package com.example;
 @FeignClient(name = "user-service")
 public interface UserClient {
     @GetMapping("/users")
     List<User> getUsers();
 }
-`);
+`,
+      );
       const contracts = await extractor.extract(null, dir, makeRepo(dir));
-      expect(contracts.filter(c => c.role === 'provider')).toHaveLength(0);
+      expect(contracts.filter((c) => c.role === 'provider')).toHaveLength(0);
     });
 
     it('does NOT skip when @RestController is present', async () => {
       const dir = path.join(tmpDir, 'ctrl-iface');
       fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
-      fs.writeFileSync(path.join(dir, 'src/UserController.java'),
-`
+      fs.writeFileSync(
+        path.join(dir, 'src/UserController.java'),
+        `
 @RestController
 @RequestMapping("/api")
 public class UserController {
     @GetMapping("/users")
     public List<User> list() { return null; }
 }
-`);
+`,
+      );
       const contracts = await extractor.extract(null, dir, makeRepo(dir));
-      expect(contracts.filter(c => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
+      expect(contracts.filter((c) => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
     });
 
     it('does NOT false-positive on interface in comments', async () => {
       const dir = path.join(tmpDir, 'iface-comment');
       fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
-      fs.writeFileSync(path.join(dir, 'src/Api.java'),
-`
+      fs.writeFileSync(
+        path.join(dir, 'src/Api.java'),
+        `
 // implements the interface UserApi
 public class Api {
     @GetMapping("/health")
     public String health() { return "ok"; }
 }
-`);
+`,
+      );
       const contracts = await extractor.extract(null, dir, makeRepo(dir));
-      expect(contracts.filter(c => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
+      expect(contracts.filter((c) => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
     });
 
     it('does NOT false-positive on interface in a string', async () => {
       const dir = path.join(tmpDir, 'iface-str');
       fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
-      fs.writeFileSync(path.join(dir, 'src/Svc.java'),
-`
+      fs.writeFileSync(
+        path.join(dir, 'src/Svc.java'),
+        `
 public class Svc {
     String desc = "implements interface Foo";
     @GetMapping("/status")
     public String status() { return desc; }
 }
-`);
+`,
+      );
       const contracts = await extractor.extract(null, dir, makeRepo(dir));
-      expect(contracts.filter(c => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
+      expect(contracts.filter((c) => c.role === 'provider').length).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/gitnexus/test/unit/receiver-extraction.test.ts
+++ b/gitnexus/test/unit/receiver-extraction.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import TypeScript from 'tree-sitter-typescript';
+import type { SyntaxNode } from '../../src/core/ingestion/utils/ast-helpers.js';
+import { getProvider } from '../../src/core/ingestion/languages/index.js';
+import { SupportedLanguages } from 'gitnexus-shared';
+
+const HTTP_CLIENT_RECEIVERS = new Set([
+  'axios','request','fetch','http','https','got','ky','superagent',
+  'needle','undici','apiclient','client','httpclient',
+  'api','$http','session','httpservice','conn',
+]);
+
+function extractReceiverText(callNode: SyntaxNode): string {
+  const funcNode = callNode.childForFieldName?.('function') ?? callNode.children?.[0];
+  let receiverNode = funcNode?.childForFieldName?.('object') ?? funcNode?.children?.[0];
+  while (receiverNode?.type === 'member_expression' || receiverNode?.type === 'call_expression') {
+    if (receiverNode.type === 'member_expression') {
+      const p = receiverNode.childForFieldName?.('property');
+      if (p) { receiverNode = p; } else { break; }
+    } else {
+      const inner = receiverNode.childForFieldName?.('function') ?? receiverNode.children?.[0];
+      if (inner && inner !== receiverNode) { receiverNode = inner; } else { break; }
+    }
+  }
+  return receiverNode?.text?.toLowerCase() ?? '';
+}
+
+function extractExpressRouteReceivers(parser: Parser, code: string) {
+  const provider = getProvider(SupportedLanguages.TypeScript);
+  const tree = parser.parse(code);
+  const query = new Parser.Query(parser.getLanguage(), provider.treeSitterQueries!);
+  const results: Array<{method:string;path:string;receiverText:string}> = [];
+  for (const match of query.matches(tree.rootNode)) {
+    const cm: Record<string,SyntaxNode> = {};
+    for (const c of match.captures) cm[c.name] = c.node;
+    if (cm['express_route'] && cm['express_route.method'] && cm['express_route.path']) {
+      results.push({method:cm['express_route.method'].text, path:cm['express_route.path'].text, receiverText:extractReceiverText(cm['express_route'])});
+    }
+  }
+  return results;
+}
+
+describe('receiver extraction (express_route walk)', () => {
+  const parser = new Parser();
+  parser.setLanguage(TypeScript.typescript);
+
+  it('bare identifier: app.get()', () => {
+    const r = extractExpressRouteReceivers(parser, 'app.get("/api/users", h);');
+    expect(r[0]?.receiverText).toBe('app');
+    expect(HTTP_CLIENT_RECEIVERS.has('app')).toBe(false);
+  });
+
+  it('bare identifier: axios.get() is HTTP client', () => {
+    const r = extractExpressRouteReceivers(parser, 'axios.get("/api/users");');
+    expect(r[0]?.receiverText).toBe('axios');
+    expect(HTTP_CLIENT_RECEIVERS.has('axios')).toBe(true);
+  });
+
+  it('member chain: this.httpService.get()', () => {
+    const r = extractExpressRouteReceivers(parser, 'class S { f() { this.httpService.get("/d"); } }');
+    const hit = r.find(x => x.path === '/d');
+    expect(hit?.receiverText).toBe('httpservice');
+    expect(HTTP_CLIENT_RECEIVERS.has('httpservice')).toBe(true);
+  });
+
+  it('member chain: this.client.post()', () => {
+    const r = extractExpressRouteReceivers(parser, 'class A { s() { this.client.post("/x"); } }');
+    const hit = r.find(x => x.path === '/x');
+    expect(hit?.receiverText).toBe('client');
+    expect(HTTP_CLIENT_RECEIVERS.has('client')).toBe(true);
+  });
+
+  it('call_expression: getClient().get()', () => {
+    const r = extractExpressRouteReceivers(parser, 'getClient().get("/api/data");');
+    expect(r.find(x => x.path === '/api/data')?.receiverText).toBe('getclient');
+  });
+
+  it('call_expression: createHttpClient().post()', () => {
+    const r = extractExpressRouteReceivers(parser, 'createHttpClient().post("/s");');
+    expect(r.find(x => x.path === '/s')?.receiverText).toBe('createhttpclient');
+  });
+
+  it('mixed: factory().api.get()', () => {
+    const r = extractExpressRouteReceivers(parser, 'factory().api.get("/items");');
+    expect(r.find(x => x.path === '/items')?.receiverText).toBe('api');
+    expect(HTTP_CLIENT_RECEIVERS.has('api')).toBe(true);
+  });
+
+  it('router.post() is NOT an HTTP client', () => {
+    const r = extractExpressRouteReceivers(parser, 'router.post("/api/items", h);');
+    expect(r[0]?.receiverText).toBe('router');
+    expect(HTTP_CLIENT_RECEIVERS.has('router')).toBe(false);
+  });
+});

--- a/gitnexus/test/unit/receiver-extraction.test.ts
+++ b/gitnexus/test/unit/receiver-extraction.test.ts
@@ -6,9 +6,24 @@ import { getProvider } from '../../src/core/ingestion/languages/index.js';
 import { SupportedLanguages } from 'gitnexus-shared';
 
 const HTTP_CLIENT_RECEIVERS = new Set([
-  'axios','request','fetch','http','https','got','ky','superagent',
-  'needle','undici','apiclient','client','httpclient',
-  'api','$http','session','httpservice','conn',
+  'axios',
+  'request',
+  'fetch',
+  'http',
+  'https',
+  'got',
+  'ky',
+  'superagent',
+  'needle',
+  'undici',
+  'apiclient',
+  'client',
+  'httpclient',
+  'api',
+  '$http',
+  'session',
+  'httpservice',
+  'conn',
 ]);
 
 function extractReceiverText(callNode: SyntaxNode): string {
@@ -17,10 +32,18 @@ function extractReceiverText(callNode: SyntaxNode): string {
   while (receiverNode?.type === 'member_expression' || receiverNode?.type === 'call_expression') {
     if (receiverNode.type === 'member_expression') {
       const p = receiverNode.childForFieldName?.('property');
-      if (p) { receiverNode = p; } else { break; }
+      if (p) {
+        receiverNode = p;
+      } else {
+        break;
+      }
     } else {
       const inner = receiverNode.childForFieldName?.('function') ?? receiverNode.children?.[0];
-      if (inner && inner !== receiverNode) { receiverNode = inner; } else { break; }
+      if (inner && inner !== receiverNode) {
+        receiverNode = inner;
+      } else {
+        break;
+      }
     }
   }
   return receiverNode?.text?.toLowerCase() ?? '';
@@ -30,12 +53,16 @@ function extractExpressRouteReceivers(parser: Parser, code: string) {
   const provider = getProvider(SupportedLanguages.TypeScript);
   const tree = parser.parse(code);
   const query = new Parser.Query(parser.getLanguage(), provider.treeSitterQueries!);
-  const results: Array<{method:string;path:string;receiverText:string}> = [];
+  const results: Array<{ method: string; path: string; receiverText: string }> = [];
   for (const match of query.matches(tree.rootNode)) {
-    const cm: Record<string,SyntaxNode> = {};
+    const cm: Record<string, SyntaxNode> = {};
     for (const c of match.captures) cm[c.name] = c.node;
     if (cm['express_route'] && cm['express_route.method'] && cm['express_route.path']) {
-      results.push({method:cm['express_route.method'].text, path:cm['express_route.path'].text, receiverText:extractReceiverText(cm['express_route'])});
+      results.push({
+        method: cm['express_route.method'].text,
+        path: cm['express_route.path'].text,
+        receiverText: extractReceiverText(cm['express_route']),
+      });
     }
   }
   return results;
@@ -58,32 +85,35 @@ describe('receiver extraction (express_route walk)', () => {
   });
 
   it('member chain: this.httpService.get()', () => {
-    const r = extractExpressRouteReceivers(parser, 'class S { f() { this.httpService.get("/d"); } }');
-    const hit = r.find(x => x.path === '/d');
+    const r = extractExpressRouteReceivers(
+      parser,
+      'class S { f() { this.httpService.get("/d"); } }',
+    );
+    const hit = r.find((x) => x.path === '/d');
     expect(hit?.receiverText).toBe('httpservice');
     expect(HTTP_CLIENT_RECEIVERS.has('httpservice')).toBe(true);
   });
 
   it('member chain: this.client.post()', () => {
     const r = extractExpressRouteReceivers(parser, 'class A { s() { this.client.post("/x"); } }');
-    const hit = r.find(x => x.path === '/x');
+    const hit = r.find((x) => x.path === '/x');
     expect(hit?.receiverText).toBe('client');
     expect(HTTP_CLIENT_RECEIVERS.has('client')).toBe(true);
   });
 
   it('call_expression: getClient().get()', () => {
     const r = extractExpressRouteReceivers(parser, 'getClient().get("/api/data");');
-    expect(r.find(x => x.path === '/api/data')?.receiverText).toBe('getclient');
+    expect(r.find((x) => x.path === '/api/data')?.receiverText).toBe('getclient');
   });
 
   it('call_expression: createHttpClient().post()', () => {
     const r = extractExpressRouteReceivers(parser, 'createHttpClient().post("/s");');
-    expect(r.find(x => x.path === '/s')?.receiverText).toBe('createhttpclient');
+    expect(r.find((x) => x.path === '/s')?.receiverText).toBe('createhttpclient');
   });
 
   it('mixed: factory().api.get()', () => {
     const r = extractExpressRouteReceivers(parser, 'factory().api.get("/items");');
-    expect(r.find(x => x.path === '/items')?.receiverText).toBe('api');
+    expect(r.find((x) => x.path === '/items')?.receiverText).toBe('api');
     expect(HTTP_CLIENT_RECEIVERS.has('api')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Two parser extraction bugs that corrupt the knowledge graph with false data.

### 1. HTTP client calls misclassified as Express routes (#692)

Calls like `request.get('/api/users')`, `this.http.post('/data')`, or `apiService.get('/path')` were classified as Express route registrations instead of HTTP client calls.

**Root cause:** The receiver extraction used `receiverNode.text` which for compound expressions like `this.request` gave the full string, not matching the `HTTP_CLIENT_RECEIVERS` filter. Fixed by walking through nested `member_expression` nodes to extract the innermost receiver name. Also expanded the receiver set with common HTTP client variable names.

### 2. Spring interfaces misattributed as providers (#714)

Methods in Feign client interfaces (e.g., `@GetMapping` on an `interface UserClient`) were classified as server-side route handlers instead of client-side consumer declarations.

**Root cause:** `scanSpringProviders` used a flat regex that couldn't distinguish `interface` from `class`. `detectFrameworkFromAST` also gave Spring framework scoring to interface methods. Fixed both paths: skip scanning interfaces without `@Controller`, and suppress framework hints for methods inside `interface_declaration` nodes.

Fixes #692, #714