### PR TITLE
feat(extractors): detect jQuery $.ajax/$.get/$.post and axios object-form as HTTP consumers

### DIFF
--- a/gitnexus/src/core/group/extractors/http-patterns/node.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/node.ts
@@ -17,6 +17,9 @@ import type { HttpDetection, HttpLanguagePlugin } from './types.js';
  *   - Express `router.get(...)` / `app.post(...)` providers
  *   - `fetch(url)` / `fetch(url, { method: 'POST' })` consumers
  *   - `axios.get(url)` / `axios.delete(url)` consumers
+ *   - `axios({ method, url })` object-form consumers
+ *   - jQuery `$.get(url)` / `$.post(url, ...)` shorthand consumers
+ *   - jQuery `$.ajax({ url, method | type })` consumers
  *
  * Because the JavaScript and TypeScript tree-sitter grammars share
  * node type names for every construct we query, pattern sources are
@@ -103,6 +106,48 @@ const AXIOS_SPEC: PatternSpec<Record<string, never>> = {
   `,
 };
 
+// ─── Consumer: jQuery shorthand $.get(url) / $.post(url, ...) ────────
+// `$` is a valid JS identifier, so tree-sitter parses `$.get(...)` as a
+// call_expression whose function is a member_expression on identifier `$`.
+const JQUERY_SHORTHAND_SPEC: PatternSpec<Record<string, never>> = {
+  meta: {},
+  query: `
+    (call_expression
+      function: (member_expression
+        object: (identifier) @obj (#eq? @obj "$")
+        property: (property_identifier) @http_method (#match? @http_method "^(get|post)$"))
+      arguments: (arguments . [(string) (template_string)] @path))
+  `,
+};
+
+// ─── Consumer: jQuery $.ajax({ url, method|type }) ───────────────────
+// The query captures the options object only; key/value pairs are read
+// programmatically via `readStringProp` below, which tolerates any key
+// order and accepts either `method:` or `type:` (jQuery supports both).
+const JQUERY_AJAX_SPEC: PatternSpec<Record<string, never>> = {
+  meta: {},
+  query: `
+    (call_expression
+      function: (member_expression
+        object: (identifier) @obj (#eq? @obj "$")
+        property: (property_identifier) @fn (#eq? @fn "ajax"))
+      arguments: (arguments (object) @options))
+  `,
+};
+
+// ─── Consumer: axios({ method, url }) object form ────────────────────
+// Distinct from AXIOS_SPEC above because the call target is an identifier
+// (`axios`) rather than a member expression (`axios.get`). As with the
+// jQuery ajax form, option keys are resolved programmatically.
+const AXIOS_OBJECT_SPEC: PatternSpec<Record<string, never>> = {
+  meta: {},
+  query: `
+    (call_expression
+      function: (identifier) @fn (#eq? @fn "axios")
+      arguments: (arguments (object) @options))
+  `,
+};
+
 interface NodePatternBundle {
   controller: CompiledPatterns<Record<string, never>>;
   methodDecorator: CompiledPatterns<Record<string, never>>;
@@ -110,6 +155,9 @@ interface NodePatternBundle {
   fetchNoOptions: CompiledPatterns<Record<string, never>>;
   fetchWithOptions: CompiledPatterns<Record<string, never>>;
   axios: CompiledPatterns<Record<string, never>>;
+  jqueryShorthand: CompiledPatterns<Record<string, never>>;
+  jqueryAjax: CompiledPatterns<Record<string, never>>;
+  axiosObject: CompiledPatterns<Record<string, never>>;
 }
 
 function compileBundle(language: unknown, name: string): NodePatternBundle {
@@ -126,6 +174,9 @@ function compileBundle(language: unknown, name: string): NodePatternBundle {
     fetchNoOptions: mk(FETCH_NO_OPTIONS_SPEC, 'fetch-no-options'),
     fetchWithOptions: mk(FETCH_WITH_OPTIONS_SPEC, 'fetch-with-options'),
     axios: mk(AXIOS_SPEC, 'axios'),
+    jqueryShorthand: mk(JQUERY_SHORTHAND_SPEC, 'jquery-shorthand'),
+    jqueryAjax: mk(JQUERY_AJAX_SPEC, 'jquery-ajax'),
+    axiosObject: mk(AXIOS_OBJECT_SPEC, 'axios-object'),
   };
 }
 
@@ -158,6 +209,28 @@ function joinPath(prefix: string, sub: string): string {
   const cleanSub = sub.replace(/^\/+/, '');
   if (!cleanPrefix) return `/${cleanSub}`;
   return `/${cleanPrefix}/${cleanSub}`;
+}
+
+/**
+ * Walk `pair` children of an `object` literal and return the unquoted
+ * string/template_string value for the first pair whose key matches one
+ * of `keyNames`. Returns null when no matching pair is present or the
+ * value is not a string literal. Used by the jQuery ajax / axios object
+ * consumers to resolve `url` / `method` / `type` keys in any order.
+ */
+function readStringProp(objectNode: Parser.SyntaxNode, keyNames: readonly string[]): string | null {
+  for (let i = 0; i < objectNode.namedChildCount; i++) {
+    const pair = objectNode.namedChild(i);
+    if (!pair || pair.type !== 'pair') continue;
+    const keyNode = pair.childForFieldName('key');
+    const valueNode = pair.childForFieldName('value');
+    if (!keyNode || !valueNode) continue;
+    if (!keyNames.includes(keyNode.text)) continue;
+    if (valueNode.type !== 'string' && valueNode.type !== 'template_string') continue;
+    const lit = unquoteLiteral(valueNode.text);
+    if (lit !== null) return lit;
+  }
+  return null;
 }
 
 /**
@@ -345,6 +418,62 @@ function scanBundle(bundle: NodePatternBundle, tree: Parser.Tree): HttpDetection
       role: 'consumer',
       framework: 'axios',
       method: methodNode.text.toUpperCase(),
+      path,
+      name: null,
+      confidence: 0.7,
+    });
+  }
+
+  // Consumer: jQuery shorthand $.get(url) / $.post(url, ...)
+  for (const match of runCompiledPatterns(bundle.jqueryShorthand, tree)) {
+    const methodNode = match.captures.http_method;
+    const pathNode = match.captures.path;
+    if (!methodNode || !pathNode) continue;
+    const path = unquoteLiteral(pathNode.text);
+    if (path === null) continue;
+    out.push({
+      role: 'consumer',
+      framework: 'jquery',
+      method: methodNode.text.toUpperCase(),
+      path,
+      name: null,
+      confidence: 0.7,
+    });
+  }
+
+  // Consumer: jQuery $.ajax({ url, method|type }). jQuery accepts either
+  // `method:` or `type:`; both default to GET when absent.
+  for (const match of runCompiledPatterns(bundle.jqueryAjax, tree)) {
+    const optionsNode = match.captures.options;
+    if (!optionsNode) continue;
+    const path = readStringProp(optionsNode, ['url']);
+    if (path === null) continue;
+    const rawMethod = readStringProp(optionsNode, ['method', 'type']);
+    const method = (rawMethod ?? 'GET').toUpperCase();
+    out.push({
+      role: 'consumer',
+      framework: 'jquery',
+      method,
+      path,
+      name: null,
+      confidence: 0.7,
+    });
+  }
+
+  // Consumer: axios({ method, url }) object form. Structurally distinct
+  // from axios.<verb>(url) (identifier vs member_expression call), so no
+  // dedup against the member-form loop above is required.
+  for (const match of runCompiledPatterns(bundle.axiosObject, tree)) {
+    const optionsNode = match.captures.options;
+    if (!optionsNode) continue;
+    const path = readStringProp(optionsNode, ['url']);
+    if (path === null) continue;
+    const rawMethod = readStringProp(optionsNode, ['method']);
+    const method = (rawMethod ?? 'GET').toUpperCase();
+    out.push({
+      role: 'consumer',
+      framework: 'axios',
+      method,
       path,
       name: null,
       confidence: 0.7,

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -327,6 +327,10 @@ function createUser(payload) {
 $.ajax({ url: '/api/orders', method: 'PUT', data: {} });
 $.ajax({ url: '/api/items',  type:   'DELETE' });
 $.ajax({ url: '/api/default' });
+
+function reloadOrder(id) {
+  return $.ajax({ url: \`/api/orders/\${id}\`, method: 'GET' });
+}
 `,
       );
 
@@ -336,6 +340,12 @@ $.ajax({ url: '/api/default' });
       expect(consumers.find((c) => c.contractId === 'http::PUT::/api/orders')).toBeDefined();
       expect(consumers.find((c) => c.contractId === 'http::DELETE::/api/items')).toBeDefined();
       expect(consumers.find((c) => c.contractId === 'http::GET::/api/default')).toBeDefined();
+      // Template-literal URL inside $.ajax is normalized to {param} the same
+      // way the fetch/axios paths do — confirms readStringProp accepts
+      // template_string values for jQuery ajax, not just for axios object form.
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/api/orders/{param}'),
+      ).toBeDefined();
     });
 
     it('extracts axios({ method, url }) object form regardless of key order', async () => {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -290,6 +290,114 @@ export const deleteUser = (id: string) => axios.delete(\`/api/users/\${id}\`);
       ).toBeDefined();
     });
 
+    it('extracts jQuery $.get and $.post shorthand', async () => {
+      const dir = path.join(tmpDir, 'jquery-shorthand');
+      fs.mkdirSync(path.join(dir, 'public/js'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'public/js/users.js'),
+        `
+function loadUsers() {
+  $.get('/api/users', function (data) { console.log(data); });
+}
+
+function createUser(payload) {
+  $.post('/api/users', payload);
+}
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      const getRoute = consumers.find((c) => c.contractId === 'http::GET::/api/users');
+      expect(getRoute).toBeDefined();
+      expect(getRoute?.meta.framework).toBe('jquery');
+
+      const postRoute = consumers.find((c) => c.contractId === 'http::POST::/api/users');
+      expect(postRoute).toBeDefined();
+      expect(postRoute?.meta.framework).toBe('jquery');
+    });
+
+    it('extracts jQuery $.ajax with method: and type: keys and default GET', async () => {
+      const dir = path.join(tmpDir, 'jquery-ajax');
+      fs.mkdirSync(path.join(dir, 'public/js'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'public/js/orders.js'),
+        `
+$.ajax({ url: '/api/orders', method: 'PUT', data: {} });
+$.ajax({ url: '/api/items',  type:   'DELETE' });
+$.ajax({ url: '/api/default' });
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      expect(consumers.find((c) => c.contractId === 'http::PUT::/api/orders')).toBeDefined();
+      expect(consumers.find((c) => c.contractId === 'http::DELETE::/api/items')).toBeDefined();
+      expect(consumers.find((c) => c.contractId === 'http::GET::/api/default')).toBeDefined();
+    });
+
+    it('extracts axios({ method, url }) object form regardless of key order', async () => {
+      const dir = path.join(tmpDir, 'axios-object');
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'src/orders.ts'),
+        `
+import axios from 'axios';
+
+export function createOrder(data: unknown) {
+  return axios({ method: 'POST', url: '/api/orders', data });
+}
+
+export function updateUser(id: string, data: unknown) {
+  return axios({ url: \`/api/users/\${id}\`, method: 'PUT', data });
+}
+
+export function listDefaults() {
+  return axios({ url: '/api/defaults' });
+}
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      expect(consumers.find((c) => c.contractId === 'http::POST::/api/orders')).toBeDefined();
+      expect(consumers.find((c) => c.contractId === 'http::PUT::/api/users/{param}')).toBeDefined();
+      expect(consumers.find((c) => c.contractId === 'http::GET::/api/defaults')).toBeDefined();
+    });
+
+    it('does not emit consumers for unrelated object-literal calls (negative control)', async () => {
+      const dir = path.join(tmpDir, 'jquery-axios-negative');
+      fs.mkdirSync(path.join(dir, 'public/js'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'public/js/misc.js'),
+        `
+// jQuery but not an ajax/get/post call
+$.fn.extend({ url: '/nope', method: 'POST' });
+$.each([1, 2, 3], function (i, v) { return v; });
+
+// Not axios and not $ — unrelated helper that happens to take { url, method }
+function myHelper(opts) { return opts; }
+myHelper({ url: '/nope', method: 'POST' });
+
+// Bare object literal, not a call argument at all
+const cfg = { url: '/nope', method: 'POST' };
+console.log(cfg);
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      // None of the above should have produced any HTTP consumer contracts.
+      const nopeConsumers = consumers.filter(
+        (c) => typeof c.meta.path === 'string' && c.meta.path.includes('/nope'),
+      );
+      expect(nopeConsumers).toHaveLength(0);
+    });
+
     it('extracts Python requests calls', async () => {
       const dir = path.join(tmpDir, 'python-consumer');
       fs.mkdirSync(path.join(dir, 'src'), { recursive: true });


### PR DESCRIPTION
Closes #828.

## Summary

Extend the JS/TS HTTP consumer extractor (`gitnexus/src/core/group/extractors/http-patterns/node.ts`) so that three widely-used call shapes emit `consumer` contracts the same way `fetch()` and `axios.<verb>()` already do:

- **jQuery shorthand:** `$.get('/api/x')`, `$.post('/api/x', data)`
- **jQuery ajax form:** `$.ajax({ url: '/api/x', method: 'GET' })` / `$.ajax({ url: '/api/x', type: 'GET' })`
- **axios object form:** `axios({ method: 'POST', url: '/api/x' })`

## Why

`group sync` over any Laravel / legacy frontend repo currently produces zero consumer contracts for files that use `$.ajax`/`$.get`/`$.post` — the cross-link between the frontend caller and the backend route is silently invisible, so downstream impact analysis misses real dependencies. Same story for codebases that call `axios({ method, url })` instead of the dotted shorthand.

## Implementation

`node.ts`:
- 3 new `PatternSpec`s alongside the existing `FETCH_*_SPEC` / `AXIOS_SPEC`: `JQUERY_SHORTHAND_SPEC`, `JQUERY_AJAX_SPEC`, `AXIOS_OBJECT_SPEC`.
- `NodePatternBundle` gains `jqueryShorthand` / `jqueryAjax` / `axiosObject` slots, compiled once per JS / TS / TSX grammar via the existing `compileBundle()` path.
- New `readStringProp()` helper walks `pair` children of an `(object)` literal and resolves `url` / `method` / `type` keys independent of declaration order.
- 3 new scan loops in `scanBundle()` emit `HttpDetection { role: 'consumer', framework: 'jquery' | 'axios', ... }` with confidence `0.7` (matching the existing source-scan consumers) and default method `GET` when absent (matches both jQuery `$.ajax` and axios runtime defaults).

### Deviation from the issue's proposed patterns

The issue sketches one tree-sitter query per pattern that encodes `url` and `method` as adjacent `pair` children. S-expression matching is positional — that forces a specific key order, which isn't guaranteed for JS object literals. This PR instead captures the options object and resolves keys in TypeScript post-processing, so `{ url, method }` and `{ method, url }` are both matched. The same path also accepts jQuery's `type:` synonym for `method:` (jQuery supports both; the issue example only showed `type`).

## Tests

`gitnexus/test/unit/group/http-route-extractor.test.ts` — 4 new `it()` cases under the existing consumer-extraction block:

1. `extracts jQuery $.get and $.post shorthand` — asserts `http::GET::/api/users` and `http::POST::/api/users` with `framework: 'jquery'`.
2. `extracts jQuery $.ajax with method: and type: keys and default GET` — covers `method: 'PUT'`, `type: 'DELETE'`, and a method-less call defaulting to `GET`.
3. `extracts axios({ method, url }) object form regardless of key order` — proves post-processing is order-independent and that a url-only call defaults to `GET`.
4. `does not emit consumers for unrelated object-literal calls (negative control)` — `$.fn.extend(...)`, `$.each(...)`, a non-axios helper call, and a bare `const cfg = { url, method }` all produce zero consumer contracts, so the new patterns can't overmatch.

## Test plan

- [x] `npx vitest run test/unit/group/http-route-extractor.test.ts` → `22 passed` (18 existing + 4 new)
- [x] `npm run test:unit` → only the 4 pre-existing unrelated failures (`test/unit/skip-git-cli.test.ts` and `test/unit/git-utils.test.ts` — both fail identically on `main` before this change; neither touches the extractor surface)
- [x] `npx tsc --noEmit` → clean
- [x] Pre-commit hook (lint-staged + eslint + prettier + tsc) → pass

## Safety / backwards-compat

- Purely additive: new `PatternSpec`s, new bundle slots, new loops. No existing code path modified.
- No changes to `HttpDetection` / `ExtractedContract` shape — the orchestrator normalises these detections identically to the existing fetch/axios consumers.
- `framework: 'jquery'` is a new label; `framework: 'axios'` is reused so downstream grouping stays consistent.
- Patterns are structurally disjoint (`axios(...)` identifier-form vs `axios.x(...)` member-form; `$.get` / `$.post` shorthand vs `$.ajax` object), so no dedup state is needed.