### PR TITLE
fix: set env.cacheDir to user-writable location

### DIFF
--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -157,6 +157,11 @@ export const initEmbedder = async (
     try {
       // Configure transformers.js environment
       env.allowLocalModels = false;
+      // Default cache to user-writable location. transformers.js defaults to
+      // ./node_modules/.cache inside its own install dir, which is unwritable
+      // when gitnexus is installed globally (e.g. /usr/lib/node_modules/).
+      // Respect HF_HOME if set, otherwise fall back to ~/.cache/huggingface.
+      env.cacheDir = process.env.HF_HOME ?? `${process.env.HOME}/.cache/huggingface`;
 
       const isDev = process.env.NODE_ENV === 'development';
       if (isDev) {

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -42,6 +42,11 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
   initPromise = (async () => {
     try {
       env.allowLocalModels = false;
+      // Default cache to user-writable location. transformers.js defaults to
+      // ./node_modules/.cache inside its own install dir, which is unwritable
+      // when gitnexus is installed globally (e.g. /usr/lib/node_modules/).
+      // Respect HF_HOME if set, otherwise fall back to ~/.cache/huggingface.
+      env.cacheDir = process.env.HF_HOME ?? `${process.env.HOME}/.cache/huggingface`;
 
       console.error('GitNexus: Loading embedding model (first search may take a moment)...');
 


### PR DESCRIPTION
## Summary

When `@huggingface/transformers` is installed globally (e.g. via `npm install -g`), it defaults its cache directory to `./node_modules/.cache` inside its own install dir — which is **unwritable** by non-root users.

This causes an `EACCES` error on first use when the model is downloaded:
```
EACCES: permission denied, mkdir '/usr/lib/node_modules/gitnexus/node_modules/@huggingface/transformers/.cache'
```

## Root Cause

`transformers.js` defaults `env.cacheDir` to `{package_install_dir}/.cache/`. It does **not** respect `HF_HOME` or `TRANSFORMERS_CACHE` env vars (those are for the Python library). Only the programmatic `env.cacheDir` setting works.

GitNexus sets `env.allowLocalModels = false` in both embedders but never configures `env.cacheDir`.

## Fix

Set `env.cacheDir` before `pipeline()` is called in both embedders:
- `gitnexus/src/mcp/core/embedder.ts`
- `gitnexus/src/core/embeddings/embedder.ts`

Respects `HF_HOME` if set, otherwise falls back to `~/.cache/huggingface`.

## Testing

- TypeScript compiles cleanly (no new errors introduced by this change)
- Verified the `env.cacheDir` assignment pattern matches existing `env.allowLocalModels` usage in the same files