### PR TITLE
fix: restore tree-sitter-swift postinstall patch for macOS ARM64

### DIFF
--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -46,6 +46,7 @@
     "test:integration": "vitest run test/integration",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "postinstall": "node scripts/patch-tree-sitter-swift.cjs",
     "prepare": "node scripts/build.js",
     "prepack": "node scripts/build.js"
   },

--- a/gitnexus/scripts/patch-tree-sitter-swift.cjs
+++ b/gitnexus/scripts/patch-tree-sitter-swift.cjs
@@ -43,8 +43,8 @@ try {
   if (content.includes('"actions"')) {
     // Strip Python-style comments (#) and trailing commas before JSON parsing
     const cleaned = content
-      .replace(/#[^\n]*/g, '')           // Remove # comments
-      .replace(/,(\s*[\]}])/g, '$1');    // Remove trailing commas before ] or }
+      .replace(/#[^\n]*/g, '') // Remove # comments
+      .replace(/,(\s*[\]}])/g, '$1'); // Remove trailing commas before ] or }
     const gyp = JSON.parse(cleaned);
 
     if (gyp.targets && gyp.targets[0] && gyp.targets[0].actions) {
@@ -72,5 +72,7 @@ try {
   }
 } catch (err) {
   console.warn('[tree-sitter-swift] Could not build native binding:', err.message);
-  console.warn('[tree-sitter-swift] You may need to manually run: cd node_modules/tree-sitter-swift && npx node-gyp rebuild');
+  console.warn(
+    '[tree-sitter-swift] You may need to manually run: cd node_modules/tree-sitter-swift && npx node-gyp rebuild',
+  );
 }

--- a/gitnexus/scripts/patch-tree-sitter-swift.cjs
+++ b/gitnexus/scripts/patch-tree-sitter-swift.cjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * WORKAROUND: tree-sitter-swift@0.6.0 binding.gyp build failure
+ *
+ * Background:
+ *   tree-sitter-swift@0.6.0's binding.gyp contains an "actions" array that
+ *   invokes `tree-sitter generate` to regenerate parser.c from grammar.js.
+ *   This is intended for grammar developers, but the published npm package
+ *   already ships pre-generated parser files (parser.c, scanner.c), so the
+ *   actions are unnecessary for consumers. Since consumers don't have
+ *   tree-sitter-cli installed, the actions always fail during `npm install`.
+ *
+ * Why we can't just upgrade:
+ *   tree-sitter-swift@0.7.1 fixes this (removes postinstall, ships prebuilds),
+ *   but it requires tree-sitter@^0.22.1. The upstream project pins tree-sitter
+ *   to ^0.21.0 and all other grammar packages depend on that version.
+ *   Upgrading tree-sitter would be a separate breaking change.
+ *
+ * How this workaround works:
+ *   1. tree-sitter-swift's own postinstall fails (npm warns but continues)
+ *   2. This script runs as gitnexus's postinstall
+ *   3. It removes the "actions" array from binding.gyp
+ *   4. It rebuilds the native binding with the cleaned binding.gyp
+ *
+ * TODO: Remove this script when tree-sitter is upgraded to ^0.22.x,
+ *       which allows using tree-sitter-swift@0.7.1+ directly.
+ */
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const swiftDir = path.join(__dirname, '..', 'node_modules', 'tree-sitter-swift');
+const bindingPath = path.join(swiftDir, 'binding.gyp');
+
+try {
+  if (!fs.existsSync(bindingPath)) {
+    process.exit(0);
+  }
+
+  const content = fs.readFileSync(bindingPath, 'utf8');
+  let needsRebuild = false;
+
+  if (content.includes('"actions"')) {
+    // Strip Python-style comments (#) and trailing commas before JSON parsing
+    const cleaned = content
+      .replace(/#[^\n]*/g, '')           // Remove # comments
+      .replace(/,(\s*[\]}])/g, '$1');    // Remove trailing commas before ] or }
+    const gyp = JSON.parse(cleaned);
+
+    if (gyp.targets && gyp.targets[0] && gyp.targets[0].actions) {
+      delete gyp.targets[0].actions;
+      fs.writeFileSync(bindingPath, JSON.stringify(gyp, null, 2) + '\n');
+      console.log('[tree-sitter-swift] Patched binding.gyp (removed actions array)');
+      needsRebuild = true;
+    }
+  }
+
+  // Check if native binding exists
+  const bindingNode = path.join(swiftDir, 'build', 'Release', 'tree_sitter_swift_binding.node');
+  if (!fs.existsSync(bindingNode)) {
+    needsRebuild = true;
+  }
+
+  if (needsRebuild) {
+    console.log('[tree-sitter-swift] Rebuilding native binding...');
+    execSync('npx node-gyp rebuild', {
+      cwd: swiftDir,
+      stdio: 'pipe',
+      timeout: 120000,
+    });
+    console.log('[tree-sitter-swift] Native binding built successfully');
+  }
+} catch (err) {
+  console.warn('[tree-sitter-swift] Could not build native binding:', err.message);
+  console.warn('[tree-sitter-swift] You may need to manually run: cd node_modules/tree-sitter-swift && npx node-gyp rebuild');
+}


### PR DESCRIPTION
## Summary

Restores `scripts/patch-tree-sitter-swift.cjs` and the `postinstall` entry in `package.json` that were accidentally dropped when PR #538 reverted the grammar package upgrades.

## Root cause

- **PR #516** bumped `tree-sitter-swift` to 0.7.1 (which ships prebuilt darwin-arm64 binaries) and correctly deleted the patch script — it was no longer needed.
- **PR #538** had to revert back to `tree-sitter-swift@^0.6.0` because `npm overrides` doesn't apply when gitnexus is installed as a non-root package via `npx -y`, causing ERESOLVE peer-dep errors. PR #538 reverted the grammar packages but **did not restore the patch script**.
- Result: `tree-sitter-swift@0.6.0`'s `binding.gyp` contains an `actions` array that invokes `tree-sitter generate`, which fails for consumers who don't have `tree-sitter-cli` installed. `gitnexus analyze` silently skips Swift files with "swift parser not available".

## Evidence of regression

`Dockerfile.test` still references `node scripts/patch-tree-sitter-swift.cjs` (line added in PR #516), but the file no longer exists — the test image build is also broken.

## Changes

- Restore `gitnexus/scripts/patch-tree-sitter-swift.cjs` from commit `0c8ec95` (exact copy, no logic changes)
- Re-add `"postinstall": "node scripts/patch-tree-sitter-swift.cjs"` to `gitnexus/package.json`

The TODO comment in the script ("Remove this script when tree-sitter is upgraded to ^0.22.x") still applies — this is a temporary restoration, not a new long-term approach.

## Test plan

- [ ] `npm install -g gitnexus` on macOS ARM64 — confirm no "Skipping swift" in `gitnexus analyze` output
- [ ] `npx -y gitnexus@latest analyze` — confirm Swift parser loads without manual patching
- [ ] `Dockerfile.test` build passes (the reference to `patch-tree-sitter-swift.cjs` is no longer a dead reference)