### PR TITLE
Fix stack overflow on large PHP files — iterative AST traversal

### DIFF
--- a/gitnexus/src/core/ingestion/languages/php.ts
+++ b/gitnexus/src/core/ingestion/languages/php.ts
@@ -160,18 +160,21 @@ function extractPhpPropertyDescription(propName: string, propDeclNode: SyntaxNod
  * Returns description like "hasMany(Post)" or null.
  */
 function extractEloquentRelationDescription(methodNode: SyntaxNode): string | null {
-  function findRelationCall(node: SyntaxNode): SyntaxNode | null {
-    if (node.type === 'member_call_expression') {
-      const children = node.children ?? [];
-      const objectNode = children.find(
-        (c: SyntaxNode) => c.type === 'variable_name' && c.text === '$this',
-      );
-      const nameNode = children.find((c: SyntaxNode) => c.type === 'name');
-      if (objectNode && nameNode && ELOQUENT_RELATIONS.has(nameNode.text)) return node;
-    }
-    for (const child of node.children ?? []) {
-      const found = findRelationCall(child);
-      if (found) return found;
+  function findRelationCall(root: SyntaxNode): SyntaxNode | null {
+    const stack: SyntaxNode[] = [root];
+    while (stack.length > 0) {
+      const node = stack.pop()!;
+      if (node.type === 'member_call_expression') {
+        const children = node.children ?? [];
+        const objectNode = children.find(
+          (c: SyntaxNode) => c.type === 'variable_name' && c.text === '$this',
+        );
+        const nameNode = children.find((c: SyntaxNode) => c.type === 'name');
+        if (objectNode && nameNode && ELOQUENT_RELATIONS.has(nameNode.text)) return node;
+      }
+      for (const child of node.children ?? []) {
+        stack.push(child);
+      }
     }
     return null;
   }

--- a/gitnexus/src/core/ingestion/languages/php.ts
+++ b/gitnexus/src/core/ingestion/languages/php.ts
@@ -172,8 +172,9 @@ function extractEloquentRelationDescription(methodNode: SyntaxNode): string | nu
         const nameNode = children.find((c: SyntaxNode) => c.type === 'name');
         if (objectNode && nameNode && ELOQUENT_RELATIONS.has(nameNode.text)) return node;
       }
-      for (const child of node.children ?? []) {
-        stack.push(child);
+      const children = node.children ?? [];
+      for (let i = children.length - 1; i >= 0; i--) {
+        stack.push(children[i]);
       }
     }
     return null;

--- a/gitnexus/src/core/ingestion/type-env.ts
+++ b/gitnexus/src/core/ingestion/type-env.ts
@@ -1088,7 +1088,11 @@ export const buildTypeEnv = (
     }
   };
 
-  const walk = (node: SyntaxNode, currentScope: string): void => {
+  const stack: Array<{ node: SyntaxNode; scope: string }> = [
+    { node: tree.rootNode, scope: FILE_SCOPE },
+  ];
+
+  const processNode = (node: SyntaxNode, currentScope: string): void => {
     // Fast skip: subtrees that can never contain type-relevant nodes (leaf-like literals).
     if (SKIP_SUBTREE_TYPES.has(node.type)) return;
 
@@ -1212,14 +1216,11 @@ export const buildTypeEnv = (
     }
   };
 
-  // Iterative walk using explicit stack instead of recursion
+  // Iterative traversal using explicit stack instead of recursion
   // to avoid "Maximum call stack size exceeded" on large files (2000+ lines)
-  const stack: Array<{ node: SyntaxNode; scope: string }> = [
-    { node: tree.rootNode, scope: FILE_SCOPE },
-  ];
   while (stack.length > 0) {
     const { node, scope } = stack.pop()!;
-    walk(node, scope);
+    processNode(node, scope);
   }
 
   // Phase 14: Seed cross-file bindings from upstream files AFTER walk

--- a/gitnexus/src/core/ingestion/type-env.ts
+++ b/gitnexus/src/core/ingestion/type-env.ts
@@ -1205,14 +1205,22 @@ export const buildTypeEnv = (
       }
     }
 
-    // Recurse into children
-    for (let i = 0; i < node.childCount; i++) {
+    // Push children onto stack (reverse order so first child is processed first)
+    for (let i = node.childCount - 1; i >= 0; i--) {
       const child = node.child(i);
-      if (child) walk(child, scope);
+      if (child) stack.push({ node: child, scope });
     }
   };
 
-  walk(tree.rootNode, FILE_SCOPE);
+  // Iterative walk using explicit stack instead of recursion
+  // to avoid "Maximum call stack size exceeded" on large files (2000+ lines)
+  const stack: Array<{ node: SyntaxNode; scope: string }> = [
+    { node: tree.rootNode, scope: FILE_SCOPE },
+  ];
+  while (stack.length > 0) {
+    const { node, scope } = stack.pop()!;
+    walk(node, scope);
+  }
 
   // Phase 14: Seed cross-file bindings from upstream files AFTER walk
   // (local declarations from walk() take precedence — first-writer-wins)

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -412,11 +412,16 @@ export const CALL_ARGUMENT_LIST_TYPES = new Set(['arguments', 'argument_list', '
 // ============================================================================
 
 /** Walk an AST node depth-first, returning the first descendant with the given type. */
-export function findDescendant(node: SyntaxNode, type: string): SyntaxNode | null {
-  if (node.type === type) return node;
-  for (const child of node.children ?? []) {
-    const found = findDescendant(child, type);
-    if (found) return found;
+export function findDescendant(root: SyntaxNode, type: string): SyntaxNode | null {
+  const stack: SyntaxNode[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node.type === type) return node;
+    // Push in reverse order so left children are visited first (depth-first)
+    const children = node.children ?? [];
+    for (let i = children.length - 1; i >= 0; i--) {
+      stack.push(children[i]);
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Fixes #776, #772, #752, #706 

- Converts 3 recursive AST traversal functions to iterative loops using explicit stacks
- `walk()` in `type-env.ts` — the main AST walker (biggest impact)
- `findRelationCall()` in `languages/php.ts` — Eloquent relationship detection
- `findDescendant()` in `utils/ast-helpers.ts` — generic node search utility

## Root cause

PHP files with deeply nested structures (closures, array literals, chained method calls) produce ASTs with 5,000–10,000+ nodes. The recursive `walk()` function in `type-env.ts` visits every node via function call recursion, hitting V8's ~10K frame call stack limit on files over ~2,000 lines.

## What changed

Each recursive function was converted to a `while` loop with an array-based stack. The traversal order and behaviour are identical — only the call mechanism changed from implicit (function call stack) to explicit (array).

## Test plan

- [x] Tested against a production Laravel codebase: **373 PHP files, 87,723 lines total** (largest file: 2,462 lines)
- [x] Indexes successfully in 17.4s with **18,201 symbols and 42,641 relationships**
- [x] The same codebase crashed with stack overflow on the recursive version
- [x] Passes `eslint`, `prettier`, and TypeScript type checking (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)