### PR TITLE
fix(embeddings): prevent batch errors from CodeEmbedding PK violations and vector-index SET restriction

### DIFF
--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -100,8 +100,8 @@ const batchInsertEmbeddings = async (
   ) => Promise<void>,
   updates: Array<{ id: string; embedding: number[] }>,
 ): Promise<void> => {
-  // INSERT into separate embedding table - much more memory efficient!
-  const cypher = `CREATE (e:CodeEmbedding {nodeId: $nodeId, embedding: $embedding})`;
+  // MERGE instead of CREATE — idempotent, handles concurrent analyzes and partial prior runs
+  const cypher = `MERGE (e:CodeEmbedding {nodeId: $nodeId}) SET e.embedding = $embedding`;
   const paramsList = updates.map((u) => ({ nodeId: u.id, embedding: u.embedding }));
   await executeWithReusedStatement(cypher, paramsList);
 };

--- a/gitnexus/src/core/lbug/csv-generator.ts
+++ b/gitnexus/src/core/lbug/csv-generator.ts
@@ -315,14 +315,18 @@ export const streamAllCSVsToDisk = async (
     CodeElement: codeElemWriter,
   };
 
-  const seenFileIds = new Set<string>();
+  // Deduplicate all node types — the pipeline can produce duplicate IDs across
+  // all symbol types (Class, Method, Function, etc.), not just File nodes.
+  // A single Set covering every label prevents PK violations on COPY.
+  const seenNodeIds = new Set<string>();
 
   // --- SINGLE PASS over all nodes ---
   for (const node of graph.iterNodes()) {
+    if (seenNodeIds.has(node.id)) continue;
+    seenNodeIds.add(node.id);
+
     switch (node.label) {
       case 'File': {
-        if (seenFileIds.has(node.id)) break;
-        seenFileIds.add(node.id);
         const content = await extractContent(node, contentCache);
         await fileWriter.addRow(
           [

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -222,7 +222,7 @@ export async function runFullAnalysis(
           const paramsList = batch.map((e) => ({ nodeId: e.nodeId, embedding: e.embedding }));
           try {
             await executeWithReusedStatement(
-              `CREATE (e:CodeEmbedding {nodeId: $nodeId, embedding: $embedding})`,
+              `MERGE (e:CodeEmbedding {nodeId: $nodeId}) SET e.embedding = $embedding`,
               paramsList,
             );
           } catch {

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -1460,8 +1460,11 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
                   rows.map((r: any) => r.nodeId ?? r[0]).filter(Boolean),
                 );
               }
-            } catch {
-              /* CodeEmbedding table may not exist yet */
+            } catch (err: any) {
+              // Swallow only "table does not exist" — let real connection errors propagate
+              if (!err?.message?.includes('does not exist') && !err?.message?.includes('not found')) {
+                throw err;
+              }
             }
             await runEmbeddingPipeline(executeQuery, executeWithReusedStatement, (p) => {
               embedJobManager.updateJob(job.id, {

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -1452,39 +1452,44 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
             // Skip nodes that already have embeddings — Kuzu forbids SET on vector-indexed properties.
             let skipNodeIds: Set<string> | undefined;
             try {
-              const rows = await executeQuery(
-                'MATCH (e:CodeEmbedding) RETURN e.nodeId AS nodeId',
-              );
+              const rows = await executeQuery('MATCH (e:CodeEmbedding) RETURN e.nodeId AS nodeId');
               if (rows && rows.length > 0) {
-                skipNodeIds = new Set(
-                  rows.map((r: any) => r.nodeId ?? r[0]).filter(Boolean),
-                );
+                skipNodeIds = new Set(rows.map((r: any) => r.nodeId ?? r[0]).filter(Boolean));
               }
             } catch (err: any) {
               // Swallow only "table does not exist" — let real connection errors propagate
-              if (!err?.message?.includes('does not exist') && !err?.message?.includes('not found')) {
+              if (
+                !err?.message?.includes('does not exist') &&
+                !err?.message?.includes('not found')
+              ) {
                 throw err;
               }
             }
-            await runEmbeddingPipeline(executeQuery, executeWithReusedStatement, (p) => {
-              embedJobManager.updateJob(job.id, {
-                progress: {
-                  phase:
-                    p.phase === 'ready' ? 'complete' : p.phase === 'error' ? 'failed' : p.phase,
-                  percent: p.percent,
-                  message:
-                    p.phase === 'loading-model'
-                      ? 'Loading embedding model...'
-                      : p.phase === 'embedding'
-                        ? `Embedding nodes (${p.percent}%)...`
-                        : p.phase === 'indexing'
-                          ? 'Creating vector index...'
-                          : p.phase === 'ready'
-                            ? 'Embeddings complete'
-                            : `${p.phase} (${p.percent}%)`,
-                },
-              });
-            }, {}, skipNodeIds);
+            await runEmbeddingPipeline(
+              executeQuery,
+              executeWithReusedStatement,
+              (p) => {
+                embedJobManager.updateJob(job.id, {
+                  progress: {
+                    phase:
+                      p.phase === 'ready' ? 'complete' : p.phase === 'error' ? 'failed' : p.phase,
+                    percent: p.percent,
+                    message:
+                      p.phase === 'loading-model'
+                        ? 'Loading embedding model...'
+                        : p.phase === 'embedding'
+                          ? `Embedding nodes (${p.percent}%)...`
+                          : p.phase === 'indexing'
+                            ? 'Creating vector index...'
+                            : p.phase === 'ready'
+                              ? 'Embeddings complete'
+                              : `${p.phase} (${p.percent}%)`,
+                  },
+                });
+              },
+              {},
+              skipNodeIds,
+            );
           });
 
           clearTimeout(embedTimeout);

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -1455,13 +1455,19 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
               const rows = await executeQuery('MATCH (e:CodeEmbedding) RETURN e.nodeId AS nodeId');
               if (rows && rows.length > 0) {
                 skipNodeIds = new Set(rows.map((r: any) => r.nodeId ?? r[0]).filter(Boolean));
+                console.log(
+                  `[embed] ${skipNodeIds.size} nodes already embedded — skipping in incremental run`,
+                );
               }
             } catch (err: any) {
-              // Swallow only "table does not exist" — let real connection errors propagate
-              if (
-                !err?.message?.includes('does not exist') &&
-                !err?.message?.includes('not found')
-              ) {
+              // Swallow only "table does not exist" — let real connection errors propagate.
+              // Log so ops can see this path fire if Kuzu ever changes error wording.
+              const msg = err?.message ?? '';
+              if (msg.includes('does not exist') || msg.includes('not found')) {
+                console.log(
+                  `[embed] CodeEmbedding table not yet present — full embedding run (${msg})`,
+                );
+              } else {
                 throw err;
               }
             }
@@ -1487,7 +1493,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
                   },
                 });
               },
-              {},
+              {}, // config: use defaults (runEmbeddingPipeline signature: executeQuery, executeWithReusedStatement, onProgress, config, skipNodeIds)
               skipNodeIds,
             );
           });

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -1449,6 +1449,20 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
           await withLbugDb(lbugPath, async () => {
             const { runEmbeddingPipeline } =
               await import('../core/embeddings/embedding-pipeline.js');
+            // Skip nodes that already have embeddings — Kuzu forbids SET on vector-indexed properties.
+            let skipNodeIds: Set<string> | undefined;
+            try {
+              const rows = await executeQuery(
+                'MATCH (e:CodeEmbedding) RETURN e.nodeId AS nodeId',
+              );
+              if (rows && rows.length > 0) {
+                skipNodeIds = new Set(
+                  rows.map((r: any) => r.nodeId ?? r[0]).filter(Boolean),
+                );
+              }
+            } catch {
+              /* CodeEmbedding table may not exist yet */
+            }
             await runEmbeddingPipeline(executeQuery, executeWithReusedStatement, (p) => {
               embedJobManager.updateJob(job.id, {
                 progress: {
@@ -1467,7 +1481,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
                             : `${p.phase} (${p.percent}%)`,
                 },
               });
-            });
+            }, {}, skipNodeIds);
           });
 
           clearTimeout(embedTimeout);


### PR DESCRIPTION
## Summary

Fix two bugs causing mass `Batch execution error` warnings in `gitnexus serve` and the web UI embed endpoint.

## Motivation / context

Closes #822

After `gitnexus analyze --embeddings` + `gitnexus serve`, hundreds of batch errors appear. Connecting via the gitnexus.vercel.app web UI triggers a second wave of errors. Two root causes were found through serve log analysis and Playwright-assisted reproduction.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only

## Scope & constraints

**In scope**

- Fix `CREATE` → `MERGE+SET` for `CodeEmbedding` inserts in `embedding-pipeline.ts` and `run-analyze.ts`
- Fix `POST /api/embed` to skip already-embedded nodes using `skipNodeIds`

**Explicitly out of scope / not done here**

- Changing how the web UI decides when to trigger `POST /api/embed`
- Changing the vector index lifecycle (drop/recreate on re-embed)

## Implementation notes

**Bug 1 — `CREATE` vs `MERGE` in `CodeEmbedding` inserts**

`batchInsertEmbeddings` used `CREATE (e:CodeEmbedding {...})`. If `analyze --embeddings` crashed before writing `meta.json`, `CodeEmbedding` nodes remained in the DB. The next full re-analyze retried `CREATE` on the same `nodeId` values → PK violation.

The error messages looked like `Found duplicated primary key value File:app/Jobs/...` — confusingly similar to File/Class node errors, but actually `CodeEmbedding` PK violations where the `nodeId` string happened to start with `File:`.

Fix: `MERGE (e:CodeEmbedding {nodeId: $nodeId}) SET e.embedding = $embedding` in both `batchInsertEmbeddings` and the cached-embedding re-insertion in `run-analyze.ts`.

**Bug 2 — Vector-index SET restriction in `POST /api/embed`**

The web UI automatically sends `POST /api/embed` whenever a repo is opened. The endpoint called `runEmbeddingPipeline` without `skipNodeIds`, so it tried to `MERGE+SET` the `embedding` property on every node including those already embedded.

Actual error (captured from serve stdout):
```
Batch execution error: Cannot set property vec in table embeddings because it is used in one or more indexes. Try delete and then insert.
```

Kuzu/LadybugDB forbids `SET` on a property that is part of a vector index. Fix: query existing `CodeEmbedding` nodeIds before calling the pipeline and pass as `skipNodeIds` — already-embedded nodes are skipped entirely.

## Testing & verification

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration`
- [x] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test`
- [ ] `cd gitnexus-web && npx tsc -b --noEmit`
- [x] Manual: clean wipe → `gitnexus analyze --embeddings` → `gitnexus serve` → open repo in gitnexus.vercel.app → zero batch errors in serve stdout

**Test environment:**

- macOS 26.4 arm64 (Apple Silicon)
- Node v22.22.0 via Laravel Herd 1.27.0 / NVM (project `.nvmrc` targets `20`; gitnexus installed globally under v22)
- GitNexus 1.6.1
- Laravel 11 project — 955 files, 7,279 symbols, 4,020 embeddings
- Web UI: gitnexus.vercel.app → `gitnexus serve` on localhost:4747

## Risk & rollout

- No breaking changes. `skipNodeIds` was already supported by `runEmbeddingPipeline` — this just passes it.
- No index rebuild needed for existing installations (MERGE is safe on fresh or partially-populated DBs).
- `POST /api/embed` becomes incremental: only nodes without embeddings are processed. This is the correct behaviour for an "add missing embeddings" endpoint.

## Checklist

- [x] PR body meets repo minimum length
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed