### PR TITLE
fix(csharp): capture interface-to-interface heritage

### DIFF
--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -623,6 +623,14 @@ export const CSHARP_QUERIES = `
 (class_declaration name: (identifier) @heritage.class
   (base_list (generic_name (identifier) @heritage.extends))) @heritage
 
+; Interface inheritance: interface IFoo : IBar / interface IFoo : IBar, IBaz
+; Without these patterns, interface-to-interface relationships are never
+; captured, so transitive "class X implements IBar" chains are broken.
+(interface_declaration name: (identifier) @heritage.class
+  (base_list (identifier) @heritage.extends)) @heritage
+(interface_declaration name: (identifier) @heritage.class
+  (base_list (generic_name (identifier) @heritage.extends))) @heritage
+
 ; Write access: obj.field = value
 (assignment_expression
   left: (member_access_expression

--- a/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/IAuditableService.cs
+++ b/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/IAuditableService.cs
@@ -1,0 +1,6 @@
+namespace Contracts;
+
+public interface IAuditableService : IFooService, IBarService
+{
+    string AuditTrail { get; }
+}

--- a/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/IBarService.cs
+++ b/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/IBarService.cs
@@ -1,0 +1,6 @@
+namespace Contracts;
+
+public interface IBarService
+{
+    void BarMethod();
+}

--- a/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/IBaseInterface.cs
+++ b/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/IBaseInterface.cs
@@ -1,0 +1,6 @@
+namespace Contracts;
+
+public interface IBaseInterface
+{
+    void BaseMethod();
+}

--- a/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/IFooService.cs
+++ b/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/IFooService.cs
@@ -1,0 +1,6 @@
+namespace Contracts;
+
+public interface IFooService : IBaseInterface
+{
+    void FooMethod();
+}

--- a/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/MyService.cs
+++ b/gitnexus/test/fixtures/lang-resolution/csharp-interface-heritage/src/MyService.cs
@@ -1,0 +1,12 @@
+namespace Services;
+
+using Contracts;
+
+public class MyService : IAuditableService
+{
+    public string AuditTrail => "audit";
+
+    public void BaseMethod() { }
+    public void FooMethod() { }
+    public void BarMethod() { }
+}

--- a/gitnexus/test/integration/resolvers/csharp.test.ts
+++ b/gitnexus/test/integration/resolvers/csharp.test.ts
@@ -1997,3 +1997,54 @@ describe('C# User implements IValidator — interface default method (SM-11)', (
     expect(validateCall!.source).toBe('Run');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Interface-to-interface heritage (single + multi base interface)
+// ---------------------------------------------------------------------------
+
+describe('C# interface-to-interface heritage', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'csharp-interface-heritage'), () => {});
+  }, 60000);
+
+  it('detects 1 class and 4 interfaces', () => {
+    expect(getNodesByLabel(result, 'Class')).toEqual(['MyService']);
+    expect(getNodesByLabel(result, 'Interface')).toEqual([
+      'IAuditableService',
+      'IBarService',
+      'IBaseInterface',
+      'IFooService',
+    ]);
+  });
+
+  it('emits no EXTENDS edges (fixture has no class inheritance)', () => {
+    const extends_ = getRelationships(result, 'EXTENDS');
+    expect(extends_.length).toBe(0);
+  });
+
+  it('emits IMPLEMENTS edge: IFooService → IBaseInterface (single base interface)', () => {
+    const implements_ = getRelationships(result, 'IMPLEMENTS');
+    const targets = edgeSet(implements_);
+    expect(targets).toContain('IFooService → IBaseInterface');
+  });
+
+  it('emits IMPLEMENTS edges: IAuditableService → IFooService, IBarService (multi base interfaces)', () => {
+    const implements_ = getRelationships(result, 'IMPLEMENTS');
+    const targets = edgeSet(implements_);
+    expect(targets).toContain('IAuditableService → IFooService');
+    expect(targets).toContain('IAuditableService → IBarService');
+  });
+
+  it('emits IMPLEMENTS edge: MyService → IAuditableService (class implements derived interface)', () => {
+    const implements_ = getRelationships(result, 'IMPLEMENTS');
+    const targets = edgeSet(implements_);
+    expect(targets).toContain('MyService → IAuditableService');
+  });
+
+  it('emits exactly 4 IMPLEMENTS edges total', () => {
+    const implements_ = getRelationships(result, 'IMPLEMENTS');
+    expect(implements_.length).toBe(4);
+  });
+});


### PR DESCRIPTION
the c# query set drops interface-to-interface heritage. given:

```csharp
interface IBase { }
interface IFoo : IBase { }
class MyClass : IFoo { }
```

only `MyClass -> IFoo` shows up in the graph. the `IFoo -> IBase` edge is just gone, which breaks anyhting that walks the full chain (e.g. asking "what implements IBase").

cause is in `tree-sitter-queries.ts`: the c# heritage block only matches `base_list` on `class_declaration`, there's no pattern for `interface_declaration` at all. so the capture never fires.

fix is two extra patterns in the c# heritage block, sitting right after the class ones. plain case `interface IFoo : IBar` and generic case `interface IFoo : IBar<T>` need to be separate because `generic_name` wraps the identifier so one pattern doesn't catch both (same reason the class side has two).

```
(interface_declaration name: (identifier) @heritage.class
  (base_list (identifier) @heritage.extends)) @heritage
(interface_declaration name: (identifier) @heritage.class
  (base_list (generic_name (identifier) @heritage.extends))) @heritage
```

heritage-processor is fine as is. it just reads `@heritage.class` / `@heritage.extends` and emits the edge, doesn't look at what the parent node was. so once the query fires the rest works.

this matters in practice because pretty much every non-trivial c# codebase hits this — `IEnumerable<T> : IEnumerable`, `IList<T> : ICollection<T>, IReadOnlyList<T>`, DI stuff like `IKeyedServiceProvider : IServiceProvider` (Microsoft.Extensions.DependencyInjection) or `ILifetimeScope : IComponentContext, IAsyncDisposable` (Autofac), rx stuff like `ISubject<T> : ISubject<T,T>` (System.Reactive / UniRx / R3). I hit it on a unity project and the graph was missing a big chunk of the implements edges.

added a fixture under `test/fixtures/lang-resolution/csharp-interface-heritage/` covering single base, multiple bases, and a class implementing a derived interface, plus 6 tests in `csharp.test.ts`. full c# resolver suite still passes (175/175).

didn't look at other languages in the file — only use c#.
