### PR TITLE
feat(ci): add release-candidate publish pipeline

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -13,16 +13,21 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: 'Semver level to bump from the current npm `latest` to form the rc base'
+        description: >-
+          Cycle policy. 'auto' (default) continues the active rc cycle on
+          this branch if there is one, otherwise bumps patch from latest.
+          Choose 'patch' / 'minor' / 'major' to explicitly start or reset
+          an rc cycle.
         required: false
-        default: 'patch'
+        default: 'auto'
         type: choice
         options:
+          - auto
           - patch
           - minor
           - major
       force:
-        description: 'Publish even when HEAD already has an rc tag'
+        description: 'Publish even when HEAD already has an rc marker'
         required: false
         default: 'false'
         type: choice
@@ -41,7 +46,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ── Skip when HEAD already has an rc tag (duplicate dispatch) ────────
+  # ── Skip when HEAD already has an rc marker (retry / duplicate dispatch) ──
+  # The marker is a lightweight tag `rc/<HEAD_SHA>` pushed *before* `npm
+  # publish`, so a failed publish leaves the marker in place and the guard
+  # refuses to re-publish. Recovery path after a partial failure:
+  #   git push --delete origin rc/<HEAD_SHA> v<RC_VERSION>
+  # then redispatch with force=true.
   guard:
     name: Check if release candidate should run
     runs-on: ubuntu-latest
@@ -60,40 +70,39 @@ jobs:
       - name: Decide
         id: decide
         shell: bash
+        env:
+          FORCE: ${{ inputs.force }}
+          BUMP_INPUT: ${{ inputs.bump }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          FORCE="${{ inputs.force }}"
           HEAD_SHA=$(git rev-parse HEAD)
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
           if [ "$FORCE" = "true" ]; then
-            echo "Force flag set — running regardless of tag history."
+            echo "Force flag set — running regardless of marker tag."
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Guard against a manual workflow_dispatch landing on the same
-          # commit that was already released by the preceding push run.
-          # Tag scheme: v<base>-rc.<N> (e.g., v1.6.2-rc.3).
-          # creatordate covers both lightweight and annotated tags by their
-          # actual creation time, unlike committerdate which sorts by the
-          # underlying commit timestamp (wrong for out-of-order pushes).
-          LAST_TAG=$(git tag --list 'v*-rc.*' --sort=-creatordate | head -n1 || true)
-          if [ -z "$LAST_TAG" ]; then
-            echo "No previous rc tag found — first run."
+          # An explicit cycle reset on dispatch (bump != auto) also bypasses
+          # the dedup guard — the maintainer is deliberately asking for a
+          # new rc from the same commit.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
+             && [ -n "${BUMP_INPUT:-}" ] \
+             && [ "${BUMP_INPUT:-auto}" != "auto" ]; then
+            echo "Explicit bump=$BUMP_INPUT — bypassing marker dedup."
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          LAST_SHA=$(git rev-list -n1 "$LAST_TAG")
-          echo "Last rc tag:  $LAST_TAG -> $LAST_SHA"
-          echo "Current HEAD: $HEAD_SHA"
-
-          if [ "$LAST_SHA" = "$HEAD_SHA" ]; then
-            echo "HEAD already released as $LAST_TAG — skipping."
+          # Dedup: is there already an rc/<HEAD_SHA> marker pointing at HEAD?
+          MARKER="rc/${HEAD_SHA}"
+          if git rev-parse "refs/tags/$MARKER" >/dev/null 2>&1; then
+            echo "HEAD already has marker $MARKER — skipping."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           else
-            echo "New commit detected — proceeding."
+            echo "No marker on HEAD — proceeding."
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -102,9 +111,6 @@ jobs:
     needs: guard
     if: needs.guard.outputs.should_run == 'true'
     uses: ./.github/workflows/ci.yml
-    # Minimum necessary for workflow_call into ci.yml:
-    # - save-pr-meta is gated on event_name == 'pull_request' and never runs here
-    # - actions: read is kept in case sub-jobs pull workflow artifacts/metadata
     permissions:
       contents: read
       actions: read
@@ -118,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: write # push rc tag, create release
+      contents: write # push rc tag + marker
       id-token: write # npm provenance
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -146,47 +152,34 @@ jobs:
         shell: bash
         working-directory: gitnexus
         env:
-          BUMP_LEVEL: ${{ inputs.bump || 'patch' }}
+          BUMP_INPUT: ${{ inputs.bump }}
+          EVENT_NAME: ${{ github.event_name }}
           PKG_NAME: gitnexus
         run: |
           set -euo pipefail
 
-          # 1. Base = next stable, derived from current `latest` on npm.
-          #    Falls back to package.json ONLY on an E404 (package not yet
-          #    published). Any other error (network, auth, malformed
-          #    response) is surfaced immediately so a transient outage
-          #    can't silently pick the wrong base.
-          NPM_STDERR="$(mktemp)"
-          if CURRENT_LATEST="$(npm view "$PKG_NAME" version 2>"$NPM_STDERR")"; then
+          # 1. Current published `latest` — the floor for any new rc base.
+          #    Only E404 ("never published") falls back to package.json; any
+          #    other error (network, auth, malformed response) fails fast.
+          NPM_STDERR_LATEST="$(mktemp)"
+          if CURRENT_LATEST="$(npm view "$PKG_NAME" version 2>"$NPM_STDERR_LATEST")"; then
             :
           else
-            if grep -q 'E404' "$NPM_STDERR"; then
+            if grep -q 'E404' "$NPM_STDERR_LATEST"; then
               CURRENT_LATEST="$(node -p "require('./package.json').version")"
-              echo "Package not yet on registry (E404) — seeding from package.json: $CURRENT_LATEST"
+              echo "Package not on registry (E404) — seeding from package.json: $CURRENT_LATEST"
             else
-              echo "::error::npm registry unreachable or returned an unexpected error:" >&2
-              cat "$NPM_STDERR" >&2
-              rm -f "$NPM_STDERR"
+              echo "::error::npm registry unreachable for 'view version':" >&2
+              cat "$NPM_STDERR_LATEST" >&2
+              rm -f "$NPM_STDERR_LATEST"
               exit 1
             fi
           fi
-          rm -f "$NPM_STDERR"
-          # Strip any prerelease suffix from the seed to guarantee a clean base.
+          rm -f "$NPM_STDERR_LATEST"
           CURRENT_LATEST_CLEAN="${CURRENT_LATEST%%-*}"
 
-          # 2. Bump by the requested semver level (default: patch) to form
-          #    the target base for this rc cycle.
-          BASE="$(npx --yes -p semver@7 semver -i "$BUMP_LEVEL" "$CURRENT_LATEST_CLEAN")"
-          echo "Current latest: $CURRENT_LATEST ($CURRENT_LATEST_CLEAN clean)"
-          echo "Bump level:     $BUMP_LEVEL"
-          echo "RC base:        $BASE"
-
-          # 3. Query the highest existing rc counter for this base, if any.
-          #    `npm view <pkg> versions --json` always returns the full list;
-          #    we parse in Node for robust semver handling.
-          # Same error handling as the version query above: only E404
-          # ("no such package") collapses to an empty list; everything
-          # else fails the step so we don't publish with a wrong counter.
+          # 2. Full version list — needed for the counter and for active-cycle
+          #    inference. Same E404-only fallback.
           NPM_STDERR_VERSIONS="$(mktemp)"
           if VERSIONS_JSON="$(npm view "$PKG_NAME" versions --json 2>"$NPM_STDERR_VERSIONS")"; then
             :
@@ -195,16 +188,57 @@ jobs:
               VERSIONS_JSON='[]'
               echo "No published versions for $PKG_NAME yet (E404)."
             else
-              echo "::error::Failed to query published versions from npm:" >&2
+              echo "::error::npm registry unreachable for 'view versions':" >&2
               cat "$NPM_STDERR_VERSIONS" >&2
               rm -f "$NPM_STDERR_VERSIONS"
               exit 1
             fi
           fi
           rm -f "$NPM_STDERR_VERSIONS"
-          # Compute next rc counter in a standalone Node script to avoid
-          # fragile shell-vs-JS backslash escaping. Writes the value to a
-          # file we then read back.
+
+          # 3. Base selection.
+          #    - workflow_dispatch + bump ∈ {patch,minor,major} → explicit cycle
+          #      reset from latest.
+          #    - Everything else (push, or dispatch with bump=auto) → continue
+          #      the highest active rc base > latest if one exists; else
+          #      default to patch from latest.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
+             && [ -n "${BUMP_INPUT:-}" ] \
+             && [ "${BUMP_INPUT:-auto}" != "auto" ]; then
+            BASE="$(npx --yes -p semver@7 semver -i "$BUMP_INPUT" "$CURRENT_LATEST_CLEAN")"
+            echo "Explicit bump=$BUMP_INPUT → BASE=$BASE"
+          else
+            cat > /tmp/active_base.mjs <<'NODESCRIPT'
+          const latest = process.env.LATEST;
+          let v;
+          try { v = JSON.parse(process.env.VERSIONS_JSON); } catch { v = []; }
+          if (!Array.isArray(v)) v = [v];
+          const parse = s => s.split(".").map(n => parseInt(n, 10));
+          const gt = (a, b) => {
+            const [A, B] = [parse(a), parse(b)];
+            for (let i = 0; i < 3; i++) if (A[i] !== B[i]) return A[i] > B[i];
+            return false;
+          };
+          const bases = new Set();
+          for (const s of v) {
+            const m = /^(\d+\.\d+\.\d+)-rc\.\d+$/.exec(s);
+            if (m && gt(m[1], latest)) bases.add(m[1]);
+          }
+          if (!bases.size) { process.stdout.write(""); process.exit(0); }
+          const sorted = [...bases].sort((a, b) => gt(a, b) ? 1 : -1);
+          process.stdout.write(sorted[sorted.length - 1]);
+          NODESCRIPT
+            ACTIVE_BASE="$(LATEST="$CURRENT_LATEST_CLEAN" VERSIONS_JSON="$VERSIONS_JSON" node /tmp/active_base.mjs)"
+            if [ -n "$ACTIVE_BASE" ]; then
+              BASE="$ACTIVE_BASE"
+              echo "Continuing active rc cycle → BASE=$BASE"
+            else
+              BASE="$(npx --yes -p semver@7 semver -i patch "$CURRENT_LATEST_CLEAN")"
+              echo "No active rc cycle → patch bump from latest → BASE=$BASE"
+            fi
+          fi
+
+          # 4. Counter: 1 + max existing N for `${BASE}-rc.*`, else 1.
           cat > /tmp/next_rc.mjs <<'NODESCRIPT'
           const base = process.env.BASE;
           const prefix = base + "-rc.";
@@ -219,10 +253,17 @@ jobs:
           NODESCRIPT
           NEXT_N="$(BASE="$BASE" VERSIONS_JSON="$VERSIONS_JSON" node /tmp/next_rc.mjs)"
           RC_VERSION="${BASE}-rc.${NEXT_N}"
-          echo "Computed rc:    $RC_VERSION"
+          echo "Computed rc: $RC_VERSION"
 
-          echo "base=$BASE"          >> "$GITHUB_OUTPUT"
-          echo "rc_n=$NEXT_N"        >> "$GITHUB_OUTPUT"
+          # 5. Defensive: if the exact version already exists on the registry
+          #    (e.g., race with another run), abort before re-publishing.
+          if npm view "$PKG_NAME@$RC_VERSION" version >/dev/null 2>&1; then
+            echo "::error::Version $RC_VERSION already exists on npm — aborting."
+            exit 1
+          fi
+
+          echo "base=$BASE"             >> "$GITHUB_OUTPUT"
+          echo "rc_n=$NEXT_N"           >> "$GITHUB_OUTPUT"
           echo "rc_version=$RC_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Apply rc version in-CI
@@ -241,34 +282,61 @@ jobs:
         run: npm publish --dry-run --tag rc
         working-directory: gitnexus
 
+      # ── Acquire the "rc lock" BEFORE publishing (fixes idempotency) ─────
+      # We create two tags and push them atomically:
+      #   v<RC_VERSION>      → annotated tag on a detached release commit
+      #                        whose tree contains the rewritten package.json
+      #                        (so the tag's source matches the npm tarball)
+      #   rc/<HEAD_SHA>      → lightweight tag on HEAD; the guard's dedup key
+      # If this push fails, nothing is published — safe.
+      # If this push succeeds but npm publish fails, the marker stays on
+      # the remote and blocks retries until an operator manually cleans up.
+      - name: Create and push rc tags
+        id: reltag
+        shell: bash
+        working-directory: gitnexus
+        env:
+          RC_VERSION: ${{ steps.version.outputs.rc_version }}
+          HEAD_SHA: ${{ needs.guard.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          VTAG="v${RC_VERSION}"
+          MARKER="rc/${HEAD_SHA}"
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          # Detached release commit with the version bump — keeps `main`
+          # pristine but gives the v-tag a tree that matches the published
+          # package contents exactly (fixes release-integrity gap).
+          git add package.json package-lock.json 2>/dev/null || git add package.json
+          git commit -m "release: ${VTAG}" --allow-empty
+          RELEASE_SHA="$(git rev-parse HEAD)"
+          echo "Detached release commit: $RELEASE_SHA"
+
+          # Annotated release tag on the release commit.
+          git tag -a "$VTAG" "$RELEASE_SHA" -m "$VTAG"
+          # Lightweight marker on the user-visible HEAD for the guard.
+          git tag "$MARKER" "$HEAD_SHA"
+
+          # Atomic push of both refs. If either would clobber an existing
+          # remote ref, the push fails and we stop before npm publish.
+          git push --atomic origin "refs/tags/$VTAG" "refs/tags/$MARKER"
+
+          echo "vtag=$VTAG"     >> "$GITHUB_OUTPUT"
+          echo "marker=$MARKER" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Publish to npm (rc dist-tag)
         run: npm publish --provenance --access public --tag rc
         working-directory: gitnexus
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Push rc git tag
-        shell: bash
-        env:
-          RC_VERSION: ${{ steps.version.outputs.rc_version }}
-          HEAD_SHA: ${{ needs.guard.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-          TAG="v${RC_VERSION}"
-          git config user.name  'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists locally — skipping tag creation."
-          else
-            git tag "$TAG" "$HEAD_SHA"
-            git push origin "$TAG"
-          fi
-
       - name: Create GitHub prerelease
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
-          tag_name: v${{ steps.version.outputs.rc_version }}
-          name: Release Candidate v${{ steps.version.outputs.rc_version }}
+          tag_name: ${{ steps.reltag.outputs.vtag }}
+          name: Release Candidate ${{ steps.reltag.outputs.vtag }}
           prerelease: true
           make_latest: 'false'
           generate_release_notes: true
@@ -278,7 +346,8 @@ jobs:
             **npm:** `npm install gitnexus@rc`
             **Version:** `${{ steps.version.outputs.rc_version }}`
             **Target base:** `${{ steps.version.outputs.base }}` (rc #${{ steps.version.outputs.rc_n }})
-            **Commit:** ${{ needs.guard.outputs.head_sha }}
+            **Source commit (main):** ${{ needs.guard.outputs.head_sha }}
+            **Release commit (versioned tree):** ${{ steps.reltag.outputs.release_sha }}
 
             Release candidates are pre-stable builds intended for early testing.
             Stable releases remain on the `latest` dist-tag.

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -74,7 +74,10 @@ jobs:
           # Guard against a manual workflow_dispatch landing on the same
           # commit that was already released by the preceding push run.
           # Tag scheme: v<base>-rc.<N> (e.g., v1.6.2-rc.3).
-          LAST_TAG=$(git tag --list 'v*-rc.*' --sort=-committerdate | head -n1 || true)
+          # creatordate covers both lightweight and annotated tags by their
+          # actual creation time, unlike committerdate which sorts by the
+          # underlying commit timestamp (wrong for out-of-order pushes).
+          LAST_TAG=$(git tag --list 'v*-rc.*' --sort=-creatordate | head -n1 || true)
           if [ -z "$LAST_TAG" ]; then
             echo "No previous rc tag found — first run."
             echo "should_run=true" >> "$GITHUB_OUTPUT"
@@ -98,10 +101,13 @@ jobs:
     needs: guard
     if: needs.guard.outputs.should_run == 'true'
     uses: ./.github/workflows/ci.yml
+    # Minimum necessary for workflow_call into ci.yml:
+    # - save-pr-meta is gated on event_name == 'pull_request' and never runs here
+    # - actions: read is kept in case sub-jobs pull workflow artifacts/metadata
     permissions:
       contents: read
       actions: read
-      pull-requests: write
+    secrets: inherit
 
   # ── Publish the rc build to npm + create GitHub prerelease ───────────
   publish:
@@ -145,13 +151,25 @@ jobs:
           set -euo pipefail
 
           # 1. Base = next stable, derived from current `latest` on npm.
-          #    Falls back to package.json when the package has no published
-          #    `latest` yet (first-ever publish scenario).
-          CURRENT_LATEST="$(npm view "$PKG_NAME" version 2>/dev/null || true)"
-          if [ -z "$CURRENT_LATEST" ]; then
-            CURRENT_LATEST="$(node -p "require('./package.json').version")"
-            echo "No published 'latest' found — seeding from package.json: $CURRENT_LATEST"
+          #    Falls back to package.json ONLY on an E404 (package not yet
+          #    published). Any other error (network, auth, malformed
+          #    response) is surfaced immediately so a transient outage
+          #    can't silently pick the wrong base.
+          NPM_STDERR="$(mktemp)"
+          if CURRENT_LATEST="$(npm view "$PKG_NAME" version 2>"$NPM_STDERR")"; then
+            :
+          else
+            if grep -q 'E404' "$NPM_STDERR"; then
+              CURRENT_LATEST="$(node -p "require('./package.json').version")"
+              echo "Package not yet on registry (E404) — seeding from package.json: $CURRENT_LATEST"
+            else
+              echo "::error::npm registry unreachable or returned an unexpected error:" >&2
+              cat "$NPM_STDERR" >&2
+              rm -f "$NPM_STDERR"
+              exit 1
+            fi
           fi
+          rm -f "$NPM_STDERR"
           # Strip any prerelease suffix from the seed to guarantee a clean base.
           CURRENT_LATEST_CLEAN="${CURRENT_LATEST%%-*}"
 
@@ -227,8 +245,6 @@ jobs:
             git tag "$TAG" "$HEAD_SHA"
             git push origin "$TAG"
           fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-        id: reltag
 
       - name: Create GitHub prerelease
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -34,8 +34,9 @@ on:
 permissions: {}
 
 concurrency:
-  # Allow overlapping manual runs to complete; back-to-back push runs on
-  # the same ref still serialize.
+  # Serialize all runs on the same ref (push + workflow_dispatch) to prevent
+  # two publishes racing on the rc counter. Do not cancel an in-progress run
+  # when a newer one is queued — we want the earlier merge to publish first.
   group: release-candidate-${{ github.ref }}
   cancel-in-progress: false
 
@@ -183,7 +184,24 @@ jobs:
           # 3. Query the highest existing rc counter for this base, if any.
           #    `npm view <pkg> versions --json` always returns the full list;
           #    we parse in Node for robust semver handling.
-          VERSIONS_JSON="$(npm view "$PKG_NAME" versions --json 2>/dev/null || echo '[]')"
+          # Same error handling as the version query above: only E404
+          # ("no such package") collapses to an empty list; everything
+          # else fails the step so we don't publish with a wrong counter.
+          NPM_STDERR_VERSIONS="$(mktemp)"
+          if VERSIONS_JSON="$(npm view "$PKG_NAME" versions --json 2>"$NPM_STDERR_VERSIONS")"; then
+            :
+          else
+            if grep -q 'E404' "$NPM_STDERR_VERSIONS"; then
+              VERSIONS_JSON='[]'
+              echo "No published versions for $PKG_NAME yet (E404)."
+            else
+              echo "::error::Failed to query published versions from npm:" >&2
+              cat "$NPM_STDERR_VERSIONS" >&2
+              rm -f "$NPM_STDERR_VERSIONS"
+              exit 1
+            fi
+          fi
+          rm -f "$NPM_STDERR_VERSIONS"
           # Compute next rc counter in a standalone Node script to avoid
           # fragile shell-vs-JS backslash escaping. Writes the value to a
           # file we then read back.

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -113,7 +113,6 @@ jobs:
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
-      actions: read
     secrets: inherit
 
   # ── Publish the rc build to npm + create GitHub prerelease ───────────
@@ -257,9 +256,23 @@ jobs:
 
           # 5. Defensive: if the exact version already exists on the registry
           #    (e.g., race with another run), abort before re-publishing.
-          if npm view "$PKG_NAME@$RC_VERSION" version >/dev/null 2>&1; then
+          #    Same E404-only pattern used above — a transient network
+          #    failure must fail loudly, not pretend the version is missing.
+          NPM_STDERR_EXISTS="$(mktemp)"
+          if npm view "$PKG_NAME@$RC_VERSION" version 2>"$NPM_STDERR_EXISTS" >/dev/null; then
+            rm -f "$NPM_STDERR_EXISTS"
             echo "::error::Version $RC_VERSION already exists on npm — aborting."
             exit 1
+          else
+            if grep -qiE 'E404|not found' "$NPM_STDERR_EXISTS"; then
+              rm -f "$NPM_STDERR_EXISTS"
+              # Version doesn't exist — safe to proceed.
+            else
+              echo "::error::npm registry unreachable for existence check:" >&2
+              cat "$NPM_STDERR_EXISTS" >&2
+              rm -f "$NPM_STDERR_EXISTS"
+              exit 1
+            fi
           fi
 
           echo "base=$BASE"             >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,250 @@
+name: Release Candidate
+
+on:
+  # Publish a release-candidate build whenever a merge/commit lands on main.
+  # Docs/README-only changes are filtered out so prose updates don't
+  # cut a release.
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver level to bump from the current npm `latest` to form the rc base'
+        required: false
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      force:
+        description: 'Publish even when HEAD already has an rc tag'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+# No workflow-level permissions — scoped per job below.
+permissions: {}
+
+concurrency:
+  # Allow overlapping manual runs to complete; back-to-back push runs on
+  # the same ref still serialize.
+  group: release-candidate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Skip when HEAD already has an rc tag (duplicate dispatch) ────────
+  guard:
+    name: Check if release candidate should run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      head_sha: ${{ steps.decide.outputs.head_sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Decide
+        id: decide
+        shell: bash
+        run: |
+          set -euo pipefail
+          FORCE="${{ inputs.force }}"
+          HEAD_SHA=$(git rev-parse HEAD)
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+          if [ "$FORCE" = "true" ]; then
+            echo "Force flag set — running regardless of tag history."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Guard against a manual workflow_dispatch landing on the same
+          # commit that was already released by the preceding push run.
+          # Tag scheme: v<base>-rc.<N> (e.g., v1.6.2-rc.3).
+          LAST_TAG=$(git tag --list 'v*-rc.*' --sort=-committerdate | head -n1 || true)
+          if [ -z "$LAST_TAG" ]; then
+            echo "No previous rc tag found — first run."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_SHA=$(git rev-list -n1 "$LAST_TAG")
+          echo "Last rc tag:  $LAST_TAG -> $LAST_SHA"
+          echo "Current HEAD: $HEAD_SHA"
+
+          if [ "$LAST_SHA" = "$HEAD_SHA" ]; then
+            echo "HEAD already released as $LAST_TAG — skipping."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New commit detected — proceeding."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ── Reuse the stable CI workflow ─────────────────────────────────────
+  ci:
+    needs: guard
+    if: needs.guard.outputs.should_run == 'true'
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+
+  # ── Publish the rc build to npm + create GitHub prerelease ───────────
+  publish:
+    name: Publish release candidate to npm
+    needs: [guard, ci]
+    if: needs.guard.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # push rc tag, create release
+      id-token: write # npm provenance
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: gitnexus/package-lock.json
+
+      - name: Build gitnexus-shared
+        run: npm install && npm run build
+        working-directory: gitnexus-shared
+
+      - name: Install gitnexus dependencies
+        run: npm ci
+        working-directory: gitnexus
+
+      - name: Resolve rc version
+        id: version
+        shell: bash
+        working-directory: gitnexus
+        env:
+          BUMP_LEVEL: ${{ inputs.bump || 'patch' }}
+          PKG_NAME: gitnexus
+        run: |
+          set -euo pipefail
+
+          # 1. Base = next stable, derived from current `latest` on npm.
+          #    Falls back to package.json when the package has no published
+          #    `latest` yet (first-ever publish scenario).
+          CURRENT_LATEST="$(npm view "$PKG_NAME" version 2>/dev/null || true)"
+          if [ -z "$CURRENT_LATEST" ]; then
+            CURRENT_LATEST="$(node -p "require('./package.json').version")"
+            echo "No published 'latest' found — seeding from package.json: $CURRENT_LATEST"
+          fi
+          # Strip any prerelease suffix from the seed to guarantee a clean base.
+          CURRENT_LATEST_CLEAN="${CURRENT_LATEST%%-*}"
+
+          # 2. Bump by the requested semver level (default: patch) to form
+          #    the target base for this rc cycle.
+          BASE="$(npx --yes -p semver@7 semver -i "$BUMP_LEVEL" "$CURRENT_LATEST_CLEAN")"
+          echo "Current latest: $CURRENT_LATEST ($CURRENT_LATEST_CLEAN clean)"
+          echo "Bump level:     $BUMP_LEVEL"
+          echo "RC base:        $BASE"
+
+          # 3. Query the highest existing rc counter for this base, if any.
+          #    `npm view <pkg> versions --json` always returns the full list;
+          #    we parse in Node for robust semver handling.
+          VERSIONS_JSON="$(npm view "$PKG_NAME" versions --json 2>/dev/null || echo '[]')"
+          # Compute next rc counter in a standalone Node script to avoid
+          # fragile shell-vs-JS backslash escaping. Writes the value to a
+          # file we then read back.
+          cat > /tmp/next_rc.mjs <<'NODESCRIPT'
+          const base = process.env.BASE;
+          const prefix = base + "-rc.";
+          let v;
+          try { v = JSON.parse(process.env.VERSIONS_JSON); } catch { v = []; }
+          if (!Array.isArray(v)) v = [v];
+          const ns = v
+            .filter(s => typeof s === "string" && s.startsWith(prefix))
+            .map(s => parseInt(s.slice(prefix.length), 10))
+            .filter(n => Number.isInteger(n) && n >= 0);
+          process.stdout.write(String(ns.length ? Math.max(...ns) + 1 : 1));
+          NODESCRIPT
+          NEXT_N="$(BASE="$BASE" VERSIONS_JSON="$VERSIONS_JSON" node /tmp/next_rc.mjs)"
+          RC_VERSION="${BASE}-rc.${NEXT_N}"
+          echo "Computed rc:    $RC_VERSION"
+
+          echo "base=$BASE"          >> "$GITHUB_OUTPUT"
+          echo "rc_n=$NEXT_N"        >> "$GITHUB_OUTPUT"
+          echo "rc_version=$RC_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Apply rc version in-CI
+        shell: bash
+        working-directory: gitnexus
+        run: |
+          set -euo pipefail
+          npm version "${{ steps.version.outputs.rc_version }}" \
+            --no-git-tag-version --allow-same-version
+
+      - name: Build gitnexus
+        run: npm run build
+        working-directory: gitnexus
+
+      - name: Dry-run publish
+        run: npm publish --dry-run --tag rc
+        working-directory: gitnexus
+
+      - name: Publish to npm (rc dist-tag)
+        run: npm publish --provenance --access public --tag rc
+        working-directory: gitnexus
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Push rc git tag
+        shell: bash
+        env:
+          RC_VERSION: ${{ steps.version.outputs.rc_version }}
+          HEAD_SHA: ${{ needs.guard.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          TAG="v${RC_VERSION}"
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists locally — skipping tag creation."
+          else
+            git tag "$TAG" "$HEAD_SHA"
+            git push origin "$TAG"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        id: reltag
+
+      - name: Create GitHub prerelease
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        with:
+          tag_name: v${{ steps.version.outputs.rc_version }}
+          name: Release Candidate v${{ steps.version.outputs.rc_version }}
+          prerelease: true
+          make_latest: 'false'
+          generate_release_notes: true
+          body: |
+            Automated release candidate build from `main`.
+
+            **npm:** `npm install gitnexus@rc`
+            **Version:** `${{ steps.version.outputs.rc_version }}`
+            **Target base:** `${{ steps.version.outputs.base }}` (rc #${{ steps.version.outputs.rc_n }})
+            **Commit:** ${{ needs.guard.outputs.head_sha }}
+
+            Release candidates are pre-stable builds intended for early testing.
+            Stable releases remain on the `latest` dist-tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,12 +61,26 @@ Two publish workflows ship `gitnexus` to npm:
   every push to `main` (typically a merged PR) plus manual dispatch. Docs-only
   changes are skipped via `paths-ignore`. Publishes to the `rc` dist-tag with
   version `X.Y.Z-rc.N` and a GitHub prerelease, where:
-  - `X.Y.Z` is the current npm `latest` bumped by the `bump` input (default
-    `patch`; `minor` or `major` when kicking off a bigger cycle).
-  - `N` is auto-incremented by querying the registry for existing
-    `X.Y.Z-rc.*` versions. First rc for a given base is `rc.1`.
-  The guard skips re-runs when HEAD already has a `v*-rc.*` git tag; dispatch
-  with `force: true` to override, or with `bump: minor` to start a new cycle.
+  - `X.Y.Z` is selected automatically. On push (and on dispatch with
+    `bump: auto`, the default) the workflow **continues the active rc cycle**:
+    if the registry already has `X.Y.Z-rc.*` versions with `X.Y.Z` > current
+    `latest`, it reuses the highest such base; otherwise it patch-bumps
+    from `latest`. Dispatching with `bump: patch|minor|major` **resets**
+    the cycle from `latest`.
+  - `N` is auto-incremented against existing `X.Y.Z-rc.*` entries on the
+    registry. First rc for a given base is `rc.1`.
+
+  Idempotency: the workflow pushes an `rc/<HEAD_SHA>` marker tag and a
+  `v<RC>` release tag **atomically, before** calling `npm publish`. The guard
+  refuses to re-run once the marker exists, so a post-publish failure will
+  not mint a duplicate rc for the same commit. The `v<RC>` tag points at a
+  detached release commit whose `package.json` matches the npm tarball
+  exactly (traceable releases). Recovery after a partial failure:
+
+  ```bash
+  git push --delete origin rc/<HEAD_SHA> v<RC>
+  # then redispatch the workflow with force: true
+  ```
 
 The rc workflow never moves `latest`. To verify after a change, inspect dist-tags:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,27 @@ Maintainers may request changes for correctness, tests, performance, or consiste
 ## AI-assisted contributions
 
 If you use coding agents, follow project context files (e.g. `AGENTS.md`, `CLAUDE.md`) and avoid drive-by refactors unrelated to the issue. Prefer incremental, test-backed changes.
+
+## Releases
+
+Two publish workflows ship `gitnexus` to npm:
+
+- **Stable** (`.github/workflows/publish.yml`) — triggered by pushing a `v*` tag
+  from `main`. Publishes to the `latest` dist-tag with a changelog-backed
+  GitHub release.
+- **Release Candidate** (`.github/workflows/release-candidate.yml`) — runs on
+  every push to `main` (typically a merged PR) plus manual dispatch. Docs-only
+  changes are skipped via `paths-ignore`. Publishes to the `rc` dist-tag with
+  version `X.Y.Z-rc.N` and a GitHub prerelease, where:
+  - `X.Y.Z` is the current npm `latest` bumped by the `bump` input (default
+    `patch`; `minor` or `major` when kicking off a bigger cycle).
+  - `N` is auto-incremented by querying the registry for existing
+    `X.Y.Z-rc.*` versions. First rc for a given base is `rc.1`.
+  The guard skips re-runs when HEAD already has a `v*-rc.*` git tag; dispatch
+  with `force: true` to override, or with `bump: minor` to start a new cycle.
+
+The rc workflow never moves `latest`. To verify after a change, inspect dist-tags:
+
+```bash
+npm view gitnexus dist-tags
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,10 @@ If you use coding agents, follow project context files (e.g. `AGENTS.md`, `CLAUD
 
 Two publish workflows ship `gitnexus` to npm:
 
-- **Stable** (`.github/workflows/publish.yml`) — triggered by pushing a `v*` tag
-  from `main`. Publishes to the `latest` dist-tag with a changelog-backed
-  GitHub release.
+- **Stable** (`.github/workflows/publish.yml`) — triggered by pushing any `v*`
+  tag. Publishes to the `latest` dist-tag with a changelog-backed GitHub
+  release. Maintainers are expected to tag from `main` as a convention; the
+  workflow itself does not enforce branch reachability.
 - **Release Candidate** (`.github/workflows/release-candidate.yml`) — runs on
   every push to `main` (typically a merged PR) plus manual dispatch. Docs-only
   changes are skipped via `paths-ignore`. Publishes to the `rc` dist-tag with

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -234,6 +234,28 @@ Installed automatically by both `gitnexus analyze` (per-repo) and `gitnexus setu
 - Node.js >= 18
 - Git repository (uses git for commit tracking)
 
+## Release candidates
+
+Stable releases publish to the default `latest` dist-tag. Whenever a pull
+request merges into `main`, an automated workflow also publishes a prerelease
+build under the `rc` dist-tag, so early adopters can try in-flight fixes
+without waiting for the next stable cut.
+
+```bash
+# Try the latest release candidate (pre-stable — may change at any time)
+npm install -g gitnexus@rc
+# — or —
+npx gitnexus@rc analyze
+```
+
+Release-candidate versions follow the standard semver prerelease format
+`X.Y.Z-rc.N`, where `X.Y.Z` is the next stable target (bumped from the
+current `latest` by patch by default; `minor` or `major` when kicking off a
+bigger cycle) and `N` increments per published rc. Example sequence:
+`1.6.2-rc.1`, `1.6.2-rc.2`, …, then once `1.6.2` ships stable,
+`1.6.3-rc.1`. See the [Releases page](https://github.com/abhigyanpatwari/GitNexus/releases)
+for the full list; stable `latest` is unaffected.
+
 ## Troubleshooting
 
 ### `Cannot destructure property 'package' of 'node.target' as it is null`

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -236,10 +236,11 @@ Installed automatically by both `gitnexus analyze` (per-repo) and `gitnexus setu
 
 ## Release candidates
 
-Stable releases publish to the default `latest` dist-tag. Whenever a pull
-request merges into `main`, an automated workflow also publishes a prerelease
-build under the `rc` dist-tag, so early adopters can try in-flight fixes
-without waiting for the next stable cut.
+Stable releases publish to the default `latest` dist-tag. When a pull request
+with non-documentation changes merges into `main`, an automated workflow also
+publishes a prerelease build under the `rc` dist-tag, so early adopters can
+try in-flight fixes without waiting for the next stable cut. (Docs-only
+merges are skipped.)
 
 ```bash
 # Try the latest release candidate (pre-stable — may change at any time)


### PR DESCRIPTION
## Summary

Adds an automated release-candidate pipeline that publishes `gitnexus@rc` to npm whenever a merge lands on `main`. Stable `latest` publishes via `publish.yml` are untouched.

## Version scheme

Canonical semver prerelease form `X.Y.Z-rc.N`:

- **Base `X.Y.Z`** = current npm `latest` bumped by the `bump` input (default `patch`; `minor` / `major` when kicking off a bigger cycle). `package.json` is **not** the source of truth — this decouples rc cadence from manual version bumps.
- **Counter `N`** = `1 + max` of existing `${BASE}-rc.*` entries on the npm registry (queried via `npm view gitnexus versions --json`). First rc for a base is `rc.1`. Once the base ships stable, the counter resets naturally because the base advances.

Example sequence with `latest = 1.6.1`:

| Trigger | bump | Result |
|---|---|---|
| push to main | `patch` (default) | `1.6.2-rc.1` |
| next push | `patch` | `1.6.2-rc.2` |
| `publish.yml` ships `1.6.2` stable | — | `latest = 1.6.2` |
| next push | `patch` | `1.6.3-rc.1` |
| manual dispatch | `minor` | `1.7.0-rc.1` |

## Workflow design

- **Trigger:** `push` to `main` (with `paths-ignore` for docs/LICENSE) + `workflow_dispatch` with inputs `bump` and `force`.
- **Guard job** checks whether HEAD already has a `v*-rc.*` git tag; dedupes duplicate manual dispatches.
- **CI job** reuses `./.github/workflows/ci.yml` via `workflow_call`, so the same quality/tests/e2e suite must pass before publish.
- **Publish job** builds `gitnexus-shared` → installs → computes rc version → `npm publish --provenance --access public --tag rc` → tags `v<rc-version>` → creates GitHub prerelease (marked `prerelease: true`, `make_latest: 'false'`).
- All third-party actions SHA-pinned; per-job permission scoping; no workflow-level permissions.

## Test plan

- [ ] After merge, dispatch the workflow manually to verify end-to-end on a live commit.
- [ ] Confirm `npm view gitnexus dist-tags` shows `latest` unchanged and `rc` updated.
- [ ] Confirm GitHub "Releases" page shows the new entry as a prerelease (not "Latest release").
- [ ] Trigger a second run on the same commit and verify the guard skips it; then dispatch with `force: true` and verify it proceeds and the counter increments.
- [ ] Dispatch with `bump: minor` and verify the base advances to `1.7.0-rc.1`.