### PR TITLE
fix: resolve C/C++ cross-file calls through transitive #include chains

### DIFF
--- a/gitnexus/src/core/ingestion/language-provider.ts
+++ b/gitnexus/src/core/ingestion/language-provider.ts
@@ -30,8 +30,30 @@ export type CaptureMap = Record<string, SyntaxNode | undefined>;
 // so `core/ingestion/model/resolve.ts` can consume it without importing from
 // this file (which would pull in the full language-registry dependency graph).
 
-/** How a language handles imports — determines wildcard synthesis behavior. */
-export type ImportSemantics = 'named' | 'wildcard' | 'namespace';
+/**
+ * How a language handles imports — determines wildcard synthesis behavior.
+ *
+ * Import resolution is a graph-traversal policy with multiple distinct strategies,
+ * analogous to MRO for method resolution. Each tag picks a strategy:
+ *
+ * | Tag                   | Mechanism                                      | Traversal           | Languages                                  |
+ * |-----------------------|------------------------------------------------|---------------------|--------------------------------------------|
+ * | `named`               | Per-symbol imports                             | None (use-site)     | JS/TS, Java, C#, Rust, PHP, Kotlin, Vue    |
+ * | `wildcard-transitive` | Textual paste, symbols chain through files     | BFS closure         | C, C++ (future: Obj-C, Fortran, Nim)       |
+ * | `wildcard-leaf`       | Whole public API, single hop                   | None (direct only)  | Go, Ruby, Swift, Dart                      |
+ * | `namespace`           | Qualified handle; symbols resolved at call site| None at import      | Python                                     |
+ * | `explicit-reexport`   | Opt-in per-symbol re-export (SCAFFOLD)         | Topological DAG     | (future: TS `export *`, Rust `pub use`)    |
+ *
+ * The `explicit-reexport` tag is a compile-time scaffold; no provider claims it yet.
+ * It falls through to `wildcard-leaf` behavior in synthesis so today's TS/Rust
+ * handling is unchanged. A future PR will implement the DAG walk for `export *`.
+ */
+export type ImportSemantics =
+  | 'named'
+  | 'wildcard-transitive'
+  | 'wildcard-leaf'
+  | 'namespace'
+  | 'explicit-reexport';
 
 /**
  * Everything a language needs to provide.
@@ -68,10 +90,12 @@ interface LanguageProviderConfig {
   /** Named binding extraction from import statements.
    *  Default: undefined (language uses wildcard/whole-module imports). */
   readonly namedBindingExtractor?: NamedBindingExtractorFn;
-  /** How this language handles imports.
+  /** How this language handles imports. See `ImportSemantics` for the full taxonomy.
    *  - 'named': per-symbol imports (JS/TS, Java, C#, Rust, PHP, Kotlin)
-   *  - 'wildcard': whole-module imports, needs synthesis (Go, Ruby, C/C++, Swift)
-   *  - 'namespace': namespace imports, needs moduleAliasMap (Python)
+   *  - 'wildcard-transitive': textual-include closure; imports chain through files (C, C++)
+   *  - 'wildcard-leaf': whole-module single-hop imports; no transitive chaining (Go, Ruby, Swift, Dart)
+   *  - 'namespace': qualified namespace imports, needs moduleAliasMap (Python)
+   *  - 'explicit-reexport': opt-in per-symbol re-export (scaffold; no provider uses yet)
    *  Default: 'named'. */
   readonly importSemantics?: ImportSemantics;
   /** Language-specific transformation of raw import path text before resolution.

--- a/gitnexus/src/core/ingestion/languages/c-cpp.ts
+++ b/gitnexus/src/core/ingestion/languages/c-cpp.ts
@@ -321,7 +321,7 @@ export const cProvider = defineLanguage({
   typeConfig: cCppConfig,
   exportChecker: cCppExportChecker,
   importResolver: resolveCImport,
-  importSemantics: 'wildcard',
+  importSemantics: 'wildcard-transitive',
   fieldExtractor: createFieldExtractor(cFieldConfig),
   methodExtractor: createMethodExtractor({
     ...cMethodConfig,
@@ -339,7 +339,7 @@ export const cppProvider = defineLanguage({
   typeConfig: cCppConfig,
   exportChecker: cCppExportChecker,
   importResolver: resolveCppImport,
-  importSemantics: 'wildcard',
+  importSemantics: 'wildcard-transitive',
   mroStrategy: 'leftmost-base',
   fieldExtractor: createFieldExtractor(cppFieldConfig),
   methodExtractor: createMethodExtractor({

--- a/gitnexus/src/core/ingestion/languages/dart.ts
+++ b/gitnexus/src/core/ingestion/languages/dart.ts
@@ -2,7 +2,7 @@
  * Dart Language Provider
  *
  * Dart traits:
- *   - importSemantics: 'wildcard' (Dart imports bring everything public into scope)
+ *   - importSemantics: 'wildcard-leaf' (Dart imports bring everything public into scope)
  *   - exportChecker: public if no leading underscore
  *   - Dart SDK imports (dart:*) and external packages are skipped
  *   - enclosingFunctionFinder: Dart's tree-sitter grammar places function_body
@@ -90,7 +90,7 @@ export const dartProvider = defineLanguage({
   typeConfig: dartConfig,
   exportChecker: dartExportChecker,
   importResolver: resolveDartImport,
-  importSemantics: 'wildcard',
+  importSemantics: 'wildcard-leaf',
   fieldExtractor: createFieldExtractor(dartFieldConfig),
   methodExtractor: createMethodExtractor(dartMethodConfig),
   classExtractor: createClassExtractor({

--- a/gitnexus/src/core/ingestion/languages/go.ts
+++ b/gitnexus/src/core/ingestion/languages/go.ts
@@ -5,7 +5,7 @@
  * LanguageProvider, following the Strategy pattern used by the pipeline.
  *
  * Key Go traits:
- *   - importSemantics: 'wildcard' (Go imports entire packages)
+ *   - importSemantics: 'wildcard-leaf' (Go imports entire packages)
  *   - callRouter: present (Go method calls may need routing)
  */
 
@@ -28,7 +28,7 @@ export const goProvider = defineLanguage({
   typeConfig: goConfig,
   exportChecker: goExportChecker,
   importResolver: resolveGoImport,
-  importSemantics: 'wildcard',
+  importSemantics: 'wildcard-leaf',
   fieldExtractor: createFieldExtractor(goFieldConfig),
   methodExtractor: createMethodExtractor(goMethodConfig),
   classExtractor: createClassExtractor({

--- a/gitnexus/src/core/ingestion/languages/ruby.ts
+++ b/gitnexus/src/core/ingestion/languages/ruby.ts
@@ -107,7 +107,7 @@ export const rubyProvider = defineLanguage({
   exportChecker: rubyExportChecker,
   importResolver: resolveRubyImport,
   callRouter: routeRubyCall,
-  importSemantics: 'wildcard',
+  importSemantics: 'wildcard-leaf',
   resolveEnclosingOwner(node) {
     // Ruby singleton_class (class << self) should resolve to the enclosing
     // class or module for owner/container resolution (HAS_METHOD edges, class IDs).

--- a/gitnexus/src/core/ingestion/languages/swift.ts
+++ b/gitnexus/src/core/ingestion/languages/swift.ts
@@ -5,7 +5,7 @@
  * LanguageProvider, following the Strategy pattern used by the pipeline.
  *
  * Key Swift traits:
- *   - importSemantics: 'wildcard' (Swift imports entire modules)
+ *   - importSemantics: 'wildcard-leaf' (Swift imports entire modules)
  *   - heritageDefaultEdge: 'IMPLEMENTS' (protocols are more common than class inheritance)
  *   - implicitImportWirer: all files in the same SPM target see each other
  */
@@ -238,7 +238,7 @@ export const swiftProvider = defineLanguage({
   typeConfig: swiftConfig,
   exportChecker: swiftExportChecker,
   importResolver: resolveSwiftImport,
-  importSemantics: 'wildcard',
+  importSemantics: 'wildcard-leaf',
   heritageDefaultEdge: 'IMPLEMENTS',
   fieldExtractor: createFieldExtractor(swiftFieldConfig),
   methodExtractor: createMethodExtractor({

--- a/gitnexus/src/core/ingestion/pipeline-phases/wildcard-synthesis.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/wildcard-synthesis.ts
@@ -43,6 +43,13 @@ const IMPORTABLE_SYMBOL_LABELS = new Set([
  *  for C/C++ files that include many large headers. */
 const MAX_SYNTHETIC_BINDINGS_PER_FILE = 1000;
 
+/** Max files allowed in a single transitive include closure. Guards against
+ *  OOM on pathological C/C++ codebases (boost, Linux kernel-style monoheaders)
+ *  where a single translation unit can transitively reach many thousands of
+ *  headers. When the cap is hit, BFS expansion stops early — the file still
+ *  synthesizes bindings from the partial closure rather than failing. */
+const MAX_TRANSITIVE_CLOSURE_SIZE = 5000;
+
 /** Import semantics tags whose languages need synthesis of whole-module imports.
  *  `wildcard-transitive` (C/C++) and `wildcard-leaf` (Go, Ruby, Swift, Dart) are
  *  the file-based wildcard strategies. `explicit-reexport` is a scaffold tag —
@@ -105,6 +112,16 @@ export function needsSynthesis(lang: SupportedLanguages): boolean {
  * Cycle-safe: the `closure.has(file)` guard prevents infinite loops on circular
  * header includes, which are valid C/C++ when paired with `#pragma once` or
  * include guards.
+ *
+ * Size-bounded: the closure is capped at `MAX_TRANSITIVE_CLOSURE_SIZE` files to
+ * prevent OOM on pathological codebases (e.g. boost, monoheader kernel code)
+ * where one translation unit can transitively reach tens of thousands of
+ * headers. Partial closures still yield useful bindings for the cluster of
+ * headers closest to the importer, which is what overload resolution and
+ * cross-file call resolution care about.
+ *
+ * Queue implementation: uses a head-index over a growing array (O(1) dequeue)
+ * instead of `Array.prototype.shift()` (O(n)) so deep chains stay linear.
  */
 export function expandTransitiveIncludeClosure(
   directImports: Iterable<string>,
@@ -113,33 +130,35 @@ export function expandTransitiveIncludeClosure(
 ): Set<string> {
   const closure = new Set<string>();
   const queue: string[] = [];
+  let head = 0; // O(1) dequeue: advance the head index instead of shift()-ing.
+
+  const tryEnqueue = (file: string): boolean => {
+    if (closure.has(file)) return true;
+    if (closure.size >= MAX_TRANSITIVE_CLOSURE_SIZE) return false;
+    closure.add(file);
+    queue.push(file);
+    return true;
+  };
+
   // Seed direct imports in declaration order (see JSDoc on order-sensitivity).
   for (const f of directImports) {
-    if (!closure.has(f)) {
-      closure.add(f);
-      queue.push(f);
-    }
+    if (!tryEnqueue(f)) break;
   }
-  // True BFS for transitive reach: FIFO via shift() preserves the "closer
+  // True BFS for transitive reach: head-index FIFO preserves the "closer
   // headers first" ordering that overload resolution depends on.
-  while (queue.length > 0) {
-    const file = queue.shift()!;
+  while (head < queue.length) {
+    if (closure.size >= MAX_TRANSITIVE_CLOSURE_SIZE) break;
+    const file = queue[head++]!;
     const nested = importMap.get(file);
     if (nested) {
       for (const n of nested) {
-        if (!closure.has(n)) {
-          closure.add(n);
-          queue.push(n);
-        }
+        if (!tryEnqueue(n)) break;
       }
     }
     const nestedGraph = graphImports.get(file);
     if (nestedGraph) {
       for (const n of nestedGraph) {
-        if (!closure.has(n)) {
-          closure.add(n);
-          queue.push(n);
-        }
+        if (!tryEnqueue(n)) break;
       }
     }
   }
@@ -238,8 +257,10 @@ export function synthesizeWildcardImportBindings(
    *     across header chains)
    *   - `wildcard-leaf`: synthesize from direct imports only (Go, Ruby, Swift, Dart)
    *   - `explicit-reexport`: scaffold tag; falls through to leaf behavior.
-   *     TODO: implement re-export DAG walk for TS `export *` / Rust `pub use` —
-   *     tracked as the larger TS barrel-file correctness gap (see plan 2026-04-14-001).
+   *     TODO(#821): implement re-export DAG walk for TS `export *` / Rust
+   *     `pub use`. The leaf fallthrough preserves today's TS/Rust behavior
+   *     (their direct imports still synthesize correctly); only the extra
+   *     re-export DAG walk for barrel-file correctness is missing.
    *   - `namespace` / `named`: no-op here (namespace handled in Loop 3 below,
    *     named needs no synthesis).
    *

--- a/gitnexus/src/core/ingestion/pipeline-phases/wildcard-synthesis.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/wildcard-synthesis.ts
@@ -149,11 +149,39 @@ export function synthesizeWildcardImportBindings(
     }
   };
 
-  // Synthesize from ctx.importMap (Ruby, C/C++, Swift file-based imports)
+  // Synthesize from ctx.importMap (Ruby, C/C++, Swift file-based imports).
+  // For C/C++, #include is transitive: if a.c includes b.h and b.h includes
+  // c.h, then a.c has access to all symbols from c.h.  Expand the include
+  // closure before synthesizing so that cross-file calls resolve correctly
+  // through header chains (e.g. db.c → server.h → dict.h → dictFind).
   for (const [filePath, importedFiles] of ctx.importMap) {
     const lang = getLanguageFromFilename(filePath);
     if (!lang || !isWildcardImportLanguage(lang)) continue;
-    synthesizeForFile(filePath, importedFiles);
+
+    if (lang === SupportedLanguages.C || lang === SupportedLanguages.CPlusPlus) {
+      const transitiveClosure = new Set<string>();
+      const queue = [...importedFiles];
+      while (queue.length > 0) {
+        const file = queue.pop()!;
+        if (transitiveClosure.has(file)) continue;
+        transitiveClosure.add(file);
+        const nested = ctx.importMap.get(file);
+        if (nested) {
+          for (const n of nested) {
+            if (!transitiveClosure.has(n)) queue.push(n);
+          }
+        }
+        const nestedGraph = graphImports.get(file);
+        if (nestedGraph) {
+          for (const n of nestedGraph) {
+            if (!transitiveClosure.has(n)) queue.push(n);
+          }
+        }
+      }
+      synthesizeForFile(filePath, transitiveClosure);
+    } else {
+      synthesizeForFile(filePath, importedFiles);
+    }
   }
 
   // Synthesize from graph IMPORTS edges (Go and other wildcard-import languages)

--- a/gitnexus/src/core/ingestion/pipeline-phases/wildcard-synthesis.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/wildcard-synthesis.ts
@@ -15,8 +15,10 @@
 
 import type { KnowledgeGraph } from '../../graph/types.js';
 import type { createResolutionContext } from '../model/resolution-context.js';
-import { getLanguageFromFilename, SupportedLanguages } from 'gitnexus-shared';
+import { getLanguageFromFilename } from 'gitnexus-shared';
+import type { SupportedLanguages } from 'gitnexus-shared';
 import { providers, getProviderForFile } from '../languages/index.js';
+import type { LanguageProvider, ImportSemantics } from '../language-provider.js';
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -41,10 +43,22 @@ const IMPORTABLE_SYMBOL_LABELS = new Set([
  *  for C/C++ files that include many large headers. */
 const MAX_SYNTHETIC_BINDINGS_PER_FILE = 1000;
 
+/** Import semantics tags whose languages need synthesis of whole-module imports.
+ *  `wildcard-transitive` (C/C++) and `wildcard-leaf` (Go, Ruby, Swift, Dart) are
+ *  the file-based wildcard strategies. `explicit-reexport` is a scaffold tag —
+ *  no provider uses it yet, but it goes through the same leaf-style synthesis
+ *  path today because a re-exporter is still an importer; only the extra DAG
+ *  walk to surface re-exported symbols is missing (future work). */
+const WILDCARD_SEMANTICS: ReadonlySet<ImportSemantics> = new Set<ImportSemantics>([
+  'wildcard-transitive',
+  'wildcard-leaf',
+  'explicit-reexport',
+]);
+
 /** Languages with whole-module import semantics (derived from providers at module load). */
 const WILDCARD_LANGUAGES = new Set(
   Object.values(providers)
-    .filter((p) => p.importSemantics === 'wildcard')
+    .filter((p) => WILDCARD_SEMANTICS.has(p.importSemantics))
     .map((p) => p.id),
 );
 
@@ -64,6 +78,72 @@ export function isWildcardImportLanguage(lang: SupportedLanguages): boolean {
  *  True for wildcard-import languages AND namespace-import languages (Python). */
 export function needsSynthesis(lang: SupportedLanguages): boolean {
   return SYNTHESIS_LANGUAGES.has(lang);
+}
+
+// ── Strategy implementations ───────────────────────────────────────────────
+
+/**
+ * Strategy implementation for `importSemantics: 'wildcard-transitive'` (C, C++).
+ *
+ * Textual-include languages chain symbols through files: if `dict.c` includes
+ * `server.h` and `server.h` includes `dict.h`, then `dict.c` sees symbols from
+ * all three files. This helper walks the include graph (combining both the
+ * ingestion-context `importMap` and the graph-level IMPORTS edges) until the
+ * closure is stable.
+ *
+ * **Order matters.** The returned `Set` preserves iteration order (insertion
+ * order). `synthesizeWildcardImportBindings` dedupes bindings by symbol name
+ * on a first-seen-wins basis, so this closure's ordering determines which
+ * declaration wins when multiple headers export the same name (e.g. overloaded
+ * free functions like `write_audit()` vs `write_audit(const char*)` in
+ * different headers). We therefore:
+ *   1. Seed the closure with direct imports in declaration order (matches the
+ *      order of `#include` directives in the source file).
+ *   2. Use FIFO / true BFS (`queue.shift()`) for transitive expansion, so
+ *      closer headers are seen before deeper ones.
+ *
+ * Cycle-safe: the `closure.has(file)` guard prevents infinite loops on circular
+ * header includes, which are valid C/C++ when paired with `#pragma once` or
+ * include guards.
+ */
+export function expandTransitiveIncludeClosure(
+  directImports: Iterable<string>,
+  importMap: ReadonlyMap<string, ReadonlySet<string>>,
+  graphImports: ReadonlyMap<string, ReadonlySet<string>>,
+): Set<string> {
+  const closure = new Set<string>();
+  const queue: string[] = [];
+  // Seed direct imports in declaration order (see JSDoc on order-sensitivity).
+  for (const f of directImports) {
+    if (!closure.has(f)) {
+      closure.add(f);
+      queue.push(f);
+    }
+  }
+  // True BFS for transitive reach: FIFO via shift() preserves the "closer
+  // headers first" ordering that overload resolution depends on.
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    const nested = importMap.get(file);
+    if (nested) {
+      for (const n of nested) {
+        if (!closure.has(n)) {
+          closure.add(n);
+          queue.push(n);
+        }
+      }
+    }
+    const nestedGraph = graphImports.get(file);
+    if (nestedGraph) {
+      for (const n of nestedGraph) {
+        if (!closure.has(n)) {
+          closure.add(n);
+          queue.push(n);
+        }
+      }
+    }
+  }
+  return closure;
 }
 
 // ── Main synthesis function ────────────────────────────────────────────────
@@ -149,44 +229,65 @@ export function synthesizeWildcardImportBindings(
     }
   };
 
-  // Synthesize from ctx.importMap (Ruby, C/C++, Swift file-based imports).
-  // For C/C++, #include is transitive: if a.c includes b.h and b.h includes
-  // c.h, then a.c has access to all symbols from c.h.  Expand the include
-  // closure before synthesizing so that cross-file calls resolve correctly
-  // through header chains (e.g. db.c → server.h → dict.h → dictFind).
+  /**
+   * Dispatch wildcard synthesis by the file's language provider strategy.
+   *
+   * Strategy tags (see `ImportSemantics`):
+   *   - `wildcard-transitive`: expand the include closure first (C/C++ #include
+   *     chains — e.g. `dict.c` → `server.h` → `dict.h` so `dictFind` resolves
+   *     across header chains)
+   *   - `wildcard-leaf`: synthesize from direct imports only (Go, Ruby, Swift, Dart)
+   *   - `explicit-reexport`: scaffold tag; falls through to leaf behavior.
+   *     TODO: implement re-export DAG walk for TS `export *` / Rust `pub use` —
+   *     tracked as the larger TS barrel-file correctness gap (see plan 2026-04-14-001).
+   *   - `namespace` / `named`: no-op here (namespace handled in Loop 3 below,
+   *     named needs no synthesis).
+   *
+   * Used by both Loop 1 (ctx.importMap) and Loop 2 (graphImports) so a future
+   * transitive-import language whose edges arrive via graphImports gets closure
+   * expansion consistently regardless of edge source.
+   */
+  const dispatchSynthesis = (
+    filePath: string,
+    importedFiles: ReadonlySet<string>,
+    provider: LanguageProvider,
+  ) => {
+    switch (provider.importSemantics) {
+      case 'wildcard-transitive':
+        synthesizeForFile(
+          filePath,
+          expandTransitiveIncludeClosure(importedFiles, ctx.importMap, graphImports),
+        );
+        return;
+      case 'wildcard-leaf':
+      case 'explicit-reexport':
+        synthesizeForFile(filePath, importedFiles);
+        return;
+      case 'namespace':
+      case 'named':
+        return;
+      default: {
+        const _exhaustive: never = provider.importSemantics;
+        void _exhaustive;
+      }
+    }
+  };
+
+  // Loop 1: synthesize from ctx.importMap (Ruby, C/C++, Swift, Dart file-based imports).
   for (const [filePath, importedFiles] of ctx.importMap) {
     const lang = getLanguageFromFilename(filePath);
     if (!lang || !isWildcardImportLanguage(lang)) continue;
-
-    if (lang === SupportedLanguages.C || lang === SupportedLanguages.CPlusPlus) {
-      const transitiveClosure = new Set<string>();
-      const queue = [...importedFiles];
-      while (queue.length > 0) {
-        const file = queue.pop()!;
-        if (transitiveClosure.has(file)) continue;
-        transitiveClosure.add(file);
-        const nested = ctx.importMap.get(file);
-        if (nested) {
-          for (const n of nested) {
-            if (!transitiveClosure.has(n)) queue.push(n);
-          }
-        }
-        const nestedGraph = graphImports.get(file);
-        if (nestedGraph) {
-          for (const n of nestedGraph) {
-            if (!transitiveClosure.has(n)) queue.push(n);
-          }
-        }
-      }
-      synthesizeForFile(filePath, transitiveClosure);
-    } else {
-      synthesizeForFile(filePath, importedFiles);
-    }
+    const provider = getProviderForFile(filePath);
+    if (!provider) continue;
+    dispatchSynthesis(filePath, importedFiles, provider);
   }
 
-  // Synthesize from graph IMPORTS edges (Go and other wildcard-import languages)
+  // Loop 2: synthesize from graph IMPORTS edges (Go and other wildcard-import
+  // languages whose edges live in the graph rather than ctx.importMap).
   for (const [filePath, importedFiles] of graphImports) {
-    synthesizeForFile(filePath, importedFiles);
+    const provider = getProviderForFile(filePath);
+    if (!provider) continue;
+    dispatchSynthesis(filePath, importedFiles, provider);
   }
 
   // Build Python module-alias maps for namespace-import languages.

--- a/gitnexus/test/fixtures/cross-file-binding/c-cross-file/src/db.c
+++ b/gitnexus/test/fixtures/cross-file-binding/c-cross-file/src/db.c
@@ -1,0 +1,12 @@
+#include "server.h"
+
+void lookupKey(const char *key) {
+    dictEntry *entry = dictFind(key);
+    if (entry) {
+        void *val = entry->val;
+    }
+}
+
+void dbGet(const char *key) {
+    void *val = dictFetchValue(key);
+}

--- a/gitnexus/test/fixtures/cross-file-binding/c-cross-file/src/dict.c
+++ b/gitnexus/test/fixtures/cross-file-binding/c-cross-file/src/dict.c
@@ -1,0 +1,12 @@
+#include "dict.h"
+#include <stdlib.h>
+
+dictEntry *dictFind(const char *key) {
+    return NULL;
+}
+
+void *dictFetchValue(const char *key) {
+    dictEntry *entry = dictFind(key);
+    if (entry) return entry->val;
+    return NULL;
+}

--- a/gitnexus/test/fixtures/cross-file-binding/c-cross-file/src/dict.h
+++ b/gitnexus/test/fixtures/cross-file-binding/c-cross-file/src/dict.h
@@ -1,0 +1,12 @@
+#ifndef DICT_H
+#define DICT_H
+
+typedef struct dictEntry {
+    void *key;
+    void *val;
+} dictEntry;
+
+dictEntry *dictFind(const char *key);
+void *dictFetchValue(const char *key);
+
+#endif

--- a/gitnexus/test/fixtures/cross-file-binding/c-cross-file/src/server.h
+++ b/gitnexus/test/fixtures/cross-file-binding/c-cross-file/src/server.h
@@ -1,0 +1,8 @@
+#ifndef SERVER_H
+#define SERVER_H
+
+#include "dict.h"
+
+void processCommand(const char *cmd);
+
+#endif

--- a/gitnexus/test/integration/cross-file-binding.test.ts
+++ b/gitnexus/test/integration/cross-file-binding.test.ts
@@ -436,6 +436,42 @@ describe('Phase 9 — Cross-File Call-Result Binding: C++', () => {
   });
 });
 
+describe('Cross-File Call Resolution: pure C transitive #include', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(CROSS_FILE_FIXTURES, 'c-cross-file'), () => {});
+  }, 60000);
+
+  it('detects dictFind and dictFetchValue functions', () => {
+    expect(getNodesByLabel(result, 'Function')).toContain('dictFind');
+    expect(getNodesByLabel(result, 'Function')).toContain('dictFetchValue');
+  });
+
+  it('detects lookupKey and dbGet in db.c', () => {
+    expect(getNodesByLabel(result, 'Function')).toContain('lookupKey');
+    expect(getNodesByLabel(result, 'Function')).toContain('dbGet');
+  });
+
+  it('resolves dictFind() call in db.c to dict via transitive header chain', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const crossFileCall = calls.find(
+      (c) =>
+        c.target === 'dictFind' && c.source === 'lookupKey' && c.targetFilePath.includes('dict'),
+    );
+    expect(crossFileCall).toBeDefined();
+  });
+
+  it('resolves dictFetchValue() call in db.c to dict via transitive header chain', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const crossFileCall = calls.find(
+      (c) =>
+        c.target === 'dictFetchValue' && c.source === 'dbGet' && c.targetFilePath.includes('dict'),
+    );
+    expect(crossFileCall).toBeDefined();
+  });
+});
+
 describe('Phase 9 — Cross-File Call-Result Binding: C#', () => {
   let result: PipelineResult;
 

--- a/gitnexus/test/unit/transitive-include-closure.test.ts
+++ b/gitnexus/test/unit/transitive-include-closure.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for `expandTransitiveIncludeClosure` — the C/C++ Strategy 1
+ * (`wildcard-transitive`) implementation extracted from `wildcard-synthesis.ts`.
+ *
+ * These tests exercise the BFS/DFS closure algorithm in isolation, without
+ * running the full pipeline. They cover edge cases flagged in PR #816 review:
+ * circular header includes, deep chains, and graphImports-only transitive paths.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { expandTransitiveIncludeClosure } from '../../src/core/ingestion/pipeline-phases/wildcard-synthesis.js';
+
+const EMPTY = new Map<string, ReadonlySet<string>>();
+
+describe('expandTransitiveIncludeClosure', () => {
+  it('returns the direct imports when none are chained', () => {
+    const direct = new Set(['a.h', 'b.h']);
+    const closure = expandTransitiveIncludeClosure(direct, EMPTY, EMPTY);
+    expect([...closure].sort()).toEqual(['a.h', 'b.h']);
+  });
+
+  it('expands a two-hop chain via importMap (a.c → b.h → c.h)', () => {
+    const importMap = new Map<string, ReadonlySet<string>>([['b.h', new Set(['c.h'])]]);
+    const closure = expandTransitiveIncludeClosure(new Set(['b.h']), importMap, EMPTY);
+    expect([...closure].sort()).toEqual(['b.h', 'c.h']);
+  });
+
+  it('expands a deep 5-level chain (A → B → C → D → E)', () => {
+    const importMap = new Map<string, ReadonlySet<string>>([
+      ['B.h', new Set(['C.h'])],
+      ['C.h', new Set(['D.h'])],
+      ['D.h', new Set(['E.h'])],
+    ]);
+    const closure = expandTransitiveIncludeClosure(new Set(['B.h']), importMap, EMPTY);
+    expect([...closure].sort()).toEqual(['B.h', 'C.h', 'D.h', 'E.h']);
+  });
+
+  it('terminates on circular header includes (A.h ↔ B.h)', () => {
+    const importMap = new Map<string, ReadonlySet<string>>([
+      ['A.h', new Set(['B.h'])],
+      ['B.h', new Set(['A.h'])],
+    ]);
+    const closure = expandTransitiveIncludeClosure(new Set(['A.h']), importMap, EMPTY);
+    expect([...closure].sort()).toEqual(['A.h', 'B.h']);
+  });
+
+  it('terminates on self-referential include (A.h includes A.h)', () => {
+    const importMap = new Map<string, ReadonlySet<string>>([['A.h', new Set(['A.h'])]]);
+    const closure = expandTransitiveIncludeClosure(new Set(['A.h']), importMap, EMPTY);
+    expect([...closure]).toEqual(['A.h']);
+  });
+
+  it('expands through graphImports edges when importMap is empty', () => {
+    const graphImports = new Map<string, ReadonlySet<string>>([['b.h', new Set(['c.h'])]]);
+    const closure = expandTransitiveIncludeClosure(new Set(['b.h']), EMPTY, graphImports);
+    expect([...closure].sort()).toEqual(['b.h', 'c.h']);
+  });
+
+  it('combines importMap and graphImports in one traversal', () => {
+    const importMap = new Map<string, ReadonlySet<string>>([['b.h', new Set(['c.h'])]]);
+    const graphImports = new Map<string, ReadonlySet<string>>([['c.h', new Set(['d.h'])]]);
+    const closure = expandTransitiveIncludeClosure(new Set(['b.h']), importMap, graphImports);
+    expect([...closure].sort()).toEqual(['b.h', 'c.h', 'd.h']);
+  });
+
+  it('returns an empty set when given no direct imports', () => {
+    const closure = expandTransitiveIncludeClosure(new Set<string>(), EMPTY, EMPTY);
+    expect(closure.size).toBe(0);
+  });
+
+  it('deduplicates when a file is reachable through multiple paths (diamond)', () => {
+    //   A
+    //  / \
+    // B   C
+    //  \ /
+    //   D
+    const importMap = new Map<string, ReadonlySet<string>>([
+      ['A.h', new Set(['B.h', 'C.h'])],
+      ['B.h', new Set(['D.h'])],
+      ['C.h', new Set(['D.h'])],
+    ]);
+    const closure = expandTransitiveIncludeClosure(new Set(['A.h']), importMap, EMPTY);
+    expect([...closure].sort()).toEqual(['A.h', 'B.h', 'C.h', 'D.h']);
+    expect(closure.size).toBe(4); // D.h appears once
+  });
+});

--- a/gitnexus/test/unit/transitive-include-closure.test.ts
+++ b/gitnexus/test/unit/transitive-include-closure.test.ts
@@ -68,6 +68,21 @@ describe('expandTransitiveIncludeClosure', () => {
     expect(closure.size).toBe(0);
   });
 
+  it('caps closure size to prevent OOM on pathological codebases', () => {
+    // Build a synthetic include graph of 10,000 files, each including the next.
+    // The cap (5000) should halt BFS early with a partial but bounded closure.
+    const importMap = new Map<string, ReadonlySet<string>>();
+    for (let i = 0; i < 10_000; i++) {
+      importMap.set(`h${i}.h`, new Set([`h${i + 1}.h`]));
+    }
+    const closure = expandTransitiveIncludeClosure(new Set(['h0.h']), importMap, EMPTY);
+    expect(closure.size).toBe(5000);
+    // Partial closure still starts from the importer's side (BFS ordering).
+    expect(closure.has('h0.h')).toBe(true);
+    expect(closure.has('h1.h')).toBe(true);
+    expect(closure.has('h9999.h')).toBe(false);
+  });
+
   it('deduplicates when a file is reachable through multiple paths (diamond)', () => {
     //   A
     //  / \


### PR DESCRIPTION
## Summary

- Expands transitive `#include` chains for C/C++ in `synthesizeWildcardImportBindings`
- Adds test fixture and 4 integration tests for pure-C cross-file call resolution through transitive headers
- Fixes #812

## Problem

In C/C++, `#include` is transitive: if `a.c` includes `b.h` and `b.h` includes `c.h`, then `a.c` can call any function declared in `c.h`. The wildcard import synthesis only walked **direct imports** (1 hop), missing symbols reachable through transitive header chains.

This is the dominant pattern in large C codebases. For example, Redis's `db.c` includes `server.h` which includes `dict.h`, so `db.c` should resolve calls to `dictFind()` declared in `dict.h`. Before this fix, those cross-file call edges were missing.

## Fix

BFS expansion of the import closure for C/C++ files before synthesizing wildcard bindings. Walks both `ctx.importMap` and `graphImports` to collect all transitively reachable headers, then passes the full closure to `synthesizeForFile`. Non-C/C++ languages are unaffected.

## Test plan

- [x] New test fixture: `c-cross-file/` — `db.c` includes `server.h`, `server.h` includes `dict.h`, `dict.c` defines the functions
- [x] 4 new integration tests in `cross-file-binding.test.ts` — symbol detection + cross-file CALLS edges through transitive headers
- [x] All 78 existing tests pass
- [x] Verified on [Redis](https://github.com/redis/redis) (~200 source files):

| Query | Before | After |
|-------|--------|-------|
| `dictFetchValue` cross-file callers | 0 | 9 |
| `processCommand` incoming callers | 0 | 1 |
| `impact dictFetchValue` risk | LOW (2) | HIGH (11) |
| Total graph edges | 65,958 | 67,904 (+1,946) |