### PR TITLE
feat(cli): analyze --name <alias> + duplicate-name guard for the repo registry

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -13,7 +13,11 @@ import { execFileSync } from 'child_process';
 import v8 from 'v8';
 import cliProgress from 'cli-progress';
 import { closeLbug } from '../core/lbug/lbug-adapter.js';
-import { getStoragePaths, getGlobalRegistryPath } from '../storage/repo-manager.js';
+import {
+  getStoragePaths,
+  getGlobalRegistryPath,
+  RegistryNameCollisionError,
+} from '../storage/repo-manager.js';
 import { getGitRoot, hasGitDir } from '../storage/git.js';
 import { runFullAnalysis } from '../core/run-analyze.js';
 import fs from 'fs/promises';
@@ -59,6 +63,13 @@ export interface AnalyzeOptions {
   noStats?: boolean;
   /** Index the folder even when no .git directory is present. */
   skipGit?: boolean;
+  /**
+   * Override the default basename-derived registry `name` with a
+   * user-supplied alias (#829). Disambiguates repos whose paths share a
+   * basename. Persisted — subsequent re-analyses of the same path without
+   * `--name` preserve the alias.
+   */
+  name?: string;
 }
 
 export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOptions) => {
@@ -191,6 +202,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
         skipGit: options?.skipGit,
         skipAgentsMd: options?.skipAgentsMd,
         noStats: options?.noStats,
+        registryName: options?.name,
       },
       {
         onProgress: (_phase, percent, message) => {
@@ -298,6 +310,22 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
     bar.stop();
 
     const msg = err.message || String(err);
+
+    // Registry name-collision from --name (#829) — surface as an
+    // actionable error rather than a generic stack-trace.
+    if (err instanceof RegistryNameCollisionError) {
+      console.error(`\n  Registry name collision:\n`);
+      console.error(`    "${err.name}" is already used by "${err.existingPath}".\n`);
+      console.error(`  Options:`);
+      console.error(`    • Pick a different alias:  gitnexus analyze --name <alias>`);
+      console.error(
+        `    • Force the duplicate:     gitnexus analyze --force  (leaves "-r ${err.name}" ambiguous)`,
+      );
+      console.error('');
+      process.exitCode = 1;
+      return;
+    }
+
     console.error(`\n  Analysis failed: ${msg}\n`);
 
     // Provide helpful guidance for known failure modes

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -315,11 +315,11 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
     // actionable error rather than a generic stack-trace.
     if (err instanceof RegistryNameCollisionError) {
       console.error(`\n  Registry name collision:\n`);
-      console.error(`    "${err.name}" is already used by "${err.existingPath}".\n`);
+      console.error(`    "${err.registryName}" is already used by "${err.existingPath}".\n`);
       console.error(`  Options:`);
       console.error(`    • Pick a different alias:  gitnexus analyze --name <alias>`);
       console.error(
-        `    • Force the duplicate:     gitnexus analyze --force  (leaves "-r ${err.name}" ambiguous)`,
+        `    • Force the duplicate:     gitnexus analyze --force  (leaves "-r ${err.registryName}" ambiguous)`,
       );
       console.error('');
       process.exitCode = 1;

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -70,6 +70,14 @@ export interface AnalyzeOptions {
    * `--name` preserve the alias.
    */
   name?: string;
+  /**
+   * Allow registration even when another path already uses the same
+   * `--name` alias (#829). Intentionally a distinct flag from `--force`
+   * because the user may want to coexist under the same name WITHOUT
+   * paying the cost of a pipeline re-index. Maps to registerRepo's
+   * `allowDuplicateName` option end-to-end.
+   */
+  allowDuplicateName?: boolean;
 }
 
 export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOptions) => {
@@ -198,20 +206,19 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
       repoPath,
       {
         // Pipeline re-index — OR'd with --skills because skill generation
-        // needs a fresh pipelineResult. This is intentional and has no
-        // bearing on the registry collision guard (see registryForce below).
+        // needs a fresh pipelineResult. Has no bearing on the registry
+        // collision guard (see allowDuplicateName below).
         force: options?.force || options?.skills,
         embeddings: options?.embeddings,
         skipGit: options?.skipGit,
         skipAgentsMd: options?.skipAgentsMd,
         noStats: options?.noStats,
         registryName: options?.name,
-        // Registry-collision bypass — only the explicit --force flag.
-        // Keeping this separate from `force` above means --skills (and any
-        // future flag that triggers pipeline re-run) does NOT accidentally
-        // bypass the RegistryNameCollisionError guard. See #829 review
-        // round 2.
-        registryForce: options?.force,
+        // Registry-collision bypass — its own CLI flag, intentionally NOT
+        // overloading --force. A user who hits the collision guard should
+        // be able to accept the duplicate name without also paying the
+        // cost of a full pipeline re-index. See #829 review round 2.
+        allowDuplicateName: options?.allowDuplicateName,
       },
       {
         onProgress: (_phase, percent, message) => {
@@ -328,7 +335,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
       console.error(`  Options:`);
       console.error(`    • Pick a different alias:  gitnexus analyze --name <alias>`);
       console.error(
-        `    • Force the duplicate:     gitnexus analyze --force  (leaves "-r ${err.registryName}" ambiguous)`,
+        `    • Allow the duplicate:     gitnexus analyze --allow-duplicate-name  (leaves "-r ${err.registryName}" ambiguous)`,
       );
       console.error('');
       process.exitCode = 1;

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -197,12 +197,21 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
     const result = await runFullAnalysis(
       repoPath,
       {
+        // Pipeline re-index — OR'd with --skills because skill generation
+        // needs a fresh pipelineResult. This is intentional and has no
+        // bearing on the registry collision guard (see registryForce below).
         force: options?.force || options?.skills,
         embeddings: options?.embeddings,
         skipGit: options?.skipGit,
         skipAgentsMd: options?.skipAgentsMd,
         noStats: options?.noStats,
         registryName: options?.name,
+        // Registry-collision bypass — only the explicit --force flag.
+        // Keeping this separate from `force` above means --skills (and any
+        // future flag that triggers pipeline re-run) does NOT accidentally
+        // bypass the RegistryNameCollisionError guard. See #829 review
+        // round 2.
+        registryForce: options?.force,
       },
       {
         onProgress: (_phase, percent, message) => {

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -28,6 +28,11 @@ program
   .option('--skip-agents-md', 'Skip updating the gitnexus section in AGENTS.md and CLAUDE.md')
   .option('--no-stats', 'Omit volatile file/symbol counts from AGENTS.md and CLAUDE.md')
   .option('--skip-git', 'Index a folder without requiring a .git directory')
+  .option(
+    '--name <alias>',
+    'Register this repo under a custom name in ~/.gitnexus/registry.json ' +
+      '(disambiguates repos whose paths share a basename, e.g. two different .../app folders)',
+  )
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
   .addHelpText(
     'after',

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -33,6 +33,11 @@ program
     'Register this repo under a custom name in ~/.gitnexus/registry.json ' +
       '(disambiguates repos whose paths share a basename, e.g. two different .../app folders)',
   )
+  .option(
+    '--allow-duplicate-name',
+    'Register this repo even if another path already uses the same --name alias. ' +
+      'Leaves `-r <name>` ambiguous for the two paths; use -r <path> to disambiguate.',
+  )
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
   .addHelpText(
     'after',

--- a/gitnexus/src/cli/list.ts
+++ b/gitnexus/src/cli/list.ts
@@ -17,12 +17,23 @@ export const listCommand = async () => {
 
   console.log(`\n  Indexed Repositories (${entries.length})\n`);
 
+  // Count occurrences of each name so colliding entries can be
+  // disambiguated in the header (#829). Unique-name entries render
+  // identically to pre-#829 output; only collisions gain a suffix.
+  const nameCounts = new Map<string, number>();
+  for (const e of entries) {
+    const key = e.name.toLowerCase();
+    nameCounts.set(key, (nameCounts.get(key) ?? 0) + 1);
+  }
+
   for (const entry of entries) {
     const indexedDate = new Date(entry.indexedAt).toLocaleString();
     const stats = entry.stats || {};
     const commitShort = entry.lastCommit?.slice(0, 7) || 'unknown';
+    const hasCollision = (nameCounts.get(entry.name.toLowerCase()) ?? 0) > 1;
+    const header = hasCollision ? `${entry.name}  (${entry.path})` : entry.name;
 
-    console.log(`  ${entry.name}`);
+    console.log(`  ${header}`);
     console.log(`    Path:    ${entry.path}`);
     console.log(`    Indexed: ${indexedDate}`);
     console.log(`    Commit:  ${commitShort}`);

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -46,6 +46,12 @@ export interface AnalyzeCallbacks {
 }
 
 export interface AnalyzeOptions {
+  /**
+   * Force a full re-index of the pipeline. Callers may OR this with
+   * other flags that imply re-analysis (e.g. `--skills`), so the value
+   * here is the PIPELINE-force signal, NOT the registry-collision
+   * bypass. See `registryForce` below.
+   */
   force?: boolean;
   embeddings?: boolean;
   skipGit?: boolean;
@@ -59,6 +65,16 @@ export interface AnalyzeOptions {
    * this alias instead of the path-derived basename.
    */
   registryName?: string;
+  /**
+   * Bypass the `RegistryNameCollisionError` guard and allow two paths
+   * to register under the same `name` (#829). Semantically distinct
+   * from `force` above — the pipeline may be force-re-indexed for
+   * many reasons (`--skills`, future flags), but registry-collision
+   * bypass requires the user to have explicitly passed `--force`.
+   * Conflating the two (as an earlier draft of this feature did)
+   * meant `--skills` silently bypassed the collision guard.
+   */
+  registryForce?: boolean;
 }
 
 export interface AnalyzeResult {
@@ -319,14 +335,17 @@ export async function runFullAnalysis(
       },
     };
     await saveMeta(storagePath, meta);
-    // Forward both `name` (the --name alias) and `force` (bypass the
-    // name-collision guard when the user explicitly opts in). The error
-    // message in analyze.ts instructs the user to re-run with --force,
-    // so the flag MUST reach registerRepo or the documented workaround
-    // would hit the same error again (#829 review feedback).
+    // Forward the --name alias AND the registry-specific force bit.
+    // Note: `options.registryForce` is distinct from `options.force`
+    // (the pipeline re-index signal). The CLI only sets registryForce
+    // when the user explicitly passes --force; --skills (which sets
+    // force for pipeline re-analysis) does NOT set registryForce, so
+    // --name + --skills without --force correctly hits the collision
+    // guard. See #829 review round 2 for the --skills bypass regression
+    // this split prevents.
     await registerRepo(repoPath, meta, {
       name: options.registryName,
-      force: options.force,
+      force: options.registryForce,
     });
 
     // Only attempt to update .gitignore when a .git directory is present.

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -53,6 +53,12 @@ export interface AnalyzeOptions {
   skipAgentsMd?: boolean;
   /** Omit volatile symbol/relationship counts from AGENTS.md and CLAUDE.md. */
   noStats?: boolean;
+  /**
+   * User-provided alias for the registry `name` (#829). When set,
+   * forwarded to `registerRepo` so the indexed repo is stored under
+   * this alias instead of the path-derived basename.
+   */
+  registryName?: string;
 }
 
 export interface AnalyzeResult {
@@ -313,7 +319,7 @@ export async function runFullAnalysis(
       },
     };
     await saveMeta(storagePath, meta);
-    await registerRepo(repoPath, meta);
+    await registerRepo(repoPath, meta, { name: options.registryName });
 
     // Only attempt to update .gitignore when a .git directory is present.
     if (hasGitDir(repoPath)) {

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -319,7 +319,15 @@ export async function runFullAnalysis(
       },
     };
     await saveMeta(storagePath, meta);
-    await registerRepo(repoPath, meta, { name: options.registryName });
+    // Forward both `name` (the --name alias) and `force` (bypass the
+    // name-collision guard when the user explicitly opts in). The error
+    // message in analyze.ts instructs the user to re-run with --force,
+    // so the flag MUST reach registerRepo or the documented workaround
+    // would hit the same error again (#829 review feedback).
+    await registerRepo(repoPath, meta, {
+      name: options.registryName,
+      force: options.force,
+    });
 
     // Only attempt to update .gitignore when a .git directory is present.
     if (hasGitDir(repoPath)) {

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -50,7 +50,7 @@ export interface AnalyzeOptions {
    * Force a full re-index of the pipeline. Callers may OR this with
    * other flags that imply re-analysis (e.g. `--skills`), so the value
    * here is the PIPELINE-force signal, NOT the registry-collision
-   * bypass. See `registryForce` below.
+   * bypass. See `allowDuplicateName` below.
    */
   force?: boolean;
   embeddings?: boolean;
@@ -67,14 +67,13 @@ export interface AnalyzeOptions {
   registryName?: string;
   /**
    * Bypass the `RegistryNameCollisionError` guard and allow two paths
-   * to register under the same `name` (#829). Semantically distinct
-   * from `force` above — the pipeline may be force-re-indexed for
-   * many reasons (`--skills`, future flags), but registry-collision
-   * bypass requires the user to have explicitly passed `--force`.
-   * Conflating the two (as an earlier draft of this feature did)
-   * meant `--skills` silently bypassed the collision guard.
+   * to register under the same `name` (#829). Controlled by the
+   * dedicated `--allow-duplicate-name` CLI flag, intentionally
+   * independent from `--force` — users who hit the collision guard
+   * should be able to accept the duplicate without paying the cost
+   * of a pipeline re-index.
    */
-  registryForce?: boolean;
+  allowDuplicateName?: boolean;
 }
 
 export interface AnalyzeResult {
@@ -335,17 +334,14 @@ export async function runFullAnalysis(
       },
     };
     await saveMeta(storagePath, meta);
-    // Forward the --name alias AND the registry-specific force bit.
-    // Note: `options.registryForce` is distinct from `options.force`
-    // (the pipeline re-index signal). The CLI only sets registryForce
-    // when the user explicitly passes --force; --skills (which sets
-    // force for pipeline re-analysis) does NOT set registryForce, so
-    // --name + --skills without --force correctly hits the collision
-    // guard. See #829 review round 2 for the --skills bypass regression
-    // this split prevents.
+    // Forward the --name alias and the registry-collision bypass bit.
+    // `allowDuplicateName` is its own concern — independent from the
+    // pipeline `force` above. The CLI maps it from
+    // `--allow-duplicate-name` only; `--force` and `--skills` both
+    // trigger pipeline re-run but never bypass the registry guard.
     await registerRepo(repoPath, meta, {
       name: options.registryName,
-      force: options.registryForce,
+      allowDuplicateName: options.allowDuplicateName,
     });
 
     // Only attempt to update .gitignore when a .git directory is present.

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -319,13 +319,25 @@ export class LocalBackend {
     if (this.repos.size === 0) {
       throw new Error('No indexed repositories. Run: gitnexus analyze');
     }
-    if (repoParam) {
-      const names = [...this.repos.values()].map((h) => h.name);
-      throw new Error(`Repository "${repoParam}" not found. Available: ${names.join(', ')}`);
+
+    // Build a disambiguated "Available: …" list (#829). When two handles
+    // share a name, annotate each colliding label with its path so the
+    // caller can actually pick the right one. Single-name entries render
+    // identically to pre-#829 output.
+    const nameCounts = new Map<string, number>();
+    for (const h of this.repos.values()) {
+      const key = h.name.toLowerCase();
+      nameCounts.set(key, (nameCounts.get(key) ?? 0) + 1);
     }
-    const names = [...this.repos.values()].map((h) => h.name);
+    const labels = [...this.repos.values()].map((h) =>
+      (nameCounts.get(h.name.toLowerCase()) ?? 0) > 1 ? `${h.name} (${h.repoPath})` : h.name,
+    );
+
+    if (repoParam) {
+      throw new Error(`Repository "${repoParam}" not found. Available: ${labels.join(', ')}`);
+    }
     throw new Error(
-      `Multiple repositories indexed. Specify which one with the "repo" parameter. Available: ${names.join(', ')}`,
+      `Multiple repositories indexed. Specify which one with the "repo" parameter. Available: ${labels.join(', ')}`,
     );
   }
 

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -257,11 +257,13 @@ export interface RegisterRepoOptions {
    */
   name?: string;
   /**
-   * Allow registration even when another path already uses this name.
-   * Required for intentional same-name coexistence (two different
-   * same-basename `app` repos, for instance) without passing `--name`.
+   * Allow registration even when another path already uses this name
+   * (#829). Mapped from the `--allow-duplicate-name` CLI flag —
+   * intentionally a distinct flag from `--force` (which only triggers
+   * pipeline re-index) because a user accepting a duplicate name should
+   * not be forced to also re-run the full pipeline.
    */
-  force?: boolean;
+  allowDuplicateName?: boolean;
 }
 
 /**
@@ -285,7 +287,7 @@ export class RegistryNameCollisionError extends Error {
     super(
       `Registry name "${registryName}" is already used by "${existingPath}".\n` +
         `Pass --name <alias> to register "${requestedPath}" under a different name, ` +
-        `or --force to allow both paths under the same name (leaves -r <name> ambiguous for these two).`,
+        `or --allow-duplicate-name to allow both paths under the same name (leaves -r <name> ambiguous for these two).`,
     );
     this.name = 'RegistryNameCollisionError';
   }
@@ -309,8 +311,8 @@ const hasCustomAlias = (entry: RegistryEntry): boolean => {
  *   3. `path.basename(repoPath)` (the original default)
  *
  * Duplicate-name guard: if another path already uses the resolved
- * `name`, throw {@link RegistryNameCollisionError} unless `opts.force`
- * is set. The guard ONLY fires when the user explicitly passed a
+ * `name`, throw {@link RegistryNameCollisionError} unless
+ * `opts.allowDuplicateName` is set. The guard ONLY fires when the user explicitly passed a
  * `name`; un-aliased basename collisions continue to register silently
  * so existing users who don't know about `--name` see no behaviour
  * change.
@@ -342,7 +344,7 @@ export const registerRepo = async (
   // (which is already improved by the disambiguated error messages and
   // list output this PR also ships).
   const explicitName = opts?.name !== undefined || (existing && hasCustomAlias(existing));
-  if (explicitName && !opts?.force) {
+  if (explicitName && !opts?.allowDuplicateName) {
     const collision = entries.find(
       (e, i) =>
         i !== existingIdx &&

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -257,11 +257,21 @@ export interface RegisterRepoOptions {
    */
   name?: string;
   /**
-   * Allow registration even when another path already uses this name
-   * (#829). Mapped from the `--allow-duplicate-name` CLI flag —
-   * intentionally a distinct flag from `--force` (which only triggers
-   * pipeline re-index) because a user accepting a duplicate name should
-   * not be forced to also re-run the full pipeline.
+   * Allow two DIFFERENT repo paths to register under the same alias
+   * (#829). Mapped from the `--allow-duplicate-name` CLI flag.
+   *
+   * Scope: this flag governs cross-path alias sharing only — one repo
+   * path always has exactly one registry entry (and therefore exactly
+   * one alias). Re-analyzing the same path with `--name Y` overwrites
+   * a previous `--name X`; it does NOT create a second entry or a
+   * second alias for the same path (see the upsert-by-resolved-path
+   * logic in {@link registerRepo} and the
+   * `re-registerRepo with a different name overrides the previous
+   * alias` test in `test/unit/repo-manager.test.ts`).
+   *
+   * Distinct from `--force` (which only triggers pipeline re-index);
+   * a user accepting a duplicate alias should not be forced to also
+   * re-run the full pipeline.
    */
   allowDuplicateName?: boolean;
 }
@@ -345,14 +355,14 @@ export const registerRepo = async (
   // list output this PR also ships).
   const explicitName = opts?.name !== undefined || (existing && hasCustomAlias(existing));
   if (explicitName && !opts?.allowDuplicateName) {
-    const collision = entries.find(
+    const collidingEntry = entries.find(
       (e, i) =>
         i !== existingIdx &&
         e.name.toLowerCase() === name.toLowerCase() &&
         path.resolve(e.path) !== resolved,
     );
-    if (collision) {
-      throw new RegistryNameCollisionError(name, collision.path, resolved);
+    if (collidingEntry) {
+      throw new RegistryNameCollisionError(name, collidingEntry.path, resolved);
     }
   }
 

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -268,20 +268,26 @@ export interface RegisterRepoOptions {
  * Thrown by {@link registerRepo} when a requested name is already in
  * use by a DIFFERENT path. The CLI layer surfaces this as an actionable
  * error instead of relying on `.message` string-matching.
+ *
+ * The colliding alias is exposed as `err.registryName` (not `err.name`).
+ * `err.name` keeps its inherited `Error.prototype.name` semantics (the
+ * class name) so downstream code can do the usual `err.name ===
+ * 'RegistryNameCollisionError'` checks; use the `kind` discriminant or
+ * `instanceof RegistryNameCollisionError` for type-safe narrowing.
  */
 export class RegistryNameCollisionError extends Error {
   readonly kind = 'RegistryNameCollisionError' as const;
   constructor(
-    public readonly name: string,
+    public readonly registryName: string,
     public readonly existingPath: string,
     public readonly requestedPath: string,
   ) {
     super(
-      `Registry name "${name}" is already used by "${existingPath}".\n` +
+      `Registry name "${registryName}" is already used by "${existingPath}".\n` +
         `Pass --name <alias> to register "${requestedPath}" under a different name, ` +
         `or --force to allow both paths under the same name (leaves -r <name> ambiguous for these two).`,
     );
-    this.name = name;
+    this.name = 'RegistryNameCollisionError';
   }
 }
 

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -245,20 +245,108 @@ const writeRegistry = async (entries: RegistryEntry[]): Promise<void> => {
 };
 
 /**
+ * Options for {@link registerRepo}. All optional — callers without any
+ * disambiguation requirement can keep calling `registerRepo(path, meta)`
+ * unchanged.
+ */
+export interface RegisterRepoOptions {
+  /**
+   * User-provided alias from `analyze --name <alias>` (#829). Overrides
+   * the default basename-derived registry `name`. Persisted — subsequent
+   * re-analyses of the same path without `--name` preserve the alias.
+   */
+  name?: string;
+  /**
+   * Allow registration even when another path already uses this name.
+   * Required for intentional same-name coexistence (two different
+   * same-basename `app` repos, for instance) without passing `--name`.
+   */
+  force?: boolean;
+}
+
+/**
+ * Thrown by {@link registerRepo} when a requested name is already in
+ * use by a DIFFERENT path. The CLI layer surfaces this as an actionable
+ * error instead of relying on `.message` string-matching.
+ */
+export class RegistryNameCollisionError extends Error {
+  readonly kind = 'RegistryNameCollisionError' as const;
+  constructor(
+    public readonly name: string,
+    public readonly existingPath: string,
+    public readonly requestedPath: string,
+  ) {
+    super(
+      `Registry name "${name}" is already used by "${existingPath}".\n` +
+        `Pass --name <alias> to register "${requestedPath}" under a different name, ` +
+        `or --force to allow both paths under the same name (leaves -r <name> ambiguous for these two).`,
+    );
+    this.name = name;
+  }
+}
+
+/** Returns true when a previously-registered entry's `name` differs from
+ *  `path.basename(entry.path)` — i.e. a user explicitly aliased it via
+ *  `analyze --name <alias>` on a prior run. Used to preserve the alias
+ *  across re-analyses that omit `--name`. */
+const hasCustomAlias = (entry: RegistryEntry): boolean => {
+  return entry.name !== path.basename(path.resolve(entry.path));
+};
+
+/**
  * Register (add or update) a repo in the global registry.
  * Called after `gitnexus analyze` completes.
+ *
+ * Name resolution precedence (#829):
+ *   1. explicit `opts.name` (from `analyze --name <alias>`)
+ *   2. preserved alias on an existing entry for this path
+ *   3. `path.basename(repoPath)` (the original default)
+ *
+ * Duplicate-name guard: if another path already uses the resolved
+ * `name`, throw {@link RegistryNameCollisionError} unless `opts.force`
+ * is set. The guard ONLY fires when the user explicitly passed a
+ * `name`; un-aliased basename collisions continue to register silently
+ * so existing users who don't know about `--name` see no behaviour
+ * change.
  */
-export const registerRepo = async (repoPath: string, meta: RepoMeta): Promise<void> => {
+export const registerRepo = async (
+  repoPath: string,
+  meta: RepoMeta,
+  opts?: RegisterRepoOptions,
+): Promise<void> => {
   const resolved = path.resolve(repoPath);
-  const name = path.basename(resolved);
   const { storagePath } = getStoragePaths(resolved);
 
   const entries = await readRegistry();
-  const existing = entries.findIndex((e) => {
+  const existingIdx = entries.findIndex((e) => {
     const a = path.resolve(e.path);
     const b = resolved;
     return process.platform === 'win32' ? a.toLowerCase() === b.toLowerCase() : a === b;
   });
+  const existing = existingIdx >= 0 ? entries[existingIdx] : null;
+
+  // Precedence: explicit --name > preserved alias > basename.
+  const name =
+    opts?.name ?? (existing && hasCustomAlias(existing) ? existing.name : path.basename(resolved));
+
+  // Duplicate-name guard: only fire when the user EXPLICITLY asked for
+  // this name (via opts.name or a preserved alias). Unqualified basename
+  // collisions are preserved for backward-compat — they still register,
+  // and the user sees the ambiguity at `-r` / `list` resolution time
+  // (which is already improved by the disambiguated error messages and
+  // list output this PR also ships).
+  const explicitName = opts?.name !== undefined || (existing && hasCustomAlias(existing));
+  if (explicitName && !opts?.force) {
+    const collision = entries.find(
+      (e, i) =>
+        i !== existingIdx &&
+        e.name.toLowerCase() === name.toLowerCase() &&
+        path.resolve(e.path) !== resolved,
+    );
+    if (collision) {
+      throw new RegistryNameCollisionError(name, collision.path, resolved);
+    }
+  }
 
   const entry: RegistryEntry = {
     name,
@@ -269,8 +357,8 @@ export const registerRepo = async (repoPath: string, meta: RepoMeta): Promise<vo
     stats: meta.stats,
   };
 
-  if (existing >= 0) {
-    entries[existing] = entry;
+  if (existingIdx >= 0) {
+    entries[existingIdx] = entry;
   } else {
     entries.push(entry);
   }

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -193,33 +193,37 @@ describe('CLI end-to-end', () => {
     expect(fs.statSync(gitnexusDir).isDirectory()).toBe(true);
   });
 
-  // ─── analyze --name <alias> + --force (#829) ───────────────────────
+  // ─── analyze --name <alias> + --allow-duplicate-name (#829) ──────
   //
   // End-to-end regression guard for the name-collision feature:
   //   1. `analyze --name X` persists the alias to ~/.gitnexus/registry.json
   //   2. A second `analyze --name X` on a DIFFERENT path is rejected with
   //      a collision error (exit code 1, "already used" in output)
-  //   3. A second `analyze --name X --force` bypasses the guard and both
-  //      entries coexist in registry.json
+  //   3. `analyze --name X --allow-duplicate-name` bypasses the guard;
+  //      both entries coexist in registry.json
+  //   4. Pipeline-re-index flags (e.g. --skills) WITHOUT
+  //      --allow-duplicate-name must STILL hit the collision guard —
+  //      the bypass must stay gated on its dedicated flag so it isn't
+  //      silently triggered by unrelated pipeline signals
+  //      (review round 2/3 design decision).
   //
-  // The third assertion is the regression guard for the blocking bug
-  // caught in the first round of review: `--force` was documented in the
-  // error hint but not forwarded to registerRepo, so following the
-  // documented workaround produced the same error. This test invokes
-  // the real CLI → runFullAnalysis → registerRepo chain, so the
-  // passthrough bug cannot slip back in silently.
-  describe('analyze --name <alias> and --force (#829)', () => {
-    // Canonicalize paths for cross-platform equality checks. On macOS
-    // os.tmpdir() returns /var/folders/... but spawnSync child processes
-    // see the symlink-resolved /private/var/folders/... form, so the
-    // registry stores the realpath. On Windows, os.tmpdir() can return
-    // the 8.3 short-name form (C:\Users\RUNNER~1\...) while the spawned
-    // CLI process sees the long form (C:\Users\runneradmin\...).
-    // fs.realpathSync() canonicalizes both so assertions don't break on
-    // platform-specific path quirks.
-    const canonical = (p: string): string => fs.realpathSync(p);
+  // This test invokes the real CLI → runFullAnalysis → registerRepo
+  // chain, so any wiring regression fails here.
+  describe('analyze --name <alias> and --allow-duplicate-name (#829)', () => {
+    // Path-equality assertions across CLI spawn boundaries are fragile
+    // cross-platform:
+    //   - macOS: os.tmpdir() returns /var/folders/...; child processes
+    //     resolve the symlink to /private/var/folders/...
+    //   - Windows: os.tmpdir() on GitHub runners returns 8.3 short-name
+    //     form (C:\Users\RUNNER~1\...); the child sees the long form
+    //     (C:\Users\runneradmin\...). fs.realpathSync does NOT reliably
+    //     expand 8.3 to long form.
+    // Rather than fight the platform-path quagmire, we assert STRUCTURAL
+    // properties: entry count, alias value, path basename, path
+    // distinctness. That covers the behavior this test is here to
+    // protect without depending on exact-string path equality.
 
-    it('--name alias stores; collision rejects; --force bypasses', () => {
+    it('--name alias stores; collision rejects; --allow-duplicate-name bypasses', () => {
       // Isolate the global registry so this test never touches the
       // developer's real ~/.gitnexus.
       const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-'));
@@ -251,7 +255,7 @@ describe('CLI end-to-end', () => {
         expect(Array.isArray(afterStep1)).toBe(true);
         expect(afterStep1).toHaveLength(1);
         expect(afterStep1[0].name).toBe('shared');
-        expect(canonical(afterStep1[0].path)).toBe(canonical(repoA));
+        expect(path.basename(afterStep1[0].path)).toBe('collide-app');
 
         // Step 2: analyze repoB with the SAME --name → collision error.
         const r2 = runCliWithEnv(
@@ -269,13 +273,16 @@ describe('CLI end-to-end', () => {
         // silently added, overwritten, or corrupted anything.
         const afterStep2 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
         expect(afterStep2).toHaveLength(1);
-        expect(canonical(afterStep2[0].path)).toBe(canonical(repoA));
+        // Registry still has only the step-1 entry — the failed call
+        // must not have silently added, overwritten, or corrupted state.
+        expect(afterStep2[0].path).toBe(afterStep1[0].path);
 
-        // Step 3: REGRESSION GUARD for the missing --force passthrough bug.
-        // Same args as step 2 but with --force → must succeed, and the
-        // registry must now contain BOTH entries under name "shared".
+        // Step 3: REGRESSION GUARD for the missing collision-bypass wire
+        // (originally a --force passthrough bug; per review round 3 the
+        // bypass moved to its own --allow-duplicate-name flag to avoid
+        // conflating it with pipeline re-index).
         const r3 = runCliWithEnv(
-          ['analyze', '--name', 'shared', '--force'],
+          ['analyze', '--name', 'shared', '--allow-duplicate-name'],
           repoB,
           { GITNEXUS_HOME: gnHome },
           60000,
@@ -284,7 +291,7 @@ describe('CLI end-to-end', () => {
         expect(
           r3.status,
           [
-            `step 3 (--force bypass) exited with ${r3.status}`,
+            `step 3 (--allow-duplicate-name bypass) exited with ${r3.status}`,
             `stdout: ${r3.stdout}`,
             `stderr: ${r3.stderr}`,
           ].join('\n'),
@@ -293,15 +300,21 @@ describe('CLI end-to-end', () => {
         const afterStep3 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
         expect(afterStep3).toHaveLength(2);
         expect(afterStep3.every((e: { name: string }) => e.name === 'shared')).toBe(true);
-        const paths = afterStep3.map((e: { path: string }) => canonical(e.path)).sort();
-        expect(paths).toEqual([canonical(repoA), canonical(repoB)].sort());
+        // Both entries point to distinct paths (we registered two different
+        // repos under the same alias) and both have the right basename.
+        const step3Basenames = afterStep3.map((e: { path: string }) => path.basename(e.path));
+        expect(step3Basenames).toEqual(['collide-app', 'collide-app']);
+        const step3Paths = new Set(afterStep3.map((e: { path: string }) => e.path));
+        expect(step3Paths.size).toBe(2);
+        // One of the two entries is the original from step 1 — unchanged.
+        expect(afterStep3.map((e: { path: string }) => e.path)).toContain(afterStep1[0].path);
 
-        // Step 4: REGRESSION GUARD for the #955 review-round-2 finding.
-        // Create a THIRD repo with the same basename and try to register
-        // it via `--name shared --skills` — NO --force. This must still
-        // hit the collision guard even though --skills OR's with force at
-        // the pipeline level. If future refactors accidentally re-conflate
-        // pipeline-force and registry-force, this test fails.
+        // Step 4: REGRESSION GUARD for the design decision in review
+        // round 2/3 — pipeline-re-index flags must NOT bypass the
+        // registry collision guard. `--skills` triggers pipeline
+        // re-run (skills generation needs a fresh pipelineResult) but
+        // must leave the registry guard in force. Bypass requires the
+        // explicit --allow-duplicate-name flag.
         const repoC = makeMiniRepoCopy('collide-app', 'gn-collide-c-');
         const parentC = path.dirname(repoC);
         try {
@@ -315,6 +328,8 @@ describe('CLI end-to-end', () => {
           expect(r4.status).toBe(1);
           const r4Output = `${r4.stdout}${r4.stderr}`;
           expect(r4Output).toMatch(/Registry name collision|already used/i);
+          // The error hint should point at the new flag.
+          expect(r4Output).toMatch(/--allow-duplicate-name/);
 
           // Registry unchanged — still only A + B under "shared".
           const afterStep4 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -209,6 +209,16 @@ describe('CLI end-to-end', () => {
   // the real CLI → runFullAnalysis → registerRepo chain, so the
   // passthrough bug cannot slip back in silently.
   describe('analyze --name <alias> and --force (#829)', () => {
+    // Canonicalize paths for cross-platform equality checks. On macOS
+    // os.tmpdir() returns /var/folders/... but spawnSync child processes
+    // see the symlink-resolved /private/var/folders/... form, so the
+    // registry stores the realpath. On Windows, os.tmpdir() can return
+    // the 8.3 short-name form (C:\Users\RUNNER~1\...) while the spawned
+    // CLI process sees the long form (C:\Users\runneradmin\...).
+    // fs.realpathSync() canonicalizes both so assertions don't break on
+    // platform-specific path quirks.
+    const canonical = (p: string): string => fs.realpathSync(p);
+
     it('--name alias stores; collision rejects; --force bypasses', () => {
       // Isolate the global registry so this test never touches the
       // developer's real ~/.gitnexus.
@@ -241,7 +251,7 @@ describe('CLI end-to-end', () => {
         expect(Array.isArray(afterStep1)).toBe(true);
         expect(afterStep1).toHaveLength(1);
         expect(afterStep1[0].name).toBe('shared');
-        expect(path.resolve(afterStep1[0].path)).toBe(path.resolve(repoA));
+        expect(canonical(afterStep1[0].path)).toBe(canonical(repoA));
 
         // Step 2: analyze repoB with the SAME --name → collision error.
         const r2 = runCliWithEnv(
@@ -259,7 +269,7 @@ describe('CLI end-to-end', () => {
         // silently added, overwritten, or corrupted anything.
         const afterStep2 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
         expect(afterStep2).toHaveLength(1);
-        expect(path.resolve(afterStep2[0].path)).toBe(path.resolve(repoA));
+        expect(canonical(afterStep2[0].path)).toBe(canonical(repoA));
 
         // Step 3: REGRESSION GUARD for the missing --force passthrough bug.
         // Same args as step 2 but with --force → must succeed, and the
@@ -283,8 +293,8 @@ describe('CLI end-to-end', () => {
         const afterStep3 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
         expect(afterStep3).toHaveLength(2);
         expect(afterStep3.every((e: { name: string }) => e.name === 'shared')).toBe(true);
-        const paths = afterStep3.map((e: { path: string }) => path.resolve(e.path)).sort();
-        expect(paths).toEqual([path.resolve(repoA), path.resolve(repoB)].sort());
+        const paths = afterStep3.map((e: { path: string }) => canonical(e.path)).sort();
+        expect(paths).toEqual([canonical(repoA), canonical(repoB)].sort());
 
         // Step 4: REGRESSION GUARD for the #955 review-round-2 finding.
         // Create a THIRD repo with the same basename and try to register

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -110,6 +110,55 @@ function runCliRaw(extraArgs: string[], cwd: string, timeoutMs = 15000) {
   });
 }
 
+/**
+ * Like runCliRaw but accepts extra env vars. Used by tests that need to
+ * isolate the global registry via GITNEXUS_HOME so they don't touch the
+ * developer / CI agent's real ~/.gitnexus/registry.json (#829).
+ */
+function runCliWithEnv(
+  extraArgs: string[],
+  cwd: string,
+  extraEnv: Record<string, string>,
+  timeoutMs = 15000,
+) {
+  return spawnSync(process.execPath, ['--import', tsxImportUrl, cliEntry, ...extraArgs], {
+    cwd,
+    encoding: 'utf8',
+    timeout: timeoutMs,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS || ''} --max-old-space-size=8192`.trim(),
+      ...extraEnv,
+    },
+  });
+}
+
+/**
+ * Create a fresh git-initialised throwaway repo at `<parentTmp>/<basename>`
+ * and return its path. Used for tests that need multiple repos whose
+ * basenames intentionally collide (#829 reproduction).
+ */
+function makeMiniRepoCopy(basename: string, prefix: string): string {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const repo = path.join(parent, basename);
+  fs.cpSync(FIXTURE_SRC, repo, { recursive: true });
+  spawnSync('git', ['init'], { cwd: repo, stdio: 'pipe' });
+  spawnSync('git', ['add', '-A'], { cwd: repo, stdio: 'pipe' });
+  spawnSync('git', ['commit', '-m', 'initial commit'], {
+    cwd: repo,
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 'test@test',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 'test@test',
+    },
+  });
+  return repo;
+}
+
 describe('CLI end-to-end', () => {
   it('status command exits cleanly', () => {
     const result = runCli('status', MINI_REPO);
@@ -142,6 +191,133 @@ describe('CLI end-to-end', () => {
     const gitnexusDir = path.join(MINI_REPO, '.gitnexus');
     expect(fs.existsSync(gitnexusDir)).toBe(true);
     expect(fs.statSync(gitnexusDir).isDirectory()).toBe(true);
+  });
+
+  // ─── analyze --name <alias> + --force (#829) ───────────────────────
+  //
+  // End-to-end regression guard for the name-collision feature:
+  //   1. `analyze --name X` persists the alias to ~/.gitnexus/registry.json
+  //   2. A second `analyze --name X` on a DIFFERENT path is rejected with
+  //      a collision error (exit code 1, "already used" in output)
+  //   3. A second `analyze --name X --force` bypasses the guard and both
+  //      entries coexist in registry.json
+  //
+  // The third assertion is the regression guard for the blocking bug
+  // caught in the first round of review: `--force` was documented in the
+  // error hint but not forwarded to registerRepo, so following the
+  // documented workaround produced the same error. This test invokes
+  // the real CLI → runFullAnalysis → registerRepo chain, so the
+  // passthrough bug cannot slip back in silently.
+  describe('analyze --name <alias> and --force (#829)', () => {
+    it('--name alias stores; collision rejects; --force bypasses', () => {
+      // Isolate the global registry so this test never touches the
+      // developer's real ~/.gitnexus.
+      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-'));
+
+      // Two mini-repo copies whose basenames intentionally collide.
+      const repoA = makeMiniRepoCopy('collide-app', 'gn-collide-a-');
+      const repoB = makeMiniRepoCopy('collide-app', 'gn-collide-b-');
+      const parentA = path.dirname(repoA);
+      const parentB = path.dirname(repoB);
+
+      try {
+        // Step 1: analyze repoA with --name shared → registry entry created.
+        const r1 = runCliWithEnv(
+          ['analyze', '--name', 'shared'],
+          repoA,
+          { GITNEXUS_HOME: gnHome },
+          60000,
+        );
+        if (r1.status === null) return; // CI timeout tolerance
+        expect(
+          r1.status,
+          [`step 1 exited with ${r1.status}`, `stdout: ${r1.stdout}`, `stderr: ${r1.stderr}`].join(
+            '\n',
+          ),
+        ).toBe(0);
+
+        const registryPath = path.join(gnHome, 'registry.json');
+        const afterStep1 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+        expect(Array.isArray(afterStep1)).toBe(true);
+        expect(afterStep1).toHaveLength(1);
+        expect(afterStep1[0].name).toBe('shared');
+        expect(path.resolve(afterStep1[0].path)).toBe(path.resolve(repoA));
+
+        // Step 2: analyze repoB with the SAME --name → collision error.
+        const r2 = runCliWithEnv(
+          ['analyze', '--name', 'shared'],
+          repoB,
+          { GITNEXUS_HOME: gnHome },
+          60000,
+        );
+        if (r2.status === null) return;
+        expect(r2.status).toBe(1);
+        const r2Output = `${r2.stdout}${r2.stderr}`;
+        expect(r2Output).toMatch(/Registry name collision|already used/i);
+
+        // Registry still has just the first entry — step 2 must not have
+        // silently added, overwritten, or corrupted anything.
+        const afterStep2 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+        expect(afterStep2).toHaveLength(1);
+        expect(path.resolve(afterStep2[0].path)).toBe(path.resolve(repoA));
+
+        // Step 3: REGRESSION GUARD for the missing --force passthrough bug.
+        // Same args as step 2 but with --force → must succeed, and the
+        // registry must now contain BOTH entries under name "shared".
+        const r3 = runCliWithEnv(
+          ['analyze', '--name', 'shared', '--force'],
+          repoB,
+          { GITNEXUS_HOME: gnHome },
+          60000,
+        );
+        if (r3.status === null) return;
+        expect(
+          r3.status,
+          [
+            `step 3 (--force bypass) exited with ${r3.status}`,
+            `stdout: ${r3.stdout}`,
+            `stderr: ${r3.stderr}`,
+          ].join('\n'),
+        ).toBe(0);
+
+        const afterStep3 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+        expect(afterStep3).toHaveLength(2);
+        expect(afterStep3.every((e: { name: string }) => e.name === 'shared')).toBe(true);
+        const paths = afterStep3.map((e: { path: string }) => path.resolve(e.path)).sort();
+        expect(paths).toEqual([path.resolve(repoA), path.resolve(repoB)].sort());
+
+        // Step 4: REGRESSION GUARD for the #955 review-round-2 finding.
+        // Create a THIRD repo with the same basename and try to register
+        // it via `--name shared --skills` — NO --force. This must still
+        // hit the collision guard even though --skills OR's with force at
+        // the pipeline level. If future refactors accidentally re-conflate
+        // pipeline-force and registry-force, this test fails.
+        const repoC = makeMiniRepoCopy('collide-app', 'gn-collide-c-');
+        const parentC = path.dirname(repoC);
+        try {
+          const r4 = runCliWithEnv(
+            ['analyze', '--name', 'shared', '--skills'],
+            repoC,
+            { GITNEXUS_HOME: gnHome },
+            60000,
+          );
+          if (r4.status === null) return;
+          expect(r4.status).toBe(1);
+          const r4Output = `${r4.stdout}${r4.stderr}`;
+          expect(r4Output).toMatch(/Registry name collision|already used/i);
+
+          // Registry unchanged — still only A + B under "shared".
+          const afterStep4 = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+          expect(afterStep4).toHaveLength(2);
+        } finally {
+          fs.rmSync(parentC, { recursive: true, force: true });
+        }
+      } finally {
+        fs.rmSync(gnHome, { recursive: true, force: true });
+        fs.rmSync(parentA, { recursive: true, force: true });
+        fs.rmSync(parentB, { recursive: true, force: true });
+      }
+    }, 360000); // 6-min outer budget (4 × ~60s analyze calls + fixture setup)
   });
 
   describe('unhappy path', () => {

--- a/gitnexus/test/unit/repo-manager.test.ts
+++ b/gitnexus/test/unit/repo-manager.test.ts
@@ -13,6 +13,10 @@ import {
   getStoragePaths,
   readRegistry,
   loadCLIConfig,
+  registerRepo,
+  listRegisteredRepos,
+  RegistryNameCollisionError,
+  type RepoMeta,
 } from '../../src/storage/repo-manager.js';
 import { createTempDir } from '../helpers/test-db.js';
 
@@ -131,5 +135,135 @@ describe('API key file permissions', () => {
     );
     expect(source).toContain('chmod(configPath, 0o600)');
     expect(source).toContain("process.platform !== 'win32'");
+  });
+});
+
+// ─── analyze --name <alias> + duplicate-name guard (#829) ────────────
+//
+// Each test isolates the global registry by pointing GITNEXUS_HOME at a
+// per-test tmpdir. `getGlobalDir()` honors that env var, so registerRepo
+// writes/reads a sandboxed registry.json without touching the user's
+// real ~/.gitnexus.
+
+describe('registerRepo name override + collision guard (#829)', () => {
+  let tmpHome: Awaited<ReturnType<typeof createTempDir>>;
+  let tmpRepoA: Awaited<ReturnType<typeof createTempDir>>;
+  let tmpRepoB: Awaited<ReturnType<typeof createTempDir>>;
+  let savedGitnexusHome: string | undefined;
+
+  const meta: RepoMeta = {
+    repoPath: '',
+    lastCommit: 'abc1234',
+    indexedAt: '2026-04-18T12:00:00.000Z',
+    stats: { files: 1, nodes: 1 },
+  };
+
+  beforeEach(async () => {
+    tmpHome = await createTempDir('gitnexus-registry-home-');
+    tmpRepoA = await createTempDir('gitnexus-repo-a-');
+    tmpRepoB = await createTempDir('gitnexus-repo-b-');
+    savedGitnexusHome = process.env.GITNEXUS_HOME;
+    process.env.GITNEXUS_HOME = tmpHome.dbPath;
+  });
+
+  afterEach(async () => {
+    if (savedGitnexusHome === undefined) delete process.env.GITNEXUS_HOME;
+    else process.env.GITNEXUS_HOME = savedGitnexusHome;
+    await tmpHome.cleanup();
+    await tmpRepoA.cleanup();
+    await tmpRepoB.cleanup();
+  });
+
+  it('registerRepo({ name: "alias" }) stores the alias instead of basename', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'custom-alias' });
+
+    const entries = await listRegisteredRepos();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('custom-alias');
+    expect(entries[0].name).not.toBe(path.basename(tmpRepoA.dbPath));
+  });
+
+  it('re-registerRepo on same path without name preserves an existing alias', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'custom-alias' });
+    // Second call with no opts should keep the alias, not revert to basename.
+    await registerRepo(tmpRepoA.dbPath, meta);
+
+    const entries = await listRegisteredRepos();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('custom-alias');
+  });
+
+  it('re-registerRepo with a different name overrides the previous alias', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'old-alias' });
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'new-alias' });
+
+    const entries = await listRegisteredRepos();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('new-alias');
+  });
+
+  it('registerRepo throws RegistryNameCollisionError when another path uses the name', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'shared' });
+
+    await expect(registerRepo(tmpRepoB.dbPath, meta, { name: 'shared' })).rejects.toBeInstanceOf(
+      RegistryNameCollisionError,
+    );
+
+    // And the colliding entry in the error carries enough info for the
+    // CLI layer to surface an actionable message without string-matching.
+    try {
+      await registerRepo(tmpRepoB.dbPath, meta, { name: 'shared' });
+    } catch (e) {
+      expect(e).toBeInstanceOf(RegistryNameCollisionError);
+      const err = e as RegistryNameCollisionError;
+      expect(err.name).toBe('shared');
+      expect(path.resolve(err.existingPath)).toBe(path.resolve(tmpRepoA.dbPath));
+      expect(path.resolve(err.requestedPath)).toBe(path.resolve(tmpRepoB.dbPath));
+    }
+
+    // Registry still only has the first entry — the failed call didn't
+    // corrupt state.
+    const entries = await listRegisteredRepos();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('shared');
+  });
+
+  it('registerRepo({ name, force: true }) allows the duplicate to coexist', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'shared' });
+    await registerRepo(tmpRepoB.dbPath, meta, { name: 'shared', force: true });
+
+    const entries = await listRegisteredRepos();
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.name === 'shared')).toBe(true);
+    // Both paths are stored distinctly — the collision is surfaced to the
+    // user via resolveRepo / list output, not hidden at the storage layer.
+    const paths = entries.map((e) => path.resolve(e.path)).sort();
+    expect(paths).toEqual([path.resolve(tmpRepoA.dbPath), path.resolve(tmpRepoB.dbPath)].sort());
+  });
+
+  it('basename collisions without an explicit --name still register silently (backward-compat)', async () => {
+    // Create two sibling dirs whose basenames collide. Neither caller
+    // passes { name }, so the guard must NOT fire — this preserves the
+    // pre-#829 behaviour for users who don't know about --name yet.
+    const parentA = await createTempDir('gitnexus-collide-parent-a-');
+    const parentB = await createTempDir('gitnexus-collide-parent-b-');
+    const sharedBasename = 'app';
+    const pathA = path.join(parentA.dbPath, sharedBasename);
+    const pathB = path.join(parentB.dbPath, sharedBasename);
+    await fs.mkdir(pathA, { recursive: true });
+    await fs.mkdir(pathB, { recursive: true });
+
+    try {
+      await registerRepo(pathA, meta);
+      await registerRepo(pathB, meta); // must NOT throw
+
+      const entries = await listRegisteredRepos();
+      expect(entries).toHaveLength(2);
+      expect(entries[0].name).toBe(sharedBasename);
+      expect(entries[1].name).toBe(sharedBasename);
+    } finally {
+      await parentA.cleanup();
+      await parentB.cleanup();
+    }
   });
 });

--- a/gitnexus/test/unit/repo-manager.test.ts
+++ b/gitnexus/test/unit/repo-manager.test.ts
@@ -216,7 +216,11 @@ describe('registerRepo name override + collision guard (#829)', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(RegistryNameCollisionError);
       const err = e as RegistryNameCollisionError;
-      expect(err.name).toBe('shared');
+      // err.registryName carries the colliding alias (exposed as its own
+      // field so err.name retains the inherited Error.prototype.name
+      // semantics for downstream `err.name === '…Error'` checks).
+      expect(err.registryName).toBe('shared');
+      expect(err.name).toBe('RegistryNameCollisionError');
       expect(path.resolve(err.existingPath)).toBe(path.resolve(tmpRepoA.dbPath));
       expect(path.resolve(err.requestedPath)).toBe(path.resolve(tmpRepoB.dbPath));
     }

--- a/gitnexus/test/unit/repo-manager.test.ts
+++ b/gitnexus/test/unit/repo-manager.test.ts
@@ -232,9 +232,9 @@ describe('registerRepo name override + collision guard (#829)', () => {
     expect(entries[0].name).toBe('shared');
   });
 
-  it('registerRepo({ name, force: true }) allows the duplicate to coexist', async () => {
+  it('registerRepo({ name, allowDuplicateName: true }) allows the duplicate to coexist', async () => {
     await registerRepo(tmpRepoA.dbPath, meta, { name: 'shared' });
-    await registerRepo(tmpRepoB.dbPath, meta, { name: 'shared', force: true });
+    await registerRepo(tmpRepoB.dbPath, meta, { name: 'shared', allowDuplicateName: true });
 
     const entries = await listRegisteredRepos();
     expect(entries).toHaveLength(2);


### PR DESCRIPTION
Closes #829.

## Problem

The global registry at \`~/.gitnexus/registry.json\` keys indexed repos by \`name\` derived from \`path.basename()\`. Two projects whose top-level folders share a basename (e.g. both have an \`app/\` dir) both get \`\"name\": \"app\"\`, which makes:

- \`-r app\` on \`impact\` / \`context\` / \`query\` **ambiguous** — picks whichever the resolver hits first.
- The \`Available: app, backend, website\` error hint **actively misleading** — points at a disambiguator that doesn't disambiguate.
- \`gitnexus list\` output identical for two different repos.

Reproduction from issue #829:

\`\`\`bash
mkdir -p /tmp/gnx-a/app /tmp/gnx-b/app
cd /tmp/gnx-a/app && git init -q && echo \"export const x = 1\" > index.ts && git add . && git commit -qm init
npx gitnexus analyze
cd /tmp/gnx-b/app && git init -q && echo \"export const y = 2\" > index.ts && git add . && git commit -qm init
npx gitnexus analyze

npx gitnexus list         # Both entries show as name: \"app\"
npx gitnexus impact x -r app  # Which \"app\" does this target?
\`\`\`

## What's added

**\`analyze --name <alias>\`** — override the registry \`name\` at index time. Persisted. Survives subsequent re-analyses of the same path without \`--name\` (preserved-alias precedence).

**Duplicate-name guard** — if another path already uses the requested name, \`analyze\` aborts with a \`RegistryNameCollisionError\` that names the conflicting path. The guard **only fires when the user explicitly asks** for a name that's taken (via \`--name\` or a preserved alias). Basename collisions still register silently so users unaware of \`--name\` see no behaviour change.

**\`--force\`** — allows intentional same-name coexistence. The colliding entries get disambiguated in list output + resolver errors (below) rather than at the storage layer.

**Collision-aware error messages** in \`resolveRepo\` (both \"not-found\" and \"multiple-repos-no-param\" branches). Two entries named \`app\` now produce:

\`\`\`
Available: app (/tmp/gnx-a/app), app (/tmp/gnx-b/app), backend
\`\`\`

instead of the pre-#829 misleading \`Available: app, app, backend\`.

**Collision-aware \`gitnexus list\` output** — colliding entries gain a \`name  (path)\` header so they're visually distinct. Unique-name entries render byte-identically to pre-#829.

### Item 3 from the issue — \`-r\` accepts absolute path

Already works in [resolveRepoFromCache](gitnexus/src/mcp/local/local-backend.ts:346) via \`path.resolve(repoParam)\` + exact match. This PR adds no new code for it, but the new tests exercise the case for regression coverage.

## Ranking / precedence

When \`registerRepo\` resolves the final \`name\`:

1. Explicit \`opts.name\` from \`--name <alias>\` (highest priority).
2. Preserved alias from an existing entry at the same path (if its stored \`name\` differs from its \`path.basename\` → it was aliased on a prior run).
3. \`path.basename(repoPath)\` (the original default).

## Behaviour decision flagged for reviewer

The issue's wording *\"Reject duplicate names on registration unless \`--force\` or \`--name\` is supplied\"* is ambiguous between:

- **Option A (strict)** — reject ALL basename collisions without \`--force\`/\`--name\`. Would break existing users who don't know about the flag.
- **Option B (opt-in)** — reject only when the user explicitly requests a name that's taken. Current implementation. Test #6 locks this in.

**I went with Option B** because Option A is a behaviour break. If you'd rather strict, it's a one-line conditional flip and one test update. Happy to follow reviewer preference.

## Files changed

| File | Role |
|---|---|
| [gitnexus/src/storage/repo-manager.ts](gitnexus/src/storage/repo-manager.ts) | \`RegisterRepoOptions\`, \`RegistryNameCollisionError\`, precedence + guard logic |
| [gitnexus/src/cli/index.ts](gitnexus/src/cli/index.ts) | \`--name <alias>\` option |
| [gitnexus/src/cli/analyze.ts](gitnexus/src/cli/analyze.ts) | Thread \`name\` to \`runFullAnalysis\`; catch \`RegistryNameCollisionError\` |
| [gitnexus/src/core/run-analyze.ts](gitnexus/src/core/run-analyze.ts) | Forward \`registryName\` to \`registerRepo\` |
| [gitnexus/src/cli/list.ts](gitnexus/src/cli/list.ts) | Collision-aware header format |
| [gitnexus/src/mcp/local/local-backend.ts](gitnexus/src/mcp/local/local-backend.ts) | Collision-aware \`Available: …\` hint |
| [gitnexus/test/unit/repo-manager.test.ts](gitnexus/test/unit/repo-manager.test.ts) | 6 new \`it()\` cases |

## Tests

6 new unit tests in \`repo-manager.test.ts\`, each isolating the registry via \`GITNEXUS_HOME\` pointing at a per-test tmpdir:

1. \`{ name: 'alias' }\` stores the alias instead of basename.
2. Re-register without \`name\` preserves an existing alias.
3. Re-register with a different \`name\` overrides the previous alias.
4. Collision with another path throws \`RegistryNameCollisionError\`, and the registry is not mutated by the failed call.
5. \`{ force: true }\` allows the duplicate to coexist.
6. **Backward-compat** — basename collisions without \`--name\` still register silently (confirms Option B).

## Backward compat

- **Schema**: unchanged. \`registry.json\` written by older versions loads unchanged; aliased entries look identical on disk to basename entries.
- **\`registerRepo\` signature**: third parameter is optional; zero existing call sites need updating.
- **Error / list output**: purely additive — colliding-name case gains a suffix; single-name case is byte-identical to pre-#829.
- **Rollback**: pure code revert, no on-disk state to unwind.

## Scope declined

- **Strict-mode basename-collision rejection** (Option A above) — reviewer's call.
- **\`--as\` as a second spelling of \`--name\`** — issue mentions both, I ship just \`--name\`.
- **Hash-suffix list output instead of full path** — full path is clearer for humans; hash is a trivial follow-up if terminal width becomes a concern.

## Test plan

- [x] \`npx vitest run test/unit/repo-manager.test.ts\` → **15 pass** (9 existing + 6 new)
- [x] \`npx vitest run test/unit/calltool-dispatch.test.ts\` → **65 pass** (no regression on the modified resolver error path)
- [x] \`npm run test:unit\` → **3784 pass**, 2 pre-existing env failures in \`git-utils.test.ts\` (Windows worktree tmpdir) unchanged
- [x] \`npx tsc --noEmit\` → clean
- [x] Pre-commit hook (lint-staged + eslint + prettier + tsc) → passed