### PR TITLE
refactor(cli): trim duplicated ai-context CLAUDE.md block

### DIFF
--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -101,44 +101,12 @@ This project is indexed by GitNexus as **${projectName}**${noStats ? '' : ` (${s
 - When exploring unfamiliar code, use \`gitnexus_query({query: "concept"})\` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use \`gitnexus_context({name: "symbolName"})\`.
 
-## When Debugging
-
-1. \`gitnexus_query({query: "<error or symptom>"})\` — find execution flows related to the issue
-2. \`gitnexus_context({name: "<suspect function>"})\` — see all callers, callees, and process participation
-3. \`READ gitnexus://repo/${projectName}/process/{processName}\` — trace the full execution flow step by step
-4. For regressions: \`gitnexus_detect_changes({scope: "compare", base_ref: "main"})\` — see what your branch changed
-
-## When Refactoring
-
-- **Renaming**: MUST use \`gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})\` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with \`dry_run: false\`.
-- **Extracting/Splitting**: MUST run \`gitnexus_context({name: "target"})\` to see all incoming/outgoing refs, then \`gitnexus_impact({target: "target", direction: "upstream"})\` to find all external callers before moving code.
-- After any refactor: run \`gitnexus_detect_changes({scope: "all"})\` to verify only expected files changed.
-
 ## Never Do
 
 - NEVER edit a function, class, or method without first running \`gitnexus_impact\` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
 - NEVER rename symbols with find-and-replace — use \`gitnexus_rename\` which understands the call graph.
 - NEVER commit changes without running \`gitnexus_detect_changes()\` to check affected scope.
-
-## Tools Quick Reference
-
-| Tool | When to use | Command |
-|------|-------------|---------|
-| \`query\` | Find code by concept | \`gitnexus_query({query: "auth validation"})\` |
-| \`context\` | 360-degree view of one symbol | \`gitnexus_context({name: "validateUser"})\` |
-| \`impact\` | Blast radius before editing | \`gitnexus_impact({target: "X", direction: "upstream"})\` |
-| \`detect_changes\` | Pre-commit scope check | \`gitnexus_detect_changes({scope: "staged"})\` |
-| \`rename\` | Safe multi-file rename | \`gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})\` |
-| \`cypher\` | Custom graph queries | \`gitnexus_cypher({query: "MATCH ..."})\` |
-
-## Impact Risk Levels
-
-| Depth | Meaning | Action |
-|-------|---------|--------|
-| d=1 | WILL BREAK — direct callers/importers | MUST update these |
-| d=2 | LIKELY AFFECTED — indirect deps | Should test |
-| d=3 | MAY NEED TESTING — transitive | Test if critical path |
 
 ## Resources
 
@@ -148,32 +116,6 @@ This project is indexed by GitNexus as **${projectName}**${noStats ? '' : ` (${s
 | \`gitnexus://repo/${projectName}/clusters\` | All functional areas |
 | \`gitnexus://repo/${projectName}/processes\` | All execution flows |
 | \`gitnexus://repo/${projectName}/process/{name}\` | Step-by-step execution trace |
-
-## Self-Check Before Finishing
-
-Before completing any code modification task, verify:
-1. \`gitnexus_impact\` was run for all modified symbols
-2. No HIGH/CRITICAL risk warnings were ignored
-3. \`gitnexus_detect_changes()\` confirms changes match expected scope
-4. All d=1 (WILL BREAK) dependents were updated
-
-## Keeping the Index Fresh
-
-After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
-
-\`\`\`bash
-npx gitnexus analyze
-\`\`\`
-
-If the index previously included embeddings, preserve them by adding \`--embeddings\`:
-
-\`\`\`bash
-npx gitnexus analyze --embeddings
-\`\`\`
-
-To check whether embeddings exist, inspect \`.gitnexus/meta.json\` — the \`stats.embeddings\` field shows the count (0 means no embeddings). **Running analyze without \`--embeddings\` will delete any previously generated embeddings.**
-
-> Claude Code users: A PostToolUse hook handles this automatically after \`git commit\` and \`git merge\`.
 
 ${
   groupNames && groupNames.length > 0

--- a/gitnexus/test/unit/ai-context.test.ts
+++ b/gitnexus/test/unit/ai-context.test.ts
@@ -45,6 +45,63 @@ describe('generateAIContextFiles', () => {
     expect(content).toContain('TestProject');
   });
 
+  it('keeps the load-bearing repo-specific sections in the CLAUDE.md block (#856)', async () => {
+    // The trimmed block must still contain everything that is genuinely
+    // unique per repo or load-bearing for the agent: the freshness warning,
+    // the Always Do / Never Do imperative lists, the Resources URI table
+    // (projectName-interpolated), and the skills routing table that tells
+    // the agent which skill file to read for each task.
+    const stats = { nodes: 50, edges: 100, processes: 5 };
+    await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);
+
+    const content = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
+
+    expect(content).toContain('If any GitNexus tool warns the index is stale');
+    expect(content).toContain('## Always Do');
+    expect(content).toContain('## Never Do');
+    expect(content).toContain('## Resources');
+    expect(content).toContain('gitnexus://repo/TestProject/context');
+    expect(content).toContain('gitnexus-impact-analysis/SKILL.md');
+    expect(content).toContain('gitnexus-refactoring/SKILL.md');
+    expect(content).toContain('gitnexus-debugging/SKILL.md');
+    expect(content).toContain('gitnexus-cli/SKILL.md');
+  });
+
+  it('does not duplicate content that already lives in skill files (#856)', async () => {
+    // The six sections listed in issue #856 are redundant with the skill
+    // files shipped alongside the CLAUDE.md block (both are loaded into
+    // every Claude Code session). Their absence is the whole point of the
+    // trim — assert each header is gone so a future regression that pads
+    // the block back out fails here.
+    const stats = { nodes: 50, edges: 100, processes: 5 };
+    await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);
+
+    const content = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
+
+    expect(content).not.toContain('## Tools Quick Reference');
+    expect(content).not.toContain('## Impact Risk Levels');
+    expect(content).not.toContain('## Self-Check Before Finishing');
+    expect(content).not.toContain('## When Debugging');
+    expect(content).not.toContain('## When Refactoring');
+    expect(content).not.toContain('## Keeping the Index Fresh');
+  });
+
+  it('keeps the CLAUDE.md GitNexus block under the token-cost budget (#856)', async () => {
+    // The pre-trim block was ~5465 chars. After #856 it's ~2580 — about a
+    // 52% reduction. 2700 is a soft ceiling that still leaves headroom for
+    // legitimate future additions but will fail loudly if the trim is
+    // reverted or someone pads the block back out toward the original size.
+    const stats = { nodes: 50, edges: 100, processes: 5 };
+    await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);
+
+    const content = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    const block = content.slice(
+      content.indexOf('<!-- gitnexus:start -->'),
+      content.indexOf('<!-- gitnexus:end -->'),
+    );
+    expect(block.length).toBeLessThan(2700);
+  });
+
   it('handles empty stats', async () => {
     const stats = {};
     const result = await generateAIContextFiles(tmpDir, storagePath, 'EmptyProject', stats);


### PR DESCRIPTION
Closes #856.

## Summary

The block that \`npx gitnexus analyze\` injects between \`<!-- gitnexus:start -->\` and \`<!-- gitnexus:end -->\` into every project's **CLAUDE.md** and **AGENTS.md** is currently **~101 lines / ~5465 characters**. Six sub-sections duplicate content that is already present in the installed skill files at \`.claude/skills/gitnexus/*/SKILL.md\`:

| Section | Already lives in |
|---------|------------------|
| Tools Quick Reference | [gitnexus-guide.md](https://github.com/abhigyanpatwari/GitNexus/blob/main/gitnexus/skills/gitnexus-guide.md) |
| Impact Risk Levels | [gitnexus-impact-analysis.md](https://github.com/abhigyanpatwari/GitNexus/blob/main/gitnexus/skills/gitnexus-impact-analysis.md) |
| Self-Check Before Finishing | [gitnexus-refactoring.md](https://github.com/abhigyanpatwari/GitNexus/blob/main/gitnexus/skills/gitnexus-refactoring.md) |
| When Debugging step list | [gitnexus-debugging.md](https://github.com/abhigyanpatwari/GitNexus/blob/main/gitnexus/skills/gitnexus-debugging.md) |
| When Refactoring step list | [gitnexus-refactoring.md](https://github.com/abhigyanpatwari/GitNexus/blob/main/gitnexus/skills/gitnexus-refactoring.md) |
| Keeping the Index Fresh detail block | one-line freshness warning retained at top + [gitnexus-cli.md](https://github.com/abhigyanpatwari/GitNexus/blob/main/gitnexus/skills/gitnexus-cli.md) |

Both the CLAUDE.md block **and** every skill file are loaded into every Claude Code session, so this duplication costs tokens on every turn of every conversation in every indexed repo.

## What changed

Rewrote the template literal inside \`generateGitNexusContent()\` at [gitnexus/src/cli/ai-context.ts](gitnexus/src/cli/ai-context.ts). Kept only content that is genuinely unique-per-repo or load-bearing for the agent before it picks a skill:

**Retained:**
- Header + \`projectName\` + stats line
- One-line freshness warning
- \`## Always Do\` (imperatives the agent must know up-front)
- \`## Never Do\` (safety constraints the agent must know up-front)
- \`## Resources\` table (URI patterns interpolated with \`projectName\`)
- \`## Cross-Repo Groups\` (conditional, unique per repo)
- \`## CLI\` header + skills routing table (the load-bearing pointer that tells the agent which skill to read for each task)

**Removed:**
- \`## Tools Quick Reference\`, \`## Impact Risk Levels\`, \`## Self-Check Before Finishing\`, \`## When Debugging\`, \`## When Refactoring\`, \`## Keeping the Index Fresh\`

**Net reduction: 58 lines / ~2900 characters (~52% smaller).** Post-trim block is ~40 lines / ~2580 characters.

## Backward compatibility

- \`<!-- gitnexus:start -->\` / \`<!-- gitnexus:end -->\` markers unchanged → the idempotent block-replacement logic continues to work on re-runs.
- \`generateAIContextFiles()\` signature, export surface, and caller contracts unchanged — called from [analyze.ts](gitnexus/src/cli/analyze.ts) and [run-analyze.ts](gitnexus/src/core/run-analyze.ts) with the same arguments.
- All six skill files continue to be installed unchanged; they are now the single source of truth for the trimmed content.
- \`skipAgentsMd\` and \`noStats\` flags are unaffected (they operate outside the template body).
- No graph/index/storage schema change. Revert is a pure text rollback with no side effects.

## Tests

Three new assertions added to [gitnexus/test/unit/ai-context.test.ts](gitnexus/test/unit/ai-context.test.ts):

1. **KEEP invariant** — block still contains the freshness warning, \`## Always Do\`, \`## Never Do\`, \`## Resources\`, the \`projectName\`-interpolated URI (\`gitnexus://repo/TestProject/context\`), and the four skills-routing targets (impact-analysis, refactoring, debugging, cli).
2. **TRIM invariant** — block does NOT contain any of the six removed headers.
3. **BUDGET invariant** — block length < 2700 chars (catches any regression that pads the block back toward the original 5465 size; current post-trim is 2582).

All 6 existing tests still pass — including \`updates existing CLAUDE.md without duplicating\` (single \`gitnexus:start\` marker on re-run).

## Test plan

- [x] \`npx vitest run test/unit/ai-context.test.ts\` → **9 pass** (6 existing + 3 new)
- [x] \`npm run test:unit\` → **3770 pass** (same 4 pre-existing env failures unchanged — \`skip-git-cli.test.ts\` needs built \`dist/\`, \`git-utils.test.ts\` Windows worktree tmpdir)
- [x] \`npx tsc --noEmit\` → clean
- [x] Pre-commit hook (lint-staged + eslint + prettier + tsc) → passed