### PR TITLE
chore: release v1.6.1

### DIFF
--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to GitNexus will be documented in this file.
 
+## [1.6.1] - 2026-04-13
+
+### Added
+- **Service group extractor expansion** — manifest extractor and broader extractor coverage (2/4 of #606 split) (#796)
+- **Dart call patterns** for `await`, cascade, lambda, and widget-tree contexts (#801)
+
+### Fixed
+- **Stack overflow and memory exhaustion** on large repository analysis (#814)
+- **`tree-sitter-dart` install crash** — switched from git URL to npm tarball (#811)
+- **Generic TypeScript awaited function calls** missing from the call graph (#804)
+- **Runtime dependency on `file:../gitnexus-shared`** removed from the published package (#803)
+- **Ruby `singleton_class` context** preserved during sequential parsing (#774)
+
+### Changed
+- **DAG-based ingestion pipeline architecture** — pipeline phases now declare typed dependencies and run via a topologically sorted DAG; container-node logic extracted to `LanguageProvider`. Includes hardened lifecycle (try/finally cleanup, error wrapping, cycle reporting), tightened `ParseOutput.exportedTypeMap` immutability, and corrected phase dependencies (#809)
+
 ## [1.6.0] - 2026-04-12
 
 ### Added

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Summary

Patch release v1.6.1 — DAG-based ingestion pipeline architecture plus a batch of language and stability fixes since v1.6.0.

### Changed
- DAG-based ingestion pipeline architecture; container-node logic moved to `LanguageProvider`; lifecycle hardening, `ParseOutput.exportedTypeMap` immutability, corrected phase deps (#809)

### Added
- Service group extractor expansion + manifest extractor (2/4 of #606 split) (#796)
- Dart call patterns for `await`, cascade, lambda, widget-tree contexts (#801)

### Fixed
- Stack overflow / memory exhaustion on large repo analysis (#814)
- `tree-sitter-dart` install crash — git URL → npm tarball (#811)
- Generic TypeScript awaited function calls missing from call graph (#804)
- Removed runtime `file:../gitnexus-shared` dependency from published package (#803)
- Ruby `singleton_class` context preserved in sequential parsing (#774)

## Test plan
- [ ] CI green
- [ ] Tag `v1.6.1` after merge to trigger `publish.yml`

Full changelog: https://github.com/abhigyanpatwari/GitNexus/compare/v1.6.0...v1.6.1