### PR TITLE
fix: load VECTOR extension during DB init for semantic search

### DIFF
--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -17,6 +17,7 @@ let db: lbug.Database | null = null;
 let conn: lbug.Connection | null = null;
 let currentDbPath: string | null = null;
 let ftsLoaded = false;
+let vectorExtensionLoaded = false;
 
 /** Expose the current Database for pool adapter reuse in tests. */
 export const getDatabase = (): lbug.Database | null => db;
@@ -135,6 +136,7 @@ const doInitLbug = async (dbPath: string) => {
     db = null;
     currentDbPath = null;
     ftsLoaded = false;
+    vectorExtensionLoaded = false;
   }
 
   // LadybugDB stores the database as a single file (not a directory).
@@ -181,6 +183,9 @@ const doInitLbug = async (dbPath: string) => {
       }
     }
   }
+
+  // Load VECTOR extension for semantic search support
+  await loadVectorExtension();
 
   currentDbPath = dbPath;
   return { db, conn };
@@ -932,7 +937,32 @@ export const loadFTSExtension = async (): Promise<void> => {
     }
   }
 };
-
+/**
+ * Load the VECTOR extension (required before using QUERY_VECTOR_INDEX).
+ * Safe to call multiple times -- tracks loaded state via module-level vectorExtensionLoaded.
+ */
+export const loadVectorExtension = async (): Promise<void> => {
+  if (vectorExtensionLoaded) return;
+  if (!conn) {
+    throw new Error('LadybugDB not initialized. Call initLbug first.');
+  }
+  try {
+    await conn.query('INSTALL VECTOR');
+    await conn.query('LOAD EXTENSION VECTOR');
+    vectorExtensionLoaded = true;
+  } catch (err: any) {
+    const msg = err?.message || '';
+    if (
+      msg.includes('already loaded') ||
+      msg.includes('already installed') ||
+      msg.includes('already exists')
+    ) {
+      vectorExtensionLoaded = true;
+    } else {
+      console.error('GitNexus: VECTOR extension load failed:', msg);
+    }
+  }
+};
 /**
  * Create a full-text search index on a table
  * @param tableName - The node table name (e.g., 'File', 'CodeSymbol')

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -105,6 +105,7 @@ export const withLbugDb = async <T>(dbPath: string, operation: () => Promise<T>)
         db = null;
         currentDbPath = null;
         ftsLoaded = false;
+        vectorExtensionLoaded = false;
       });
       // Sleep outside the lock — no need to block others while waiting
       await new Promise((resolve) => setTimeout(resolve, DB_LOCK_RETRY_DELAY_MS * attempt));
@@ -812,6 +813,7 @@ export const closeLbug = async (): Promise<void> => {
   }
   currentDbPath = null;
   ftsLoaded = false;
+  vectorExtensionLoaded = false;
 };
 
 export const isLbugReady = (): boolean => conn !== null && db !== null;

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -398,10 +398,13 @@ export async function initLbugWithDb(
   }
 
   // Load FTS extension if not already loaded on this Database
-  try {
-    await available[0].query('LOAD EXTENSION fts');
-  } catch {
-    // Extension may already be loaded or not installed
+  if (!shared.ftsLoaded) {
+    try {
+      await available[0].query('LOAD EXTENSION fts');
+      shared.ftsLoaded = true;
+    } catch {
+      // Extension may already be loaded or not installed
+    }
   }
 
   // Load VECTOR extension for semantic search support

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -44,6 +44,7 @@ interface SharedDB {
   db: lbug.Database;
   refCount: number;
   ftsLoaded: boolean;
+  vectorLoaded: boolean;
   /** When true, closeOne skips db.close() — the Database is owned externally. */
   external?: boolean;
 }
@@ -276,7 +277,7 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
           true, // readOnly
         );
         restoreStdout();
-        shared = { db, refCount: 0, ftsLoaded: false };
+        shared = { db, refCount: 0, ftsLoaded: false, vectorLoaded: false };
         dbCache.set(dbPath, shared);
         break;
       } catch (err: any) {
@@ -325,6 +326,17 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
     }
   }
 
+  // Load VECTOR extension once per shared Database for semantic search support.
+  if (!shared.vectorLoaded) {
+    try {
+      await available[0].query('INSTALL VECTOR');
+      await available[0].query('LOAD EXTENSION VECTOR');
+      shared.vectorLoaded = true;
+    } catch {
+      // VECTOR extension may not be available
+    }
+  }
+
   // Register pool entry only after all connections are pre-warmed and FTS is
   // loaded.  Concurrent executeQuery calls see either "not initialized"
   // (and throw cleanly) or a fully ready pool — never a half-built one.
@@ -368,7 +380,7 @@ export async function initLbugWithDb(
   // closeOne() respects the external flag and skips db.close().
   let shared = dbCache.get(dbPath);
   if (!shared) {
-    shared = { db: existingDb, refCount: 0, ftsLoaded: false, external: true };
+    shared = { db: existingDb, refCount: 0, ftsLoaded: false, vectorLoaded: false, external: true };
     dbCache.set(dbPath, shared);
   }
   shared.refCount++;
@@ -388,6 +400,14 @@ export async function initLbugWithDb(
     await available[0].query('LOAD EXTENSION fts');
   } catch {
     // Extension may already be loaded or not installed
+  }
+
+  // Load VECTOR extension for semantic search support
+  try {
+    await available[0].query('INSTALL VECTOR');
+    await available[0].query('LOAD EXTENSION VECTOR');
+  } catch {
+    // VECTOR extension may not be available
   }
 
   pool.set(repoId, {

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -408,11 +408,14 @@ export async function initLbugWithDb(
   }
 
   // Load VECTOR extension for semantic search support
-  try {
-    await available[0].query('INSTALL VECTOR');
-    await available[0].query('LOAD EXTENSION VECTOR');
-  } catch {
-    // VECTOR extension may not be available
+  if (!shared.vectorLoaded) {
+    try {
+      await available[0].query('INSTALL VECTOR');
+      await available[0].query('LOAD EXTENSION VECTOR');
+      shared.vectorLoaded = true;
+    } catch {
+      // VECTOR extension may not be available
+    }
   }
 
   pool.set(repoId, {

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -149,6 +149,8 @@ function closeOne(repoId: string): void {
         // or remove from cache.  Keep the entry so future initLbug() calls
         // for the same dbPath reuse it instead of hitting a file lock.
         shared.refCount = 0;
+        shared.ftsLoaded = false;
+        shared.vectorLoaded = false;
       } else {
         shared.db.close().catch(() => {});
         dbCache.delete(entry.dbPath);

--- a/gitnexus/test/integration/lbug-vector-extension.test.ts
+++ b/gitnexus/test/integration/lbug-vector-extension.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Integration Tests: Vector extension loading and state reset
+ *
+ * Tests: loadVectorExtension idempotency, vectorExtensionLoaded reset
+ * on closeLbug and busy-retry cleanup paths.
+ *
+ * Follows existing lbug integration test patterns (lbug-core-adapter,
+ * lbug-lock-retry).
+ */
+import { describe, it, expect } from 'vitest';
+import { withTestLbugDB } from '../helpers/test-indexed-db.js';
+
+withTestLbugDB('vector-extension', (handle) => {
+  describe('loadVectorExtension', () => {
+    it('loads the VECTOR extension without error', async () => {
+      const { loadVectorExtension } = await import('../../src/core/lbug/lbug-adapter.js');
+
+      // Should resolve without throwing -- idempotent if already loaded by doInitLbug
+      await expect(loadVectorExtension()).resolves.toBeUndefined();
+    });
+
+    it('is idempotent -- calling twice does not throw', async () => {
+      const { loadVectorExtension } = await import('../../src/core/lbug/lbug-adapter.js');
+
+      await loadVectorExtension();
+      await expect(loadVectorExtension()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('vectorExtensionLoaded reset on closeLbug', () => {
+    it('re-initializes vector extension after close + re-init cycle', async () => {
+      const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+
+      // Ensure vector extension is loaded
+      await adapter.loadVectorExtension();
+
+      // Close the adapter -- should reset vectorExtensionLoaded
+      await adapter.closeLbug();
+      expect(adapter.isLbugReady()).toBe(false);
+
+      // Re-initialize -- doInitLbug calls loadVectorExtension internally
+      await adapter.initLbug(handle.dbPath);
+      expect(adapter.isLbugReady()).toBe(true);
+
+      // loadVectorExtension should succeed (not skip due to stale flag)
+      await expect(adapter.loadVectorExtension()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('vectorExtensionLoaded reset on busy-retry cleanup', () => {
+    it('withLbugDb resets vectorExtensionLoaded on BUSY retry', async () => {
+      const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+
+      // Ensure vector extension is loaded
+      await adapter.loadVectorExtension();
+
+      // Simulate a BUSY error on first attempt, success on second.
+      // The retry path should reset vectorExtensionLoaded so the
+      // re-initialized DB gets a fresh extension load.
+      let callCount = 0;
+      const result = await adapter.withLbugDb(handle.dbPath, async () => {
+        callCount++;
+        if (callCount === 1) throw new Error('database is BUSY');
+        return 'recovered';
+      });
+
+      expect(result).toBe('recovered');
+      expect(callCount).toBe(2);
+
+      // After recovery, vector extension should still be loadable
+      // (the flag was reset and re-loaded during re-init)
+      await expect(adapter.loadVectorExtension()).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Semantic and hybrid search fail on a fresh `gitnexus serve` session even when embeddings already exist in the database (#766).

The root cause: the FTS extension is loaded proactively during DB initialization (both in `lbug-adapter.ts` and `pool-adapter.ts`), but the VECTOR extension is only loaded inside `createVectorIndex()` in `embedding-pipeline.ts`, which only runs during `gitnexus analyze --embeddings`.

On a fresh serve, `CALL QUERY_VECTOR_INDEX(...)` fails because the extension was never loaded in the current DB session.

## Fix

Added VECTOR extension loading (`INSTALL VECTOR` / `LOAD EXTENSION VECTOR`) alongside the existing FTS loading in both initialization paths:
- `lbug-adapter.ts` `doInitLbug()` -- single-connection path
- `pool-adapter.ts` `doInitLbug()` -- connection pool path

Both use direct `conn.query()` calls (same pattern as FTS) to bypass the `CYPHER_WRITE_RE` check that blocks `INSTALL`/`LOAD` in `executeQuery()`.

Fixes #766