### PR TITLE
feat(ingestion): ScopeExtractor driver — 5-pass CaptureMatch → ParsedFile (#919, RFC #909 Ring 2 PKG)

### DIFF
--- a/gitnexus-shared/src/index.ts
+++ b/gitnexus-shared/src/index.ts
@@ -77,6 +77,10 @@ export type { QualifiedNameIndex } from './scope-resolution/qualified-name-index
 export { resolveTypeRef } from './scope-resolution/resolve-type-ref.js';
 export type { ResolveTypeRefContext } from './scope-resolution/resolve-type-ref.js';
 
+// ScopeExtractor output contracts (RFC §3.2 Phase 1; Ring 2 PKG #919)
+export type { ParsedFile } from './scope-resolution/parsed-file.js';
+export type { ReferenceSite, ReferenceKind, CallForm } from './scope-resolution/reference-site.js';
+
 // Method-dispatch materialized view over HeritageMap (RFC §3.1; Ring 2 SHARED #914)
 export { buildMethodDispatchIndex } from './scope-resolution/method-dispatch-index.js';
 export type {

--- a/gitnexus-shared/src/scope-resolution/parsed-file.ts
+++ b/gitnexus-shared/src/scope-resolution/parsed-file.ts
@@ -1,0 +1,65 @@
+/**
+ * `ParsedFile` — the per-file artifact produced by `ScopeExtractor`
+ * (RFC §3.2 Phase 1; Ring 2 PKG #919).
+ *
+ * The boundary between Phase 1 (extraction, per-file, parallelizable) and
+ * Phase 2 (finalize, cross-file). One `ParsedFile` is emitted per source
+ * file; the finalize orchestrator (#921) collects them into a workspace-
+ * wide set and feeds them to the shared `finalize` algorithm (#915).
+ *
+ * ## Shape
+ *
+ *   - `scopes`           — every `Scope` created for this file, in tree-
+ *                          topological order (module first, then children).
+ *                          `Scope.bindings` carry **local-only** bindings at
+ *                          this stage; finalize merges imports/wildcards on top.
+ *   - `parsedImports`    — raw `ParsedImport[]` for this file; finalize
+ *                          resolves each to a concrete `ImportEdge`.
+ *   - `localDefs`        — defs structurally declared in this file. A
+ *                          superset of every `Scope.ownedDefs` union.
+ *                          Listed separately so `finalize` can dedup-index
+ *                          without re-walking scopes.
+ *   - `referenceSites`   — pre-resolution usage facts; populated by the
+ *                          resolution phase into `ReferenceIndex`.
+ *
+ * ## What `ParsedFile` deliberately does NOT carry
+ *
+ *   - Linked `ImportEdge`s. Those are finalize output.
+ *   - A `ScopeTree` instance. Callers build one from `scopes` (cheap —
+ *     `buildScopeTree(parsedFile.scopes)`). Keeping the ParsedFile flat
+ *     makes IPC serialization from worker threads straightforward.
+ *   - Merged module-scope bindings. Finalize owns that materialization.
+ *
+ * ## Compatibility with `FinalizeFile`
+ *
+ * `FinalizeFile` (defined in `./finalize-algorithm.ts`) is a structural
+ * subset of `ParsedFile` — `filePath`, `moduleScope`, `parsedImports`,
+ * `localDefs`. A `ParsedFile` is trivially convertible to a `FinalizeFile`
+ * by picking those four fields, so the finalize orchestrator threads
+ * ParsedFile through to the shared algorithm without shape-shifting.
+ */
+
+import type { Scope, ScopeId } from './types.js';
+import type { ParsedImport } from './types.js';
+import type { SymbolDefinition } from './symbol-definition.js';
+import type { ReferenceSite } from './reference-site.js';
+
+export interface ParsedFile {
+  readonly filePath: string;
+  /** `Scope.id` of the file's root `Module` scope. */
+  readonly moduleScope: ScopeId;
+  /**
+   * All scopes in this file, typically emitted in tree-topological order.
+   * Caller reconstructs a `ScopeTree` via `buildScopeTree(scopes)` when
+   * navigation or invariant re-validation is needed.
+   */
+  readonly scopes: readonly Scope[];
+  readonly parsedImports: readonly ParsedImport[];
+  /**
+   * All defs structurally declared in this file (classes, methods, fields,
+   * variables). Mirrors the union of `Scope.ownedDefs` across `scopes`,
+   * pre-flattened for O(N) consumption by finalize.
+   */
+  readonly localDefs: readonly SymbolDefinition[];
+  readonly referenceSites: readonly ReferenceSite[];
+}

--- a/gitnexus-shared/src/scope-resolution/reference-site.ts
+++ b/gitnexus-shared/src/scope-resolution/reference-site.ts
@@ -1,0 +1,74 @@
+/**
+ * `ReferenceSite` — a pre-resolution usage fact collected by `ScopeExtractor`
+ * (RFC §3.2 Phase 1; Ring 2 PKG #919).
+ *
+ * One record per `@reference.*` capture. The extractor records:
+ *   - the name being referenced (method/field/class name),
+ *   - the source range,
+ *   - the innermost lexical scope containing the reference,
+ *   - the reference kind (call, read, write, inherits, etc.),
+ *   - optional call-form classification from `provider.classifyCallForm`,
+ *   - optional explicit-receiver hint for dotted calls (`user.save()`),
+ *   - optional arity for call sites.
+ *
+ * Reference sites are consumed by the resolution phase (RFC §3.2 Phase 4)
+ * which routes each through `Registry.lookup` / `resolveTypeRef` and
+ * emits the final `Reference` record into `ReferenceIndex`.
+ *
+ * **Pre-resolution only.** `ReferenceSite` intentionally carries no
+ * `toDef`, `confidence`, or `evidence`. Those are populated by the
+ * resolution step that reads this record and produces a `Reference`
+ * (defined in `./types.ts`).
+ */
+
+import type { Range, ScopeId } from './types.js';
+
+/**
+ * What kind of usage this reference represents — the graph-edge kind
+ * emitted after resolution (`CALLS`, `READS`, `WRITES`, etc.).
+ *
+ * Matches the `kind` field on `Reference` in `./types.ts` so the
+ * resolution phase can pass it through without re-classification.
+ */
+export type ReferenceKind =
+  | 'call'
+  | 'read'
+  | 'write'
+  | 'type-reference'
+  | 'inherits'
+  | 'import-use';
+
+/**
+ * How a call site binds its target. Informs `Registry.lookup` Step 2
+ * (type-binding path):
+ *   - `'free'`   — bare call (no receiver); resolution via lexical chain.
+ *   - `'member'` — dotted call (`x.foo()`); resolution via receiver type.
+ *   - `'constructor'` — `new Foo()`; receiver is the class itself.
+ *   - `'index'`  — index expression (`arr[0]`); rare as a dispatch site.
+ *
+ * Only meaningful for `kind === 'call'`; ignored for reads/writes.
+ */
+export type CallForm = 'free' | 'member' | 'constructor' | 'index';
+
+export interface ReferenceSite {
+  /** The name being referenced (e.g., `'save'`, `'User'`, `'count'`). */
+  readonly name: string;
+  /** Source-text range of this reference. */
+  readonly atRange: Range;
+  /**
+   * Innermost lexical scope that contains `atRange`. Resolved by the
+   * extractor via position lookup and frozen here so the resolution
+   * phase doesn't re-compute it per call.
+   */
+  readonly inScope: ScopeId;
+  readonly kind: ReferenceKind;
+  /** Set when `kind === 'call'`. */
+  readonly callForm?: CallForm;
+  /**
+   * Explicit receiver for dotted calls (`user.save()` → `{ name: 'user' }`).
+   * Passed through to `Registry.lookup.explicitReceiver`.
+   */
+  readonly explicitReceiver?: { readonly name: string };
+  /** Argument count at the call site; used by `provider.arityCompatibility`. */
+  readonly arity?: number;
+}

--- a/gitnexus/src/core/ingestion/language-provider.ts
+++ b/gitnexus/src/core/ingestion/language-provider.ts
@@ -12,7 +12,6 @@
 import type {
   SupportedLanguages,
   MroStrategy,
-  Capture,
   CaptureMatch,
   BindingRef,
   TypeRef,
@@ -303,22 +302,31 @@ interface LanguageProviderConfig {
   // ── Parse phase (per-capture interpretation) ───────────────────────
 
   /**
-   * Emit scope captures from raw source. Tree-sitter-based providers run a
-   * `scopes.scm` query; standalone providers (COBOL) emit captures from a
-   * regex tagger. The return shape is parser-agnostic: the central
-   * `ScopeExtractor` consumes `Capture[]` without knowing which parser
-   * produced them.
+   * Emit scope captures from raw source, **pre-grouped per tree-sitter
+   * query match**. Tree-sitter-based providers run a `scopes.scm` query
+   * and emit one `CaptureMatch` per query match; standalone providers
+   * (COBOL) emit matches from a regex tagger. The return shape is
+   * parser-agnostic: the central `ScopeExtractor` consumes
+   * `CaptureMatch[]` without knowing which parser produced them.
+   *
+   * **Pre-grouping is the provider's job.** The extractor expects each
+   * `CaptureMatch` to correspond to one logical match — e.g., an import
+   * statement match carries `@import.statement` + `@import.source` +
+   * `@import.name` keyed under their capture names. Providers MUST
+   * preserve the tree-sitter match boundaries so the extractor's topic
+   * routing (scope / declaration / import / type-binding / reference)
+   * lands on coherent records.
    *
    * Required for any provider participating in scope-based resolution.
-   * Providers that have not yet migrated continue to run through the legacy
-   * DAG path (feature-flagged per `REGISTRY_PRIMARY_<LANG>`).
+   * Providers that have not yet migrated continue to run through the
+   * legacy DAG path (feature-flagged per `REGISTRY_PRIMARY_<LANG>`).
    *
    * Default: undefined (language continues to use legacy DAG).
    */
   readonly emitScopeCaptures?: (
     sourceText: string,
     filePath: string,
-  ) => Promise<readonly Capture[]>;
+  ) => Promise<readonly CaptureMatch[]>;
 
   /**
    * Interpret a raw `@import.statement` capture group into a `ParsedImport`.

--- a/gitnexus/src/core/ingestion/scope-extractor.ts
+++ b/gitnexus/src/core/ingestion/scope-extractor.ts
@@ -78,6 +78,31 @@ import type {
 import { buildPositionIndex, buildScopeTree, makeScopeId } from 'gitnexus-shared';
 import type { LanguageProvider } from './language-provider.js';
 
+// ─── Narrow hook surface the extractor actually uses ───────────────────────
+
+/**
+ * The subset of `LanguageProvider` hooks that `extract()` reads. Declared
+ * as its own type so:
+ *
+ *   - Tests can implement just these six hooks without faking the whole
+ *     `LanguageProvider` interface (which is ~40 fields including the
+ *     legacy-DAG surface).
+ *   - The extractor's dependency contract stays explicit — adding a new
+ *     hook read requires updating this type.
+ *
+ * Real callers pass a full `LanguageProvider` — structural typing makes it
+ * a `ScopeExtractorHooks` for free.
+ */
+export type ScopeExtractorHooks = Pick<
+  LanguageProvider,
+  | 'shouldCreateScope'
+  | 'resolveScopeKind'
+  | 'bindingScopeFor'
+  | 'interpretImport'
+  | 'interpretTypeBinding'
+  | 'classifyCallForm'
+>;
+
 // ─── Public entry point ─────────────────────────────────────────────────────
 
 /**
@@ -92,7 +117,7 @@ import type { LanguageProvider } from './language-provider.js';
 export function extract(
   matches: readonly CaptureMatch[],
   filePath: string,
-  provider: LanguageProvider,
+  provider: ScopeExtractorHooks,
 ): ParsedFile {
   // Partition matches by topic up front — one linear pass over the input.
   const partitioned = partitionByTopic(matches);
@@ -102,6 +127,14 @@ export function extract(
   const scopes = scopeDrafts.map(draftToScope);
   // buildScopeTree validates invariants (throws on violation) and exposes
   // the lookup contract consumed by Passes 2-5.
+  //
+  // **Snapshot semantics.** Both `scopeTree` and `positionIndex` are built
+  // from the post-Pass-1 `scopes` — parent/range/kind are accurate, but
+  // `bindings`, `ownedDefs`, and `typeBindings` are all empty here. Later
+  // passes write into the *drafts*, not into these snapshots; any hook
+  // that reads `scope.bindings` etc. via the `scopeTree` argument sees a
+  // structural view only. This is by design — hooks use scopeTree for
+  // "what's the parent chain?" queries, not for content queries.
   const scopeTree = buildScopeTree(scopes);
   const positionIndex = buildPositionIndex(scopes);
 
@@ -134,13 +167,21 @@ export function extract(
     partitioned.typeBinding,
     scopeDrafts,
     positionIndex,
+    filePath,
     provider,
     scopeTree,
   );
 
   // ── Pass 5: collect reference sites ─────────────────────────────────
   const referenceSites: ReferenceSite[] = [];
-  pass5CollectReferences(partitioned.reference, positionIndex, referenceSites, provider, scopeTree);
+  pass5CollectReferences(
+    partitioned.reference,
+    positionIndex,
+    filePath,
+    referenceSites,
+    provider,
+    scopeTree,
+  );
 
   // Freeze Scope drafts into final shape and return.
   const frozenScopes = scopeDrafts.map(draftToScope);
@@ -274,7 +315,7 @@ function draftToScope(draft: ScopeDraft): Scope {
 function pass1BuildScopes(
   matches: readonly CaptureMatch[],
   filePath: string,
-  provider: LanguageProvider,
+  provider: ScopeExtractorHooks,
 ): ScopeDraft[] {
   interface Candidate {
     readonly match: CaptureMatch;
@@ -328,7 +369,7 @@ function pass1BuildScopes(
 function resolveKindForScopeMatch(
   match: CaptureMatch,
   anchor: { readonly name: string },
-  provider: LanguageProvider,
+  provider: ScopeExtractorHooks,
 ): ScopeKind | null {
   // Provider override takes precedence.
   const override = provider.resolveScopeKind?.(match);
@@ -382,7 +423,7 @@ function pass2AttachDeclarations(
   positionIndex: ReturnType<typeof buildPositionIndex>,
   localDefs: SymbolDefinition[],
   filePath: string,
-  provider: LanguageProvider,
+  provider: ScopeExtractorHooks,
   scopeTree: ReturnType<typeof buildScopeTree>,
 ): void {
   const draftById = new Map<ScopeId, ScopeDraft>();
@@ -405,25 +446,25 @@ function pass2AttachDeclarations(
     const innermost = draftById.get(innermostId);
     if (innermost === undefined) continue;
 
-    // Ownership: `ownedDefs` always attaches to the innermost scope — that's
-    // the structural owner. `ownerId` is set to the owner's nodeId here when
-    // the innermost is a Class/Namespace so method/field defs carry their
-    // owner's graph id; this is a pragmatic defaulting to avoid surprises
-    // downstream (#917 `MethodDispatch` keys off `def.ownerId`).
+    // Ownership: attach the def to the innermost scope's `ownedDefs` — that
+    // is the structural owner. `def.ownerId` is NOT populated here — the
+    // extractor has no clean path to the parent's own DefId mid-extraction
+    // (the parent declaration may not yet have been processed, or may live
+    // in a different scope entirely). Providers that need `ownerId` should
+    // set it directly from the declaration hook (e.g., derive from the
+    // `@declaration.owner` capture or the parent scope id); otherwise
+    // `finalize` populates method/field `ownerId` via `MethodDispatchIndex`
+    // (#914) in a follow-up pass that sees every def already in place.
     innermost.ownedDefs.push(def);
-    if (def.ownerId === undefined && isOwnerKind(innermost.kind)) {
-      // Mutate via a typed clone — SymbolDefinition fields are declared
-      // non-readonly today so this is structurally safe, but we avoid
-      // touching the caller's input by building a new record.
-      const withOwner: SymbolDefinition = { ...def, ownerId: ownerDefIdFor(innermost, drafts) };
-      innermost.ownedDefs[innermost.ownedDefs.length - 1] = withOwner;
-      localDefs.push(withOwner);
-    } else {
-      localDefs.push(def);
-    }
+    localDefs.push(def);
 
     // Binding visibility: default to innermost; allow hoisting via
-    // `provider.bindingScopeFor`.
+    // `provider.bindingScopeFor`. `draftToScope(innermost)` here is a
+    // **structural** snapshot — parent/range/kind only. Hooks MUST NOT
+    // rely on `scope.bindings`, `ownedDefs`, or `typeBindings` being
+    // populated during Pass 2: those fields are written across passes,
+    // so reading them mid-extraction yields a partial view. The
+    // `scopeTree` argument is similarly snapshot-before-mutation.
     const bindingScopeId =
       provider.bindingScopeFor?.(match, draftToScope(innermost), scopeTree) ?? innermost.id;
     const bindingHost = draftById.get(bindingScopeId) ?? innermost;
@@ -431,26 +472,10 @@ function pass2AttachDeclarations(
     const nameKey = deriveDeclarationName(match, def);
     if (nameKey === undefined) continue;
 
-    const emittedDef = localDefs[localDefs.length - 1]!;
     const existing = bindingHost.bindings.get(nameKey) ?? [];
-    existing.push({ def: emittedDef, origin: 'local' });
+    existing.push({ def, origin: 'local' });
     bindingHost.bindings.set(nameKey, existing);
   }
-}
-
-function isOwnerKind(kind: ScopeKind): boolean {
-  return kind === 'Class' || kind === 'Namespace';
-}
-
-function ownerDefIdFor(innermost: ScopeDraft, drafts: readonly ScopeDraft[]): string | undefined {
-  // Heuristic: the Class/Namespace scope's own declaration record, if any,
-  // is the first `ownedDef` pushed onto its parent. We don't have a direct
-  // back-reference in the draft, so return undefined and let the graph
-  // layer's naming convention fill in. Providers that care strongly can
-  // set `def.ownerId` at the interpreter hook.
-  void innermost;
-  void drafts;
-  return undefined;
 }
 
 function buildDefFromDeclarationMatch(
@@ -558,7 +583,7 @@ function makeDefId(
 function pass3CollectImports(
   matches: readonly CaptureMatch[],
   parsedImports: ParsedImport[],
-  provider: LanguageProvider,
+  provider: ScopeExtractorHooks,
 ): void {
   if (provider.interpretImport === undefined) return;
   for (const match of matches) {
@@ -576,7 +601,8 @@ function pass4CollectTypeBindings(
   matches: readonly CaptureMatch[],
   drafts: readonly ScopeDraft[],
   positionIndex: ReturnType<typeof buildPositionIndex>,
-  provider: LanguageProvider,
+  filePath: string,
+  provider: ScopeExtractorHooks,
   scopeTree: ReturnType<typeof buildScopeTree>,
 ): void {
   const draftById = new Map<ScopeId, ScopeDraft>();
@@ -590,7 +616,7 @@ function pass4CollectTypeBindings(
     if (parsed === null || parsed === undefined) continue;
 
     const innermostId = positionIndex.atPosition(
-      drafts[0]!.filePath,
+      filePath,
       anchor.range.startLine,
       anchor.range.startCol,
     );
@@ -617,8 +643,9 @@ function pass4CollectTypeBindings(
 function pass5CollectReferences(
   matches: readonly CaptureMatch[],
   positionIndex: ReturnType<typeof buildPositionIndex>,
+  filePath: string,
   referenceSites: ReferenceSite[],
-  provider: LanguageProvider,
+  provider: ScopeExtractorHooks,
   scopeTree: ReturnType<typeof buildScopeTree>,
 ): void {
   for (const match of matches) {
@@ -630,9 +657,7 @@ function pass5CollectReferences(
 
     const nameCap = match['@reference.name'] ?? anchor;
     const inScopeId = positionIndex.atPosition(
-      // Any scope carries the same filePath; use the anchor's range to find
-      // the innermost scope via the position index.
-      anyFilePathFromScopeTree(scopeTree) ?? '',
+      filePath,
       anchor.range.startLine,
       anchor.range.startCol,
     );
@@ -686,7 +711,7 @@ function referenceKindFromAnchor(name: string): ReferenceKind | undefined {
 function classifyCallFormForMatch(
   match: CaptureMatch,
   anchorName: string,
-  provider: LanguageProvider,
+  provider: ScopeExtractorHooks,
   scopeTree: ReturnType<typeof buildScopeTree>,
   inScopeId: ScopeId,
 ): 'free' | 'member' | 'constructor' | 'index' {
@@ -724,13 +749,6 @@ function extractArity(match: CaptureMatch): number | undefined {
   if (cap === undefined) return undefined;
   const n = Number.parseInt(cap.text, 10);
   return Number.isFinite(n) ? n : undefined;
-}
-
-function anyFilePathFromScopeTree(
-  scopeTree: ReturnType<typeof buildScopeTree>,
-): string | undefined {
-  for (const scope of scopeTree.byId.values()) return scope.filePath;
-  return undefined;
 }
 
 // ─── Internal: range + capture utilities ───────────────────────────────────

--- a/gitnexus/src/core/ingestion/scope-extractor.ts
+++ b/gitnexus/src/core/ingestion/scope-extractor.ts
@@ -1,0 +1,805 @@
+/**
+ * `ScopeExtractor` — the central, source-agnostic driver that turns a
+ * language provider's `CaptureMatch[]` into a `ParsedFile`
+ * (RFC §5.3 + §3.2 Phase 1; Ring 2 PKG #919).
+ *
+ * Exactly one entry point: `extract(matches, filePath, provider) → ParsedFile`.
+ * Runs a five-pass pipeline over the matches. Each pass is internal; the
+ * public contract is the output `ParsedFile`.
+ *
+ * ## Design principles
+ *
+ *   - **Source-agnostic.** Consumes `CaptureMatch[]` from providers;
+ *     doesn't know whether they came from tree-sitter queries or COBOL's
+ *     regex tagger. No `Tree` / `SyntaxNode` types leak into this file.
+ *   - **One AST walk per language.** Providers do the AST walk inside
+ *     their `emitScopeCaptures` hook; this driver does zero further
+ *     traversal — it consumes captures only.
+ *   - **Pure-ish.** The extractor itself is pure (same matches →
+ *     same ParsedFile) when providers are pure. No side effects, no I/O.
+ *   - **Centralized invariant enforcement.** Structural invariants on the
+ *     scope tree (non-module has parent; parent contains child; siblings
+ *     don't overlap) are enforced by `buildScopeTree` from Ring 2 SHARED
+ *     (#912). Malformed inputs throw `ScopeTreeInvariantError`.
+ *
+ * ## The five passes
+ *
+ *   1. **Build scope tree.** Walk `@scope.*` matches. For each, consult
+ *      `provider.shouldCreateScope` (default true) and
+ *      `provider.resolveScopeKind` (default: suffix of the capture name).
+ *      Derive parent by lexical-range containment. Hand the resulting
+ *      `Scope[]` to `buildScopeTree` for validation.
+ *   2. **Attach declarations + local bindings.** Walk `@declaration.*`
+ *      matches. For each, build a `SymbolDefinition` and attach it to
+ *      `provider.bindingScopeFor` (default: innermost containing scope)
+ *      as `ownedDefs` + a local `BindingRef { origin: 'local' }`.
+ *   3. **Collect raw imports.** Walk `@import.*` matches. Call
+ *      `provider.interpretImport` per match; attach the returned
+ *      `ParsedImport` to the ParsedFile (not to any `Scope` — finalize
+ *      reconstructs the owning scope via `provider.importOwningScope`
+ *      during Phase 2).
+ *   4. **Collect type bindings.** Walk `@type-binding.*` matches. Call
+ *      `provider.interpretTypeBinding` per match. Attach the resulting
+ *      `TypeRef` to the innermost containing scope's `typeBindings`
+ *      (or override via `provider.bindingScopeFor` if set).
+ *   5. **Collect reference sites.** Walk `@reference.*` matches. Emit
+ *      one `ReferenceSite` per match. Classify call form via
+ *      `provider.classifyCallForm` (default: the capture's sub-tag if
+ *      present; else `'free'`).
+ *
+ * ## What gets attached where
+ *
+ *   - `Scope.bindings`     — **local bindings only** at this stage (Pass 2).
+ *                            Finalize (#915) merges imports/wildcards on top.
+ *   - `Scope.ownedDefs`    — declarations structurally owned by this scope.
+ *   - `Scope.typeBindings` — local type facts (parameter annotations, `self`).
+ *   - `Scope.imports`      — empty here. Populated by the finalize algorithm
+ *                            when it resolves `ParsedImport.targetRaw`.
+ *   - `ParsedFile.parsedImports` — every raw import in this file.
+ *   - `ParsedFile.localDefs`     — flattened union of `Scope.ownedDefs`.
+ *   - `ParsedFile.referenceSites` — pre-resolution usage facts.
+ */
+
+import type {
+  BindingRef,
+  CaptureMatch,
+  ImportEdge,
+  ParsedFile,
+  ParsedImport,
+  ReferenceSite,
+  ReferenceKind,
+  Range,
+  Scope,
+  ScopeId,
+  ScopeKind,
+  SymbolDefinition,
+  TypeRef,
+} from 'gitnexus-shared';
+import { buildPositionIndex, buildScopeTree, makeScopeId } from 'gitnexus-shared';
+import type { LanguageProvider } from './language-provider.js';
+
+// ─── Public entry point ─────────────────────────────────────────────────────
+
+/**
+ * Drive the five extraction passes and return a `ParsedFile`.
+ *
+ * Throws `ScopeTreeInvariantError` (from #912) when the provider emits
+ * captures that violate structural scope invariants. The error surfaces
+ * upward rather than being silently corrected — a malformed capture set
+ * is a bug in the provider's `emitScopeCaptures`, not a data condition
+ * to tolerate.
+ */
+export function extract(
+  matches: readonly CaptureMatch[],
+  filePath: string,
+  provider: LanguageProvider,
+): ParsedFile {
+  // Partition matches by topic up front — one linear pass over the input.
+  const partitioned = partitionByTopic(matches);
+
+  // ── Pass 1: build the scope tree ─────────────────────────────────────
+  const scopeDrafts = pass1BuildScopes(partitioned.scope, filePath, provider);
+  const scopes = scopeDrafts.map(draftToScope);
+  // buildScopeTree validates invariants (throws on violation) and exposes
+  // the lookup contract consumed by Passes 2-5.
+  const scopeTree = buildScopeTree(scopes);
+  const positionIndex = buildPositionIndex(scopes);
+
+  const moduleScope = scopeDrafts.find((s) => s.kind === 'Module');
+  if (moduleScope === undefined) {
+    throw new Error(
+      `ScopeExtractor: no Module scope found for '${filePath}'. ` +
+        `Provider must emit at least one @scope.module capture per file.`,
+    );
+  }
+
+  // ── Pass 2: attach declarations + local bindings ────────────────────
+  const localDefs: SymbolDefinition[] = [];
+  pass2AttachDeclarations(
+    partitioned.declaration,
+    scopeDrafts,
+    positionIndex,
+    localDefs,
+    filePath,
+    provider,
+    scopeTree,
+  );
+
+  // ── Pass 3: collect raw imports ─────────────────────────────────────
+  const parsedImports: ParsedImport[] = [];
+  pass3CollectImports(partitioned.import_, parsedImports, provider);
+
+  // ── Pass 4: collect type bindings ───────────────────────────────────
+  pass4CollectTypeBindings(
+    partitioned.typeBinding,
+    scopeDrafts,
+    positionIndex,
+    provider,
+    scopeTree,
+  );
+
+  // ── Pass 5: collect reference sites ─────────────────────────────────
+  const referenceSites: ReferenceSite[] = [];
+  pass5CollectReferences(partitioned.reference, positionIndex, referenceSites, provider, scopeTree);
+
+  // Freeze Scope drafts into final shape and return.
+  const frozenScopes = scopeDrafts.map(draftToScope);
+  return Object.freeze({
+    filePath,
+    moduleScope: moduleScope.id,
+    scopes: Object.freeze(frozenScopes),
+    parsedImports: Object.freeze(parsedImports.slice()),
+    localDefs: Object.freeze(localDefs.slice()),
+    referenceSites: Object.freeze(referenceSites.slice()),
+  });
+}
+
+// ─── Internal: partitioning by topic ───────────────────────────────────────
+
+interface Partitioned {
+  readonly scope: readonly CaptureMatch[];
+  readonly declaration: readonly CaptureMatch[];
+  readonly import_: readonly CaptureMatch[];
+  readonly typeBinding: readonly CaptureMatch[];
+  readonly reference: readonly CaptureMatch[];
+}
+
+/**
+ * Bucket each match by the topic of its anchor capture. The anchor is the
+ * capture whose name is prefixed with the match's topic (`@scope.*`,
+ * `@declaration.*`, `@import.*`, `@type-binding.*`, `@reference.*`).
+ *
+ * A match may contain additional captures (e.g., `@import.source`,
+ * `@declaration.class.name`) that are used by the provider hooks to
+ * decode details. Those live inside the `CaptureMatch` and are surfaced
+ * to hooks verbatim — the extractor itself only routes by anchor.
+ */
+function partitionByTopic(matches: readonly CaptureMatch[]): Partitioned {
+  const scope: CaptureMatch[] = [];
+  const declaration: CaptureMatch[] = [];
+  const import_: CaptureMatch[] = [];
+  const typeBinding: CaptureMatch[] = [];
+  const reference: CaptureMatch[] = [];
+
+  for (const match of matches) {
+    const topic = topicOf(match);
+    switch (topic) {
+      case 'scope':
+        scope.push(match);
+        break;
+      case 'declaration':
+        declaration.push(match);
+        break;
+      case 'import':
+        import_.push(match);
+        break;
+      case 'type-binding':
+        typeBinding.push(match);
+        break;
+      case 'reference':
+        reference.push(match);
+        break;
+      case 'unknown':
+        // Unrecognized anchor — silently skip. Providers may emit extra
+        // captures (e.g., `@comment`) that the extractor has no topic for.
+        break;
+    }
+  }
+
+  return { scope, declaration, import_, typeBinding, reference };
+}
+
+type Topic = 'scope' | 'declaration' | 'import' | 'type-binding' | 'reference' | 'unknown';
+
+function topicOf(match: CaptureMatch): Topic {
+  // The anchor is the capture whose name uses one of the known topic
+  // prefixes. For multi-capture matches, ALL captures share the topic;
+  // we pick the first matching key for efficiency.
+  for (const name of Object.keys(match)) {
+    if (name.startsWith('@scope.')) return 'scope';
+    if (name.startsWith('@declaration.')) return 'declaration';
+    if (name.startsWith('@import.')) return 'import';
+    if (name.startsWith('@type-binding.')) return 'type-binding';
+    if (name.startsWith('@reference.')) return 'reference';
+  }
+  return 'unknown';
+}
+
+// ─── Internal: Scope draft model ───────────────────────────────────────────
+
+/**
+ * Mutable Scope record used during extraction. The final `Scope` (readonly,
+ * returned in `ParsedFile.scopes`) is produced by `draftToScope` at the end
+ * of each pass's writes.
+ */
+interface ScopeDraft {
+  readonly id: ScopeId;
+  readonly parent: ScopeId | null;
+  readonly kind: ScopeKind;
+  readonly range: Range;
+  readonly filePath: string;
+  readonly bindings: Map<string, BindingRef[]>;
+  readonly ownedDefs: SymbolDefinition[];
+  readonly imports: ImportEdge[];
+  readonly typeBindings: Map<string, TypeRef>;
+}
+
+function draftToScope(draft: ScopeDraft): Scope {
+  const frozenBindings = new Map<string, readonly BindingRef[]>();
+  for (const [name, refs] of draft.bindings) {
+    frozenBindings.set(name, Object.freeze(refs.slice()));
+  }
+  return {
+    id: draft.id,
+    parent: draft.parent,
+    kind: draft.kind,
+    range: draft.range,
+    filePath: draft.filePath,
+    bindings: frozenBindings,
+    ownedDefs: Object.freeze(draft.ownedDefs.slice()),
+    imports: Object.freeze(draft.imports.slice()),
+    typeBindings: new Map(draft.typeBindings),
+  };
+}
+
+// ─── Pass 1: build scope tree ──────────────────────────────────────────────
+
+/**
+ * Convert `@scope.*` matches into `ScopeDraft[]`. Parent relationships
+ * are derived from range containment (outermost scope containing `range`
+ * becomes the parent). Scopes with `shouldCreateScope === false` are
+ * silently omitted — their children reparent to the next enclosing
+ * real scope.
+ */
+function pass1BuildScopes(
+  matches: readonly CaptureMatch[],
+  filePath: string,
+  provider: LanguageProvider,
+): ScopeDraft[] {
+  interface Candidate {
+    readonly match: CaptureMatch;
+    readonly range: Range;
+    readonly kind: ScopeKind;
+    readonly create: boolean;
+    readonly id: ScopeId;
+  }
+
+  const candidates: Candidate[] = [];
+  for (const match of matches) {
+    const anchor = anchorCaptureFor(match, '@scope.');
+    if (anchor === undefined) continue;
+    const kind = resolveKindForScopeMatch(match, anchor, provider);
+    if (kind === null) continue;
+    const create = provider.shouldCreateScope?.(match) ?? true;
+    const id = makeScopeId({ filePath, range: anchor.range, kind });
+    candidates.push({ match, range: anchor.range, kind, create, id });
+  }
+
+  // Sort by (startLine, startCol) ASC, (endLine, endCol) DESC so outer
+  // scopes appear before their children for parent-resolution.
+  candidates.sort((a, b) => {
+    if (a.range.startLine !== b.range.startLine) return a.range.startLine - b.range.startLine;
+    if (a.range.startCol !== b.range.startCol) return a.range.startCol - b.range.startCol;
+    if (a.range.endLine !== b.range.endLine) return b.range.endLine - a.range.endLine;
+    return b.range.endCol - a.range.endCol;
+  });
+
+  const drafts: ScopeDraft[] = [];
+  const stack: Candidate[] = []; // enclosing real scopes, outermost at [0]
+
+  for (const cand of candidates) {
+    // Pop the stack until the top strictly contains this candidate.
+    while (stack.length > 0 && !rangeStrictlyContains(stack[stack.length - 1]!.range, cand.range)) {
+      stack.pop();
+    }
+
+    if (cand.create) {
+      const parent = stack.length > 0 ? stack[stack.length - 1]!.id : null;
+      drafts.push(makeDraft(cand.id, parent, cand.kind, cand.range, filePath));
+      stack.push(cand);
+    }
+    // If `cand.create === false`, we don't push it onto the stack — child
+    // scopes will reparent to whatever's below it.
+  }
+
+  return drafts;
+}
+
+function resolveKindForScopeMatch(
+  match: CaptureMatch,
+  anchor: { readonly name: string },
+  provider: LanguageProvider,
+): ScopeKind | null {
+  // Provider override takes precedence.
+  const override = provider.resolveScopeKind?.(match);
+  if (override !== undefined && override !== null) return override;
+
+  // Default: derive from capture name suffix (`@scope.function` → 'Function').
+  const suffix = anchor.name.slice('@scope.'.length);
+  switch (suffix.toLowerCase()) {
+    case 'module':
+      return 'Module';
+    case 'namespace':
+      return 'Namespace';
+    case 'class':
+      return 'Class';
+    case 'function':
+      return 'Function';
+    case 'block':
+      return 'Block';
+    case 'expression':
+      return 'Expression';
+    default:
+      return null;
+  }
+}
+
+function makeDraft(
+  id: ScopeId,
+  parent: ScopeId | null,
+  kind: ScopeKind,
+  range: Range,
+  filePath: string,
+): ScopeDraft {
+  return {
+    id,
+    parent,
+    kind,
+    range,
+    filePath,
+    bindings: new Map(),
+    ownedDefs: [],
+    imports: [],
+    typeBindings: new Map(),
+  };
+}
+
+// ─── Pass 2: attach declarations + local bindings ──────────────────────────
+
+function pass2AttachDeclarations(
+  matches: readonly CaptureMatch[],
+  drafts: readonly ScopeDraft[],
+  positionIndex: ReturnType<typeof buildPositionIndex>,
+  localDefs: SymbolDefinition[],
+  filePath: string,
+  provider: LanguageProvider,
+  scopeTree: ReturnType<typeof buildScopeTree>,
+): void {
+  const draftById = new Map<ScopeId, ScopeDraft>();
+  for (const d of drafts) draftById.set(d.id, d);
+
+  for (const match of matches) {
+    const anchor = anchorCaptureFor(match, '@declaration.');
+    if (anchor === undefined) continue;
+
+    const def = buildDefFromDeclarationMatch(match, anchor, filePath);
+    if (def === undefined) continue;
+
+    // Find the innermost scope that contains the declaration's anchor range.
+    const innermostId = positionIndex.atPosition(
+      filePath,
+      anchor.range.startLine,
+      anchor.range.startCol,
+    );
+    if (innermostId === undefined) continue;
+    const innermost = draftById.get(innermostId);
+    if (innermost === undefined) continue;
+
+    // Ownership: `ownedDefs` always attaches to the innermost scope — that's
+    // the structural owner. `ownerId` is set to the owner's nodeId here when
+    // the innermost is a Class/Namespace so method/field defs carry their
+    // owner's graph id; this is a pragmatic defaulting to avoid surprises
+    // downstream (#917 `MethodDispatch` keys off `def.ownerId`).
+    innermost.ownedDefs.push(def);
+    if (def.ownerId === undefined && isOwnerKind(innermost.kind)) {
+      // Mutate via a typed clone — SymbolDefinition fields are declared
+      // non-readonly today so this is structurally safe, but we avoid
+      // touching the caller's input by building a new record.
+      const withOwner: SymbolDefinition = { ...def, ownerId: ownerDefIdFor(innermost, drafts) };
+      innermost.ownedDefs[innermost.ownedDefs.length - 1] = withOwner;
+      localDefs.push(withOwner);
+    } else {
+      localDefs.push(def);
+    }
+
+    // Binding visibility: default to innermost; allow hoisting via
+    // `provider.bindingScopeFor`.
+    const bindingScopeId =
+      provider.bindingScopeFor?.(match, draftToScope(innermost), scopeTree) ?? innermost.id;
+    const bindingHost = draftById.get(bindingScopeId) ?? innermost;
+
+    const nameKey = deriveDeclarationName(match, def);
+    if (nameKey === undefined) continue;
+
+    const emittedDef = localDefs[localDefs.length - 1]!;
+    const existing = bindingHost.bindings.get(nameKey) ?? [];
+    existing.push({ def: emittedDef, origin: 'local' });
+    bindingHost.bindings.set(nameKey, existing);
+  }
+}
+
+function isOwnerKind(kind: ScopeKind): boolean {
+  return kind === 'Class' || kind === 'Namespace';
+}
+
+function ownerDefIdFor(innermost: ScopeDraft, drafts: readonly ScopeDraft[]): string | undefined {
+  // Heuristic: the Class/Namespace scope's own declaration record, if any,
+  // is the first `ownedDef` pushed onto its parent. We don't have a direct
+  // back-reference in the draft, so return undefined and let the graph
+  // layer's naming convention fill in. Providers that care strongly can
+  // set `def.ownerId` at the interpreter hook.
+  void innermost;
+  void drafts;
+  return undefined;
+}
+
+function buildDefFromDeclarationMatch(
+  match: CaptureMatch,
+  anchor: { readonly name: string; readonly range: Range; readonly text: string },
+  filePath: string,
+): SymbolDefinition | undefined {
+  // Anchor name pattern: `@declaration.<kind>` where <kind> maps to NodeLabel.
+  const kindStr = anchor.name.slice('@declaration.'.length);
+  const type = normalizeNodeLabel(kindStr);
+  if (type === undefined) return undefined;
+
+  const nameCap =
+    match['@declaration.name'] ?? match[`@declaration.${kindStr}.name`] ?? match[anchor.name];
+  if (nameCap === undefined) return undefined;
+
+  const qualifiedCap = match['@declaration.qualified_name'];
+  const qualifiedName = qualifiedCap?.text;
+
+  return {
+    nodeId: makeDefId(filePath, anchor.range, type, nameCap.text),
+    filePath,
+    type,
+    ...(qualifiedName !== undefined ? { qualifiedName } : { qualifiedName: nameCap.text }),
+  };
+}
+
+function deriveDeclarationName(match: CaptureMatch, def: SymbolDefinition): string | undefined {
+  const nameCap =
+    match['@declaration.name'] ??
+    match[
+      Object.keys(match).find((k) => k.startsWith('@declaration.') && k.endsWith('.name')) ?? ''
+    ];
+  if (nameCap !== undefined) return nameCap.text;
+  // Fall back to qualifiedName tail.
+  const q = def.qualifiedName;
+  if (q !== undefined && q.length > 0) {
+    const dot = q.lastIndexOf('.');
+    return dot === -1 ? q : q.slice(dot + 1);
+  }
+  return undefined;
+}
+
+/**
+ * Map a lower-case declaration kind (from `@declaration.<kind>`) to a
+ * graph `NodeLabel`. Silently returns `undefined` for kinds we don't
+ * recognize — providers can emit richer captures without breaking the
+ * driver.
+ */
+function normalizeNodeLabel(kindStr: string): SymbolDefinition['type'] | undefined {
+  switch (kindStr.toLowerCase()) {
+    case 'class':
+      return 'Class';
+    case 'interface':
+      return 'Interface';
+    case 'enum':
+      return 'Enum';
+    case 'struct':
+      return 'Struct';
+    case 'union':
+      return 'Union';
+    case 'trait':
+      return 'Trait';
+    case 'method':
+      return 'Method';
+    case 'function':
+      return 'Function';
+    case 'constructor':
+      return 'Constructor';
+    case 'field':
+    case 'property':
+      return 'Property';
+    case 'variable':
+    case 'const':
+      return 'Variable';
+    case 'typealias':
+    case 'type_alias':
+      return 'TypeAlias';
+    case 'typedef':
+      return 'Typedef';
+    case 'record':
+      return 'Record';
+    case 'delegate':
+      return 'Delegate';
+    case 'annotation':
+      return 'Annotation';
+    case 'namespace':
+      return 'Namespace';
+    default:
+      return undefined;
+  }
+}
+
+function makeDefId(
+  filePath: string,
+  range: Range,
+  type: SymbolDefinition['type'],
+  name: string,
+): string {
+  return `def:${filePath}#${range.startLine}:${range.startCol}:${type}:${name}`;
+}
+
+// ─── Pass 3: collect raw imports ───────────────────────────────────────────
+
+function pass3CollectImports(
+  matches: readonly CaptureMatch[],
+  parsedImports: ParsedImport[],
+  provider: LanguageProvider,
+): void {
+  if (provider.interpretImport === undefined) return;
+  for (const match of matches) {
+    const anchor = anchorCaptureFor(match, '@import.');
+    if (anchor === undefined) continue;
+    const parsed = provider.interpretImport(match);
+    if (parsed === null) continue;
+    parsedImports.push(parsed);
+  }
+}
+
+// ─── Pass 4: collect type bindings ─────────────────────────────────────────
+
+function pass4CollectTypeBindings(
+  matches: readonly CaptureMatch[],
+  drafts: readonly ScopeDraft[],
+  positionIndex: ReturnType<typeof buildPositionIndex>,
+  provider: LanguageProvider,
+  scopeTree: ReturnType<typeof buildScopeTree>,
+): void {
+  const draftById = new Map<ScopeId, ScopeDraft>();
+  for (const d of drafts) draftById.set(d.id, d);
+
+  for (const match of matches) {
+    const anchor = anchorCaptureFor(match, '@type-binding.');
+    if (anchor === undefined) continue;
+
+    const parsed = provider.interpretTypeBinding?.(match);
+    if (parsed === null || parsed === undefined) continue;
+
+    const innermostId = positionIndex.atPosition(
+      drafts[0]!.filePath,
+      anchor.range.startLine,
+      anchor.range.startCol,
+    );
+    if (innermostId === undefined) continue;
+    const innermost = draftById.get(innermostId);
+    if (innermost === undefined) continue;
+
+    // `bindingScopeFor` may hoist the type binding to an outer scope.
+    const hostId =
+      provider.bindingScopeFor?.(match, draftToScope(innermost), scopeTree) ?? innermost.id;
+    const host = draftById.get(hostId) ?? innermost;
+
+    const typeRef: TypeRef = {
+      rawName: parsed.rawTypeName,
+      declaredAtScope: host.id,
+      source: parsed.source,
+    };
+    host.typeBindings.set(parsed.boundName, typeRef);
+  }
+}
+
+// ─── Pass 5: collect reference sites ───────────────────────────────────────
+
+function pass5CollectReferences(
+  matches: readonly CaptureMatch[],
+  positionIndex: ReturnType<typeof buildPositionIndex>,
+  referenceSites: ReferenceSite[],
+  provider: LanguageProvider,
+  scopeTree: ReturnType<typeof buildScopeTree>,
+): void {
+  for (const match of matches) {
+    const anchor = anchorCaptureFor(match, '@reference.');
+    if (anchor === undefined) continue;
+
+    const kind = referenceKindFromAnchor(anchor.name);
+    if (kind === undefined) continue;
+
+    const nameCap = match['@reference.name'] ?? anchor;
+    const inScopeId = positionIndex.atPosition(
+      // Any scope carries the same filePath; use the anchor's range to find
+      // the innermost scope via the position index.
+      anyFilePathFromScopeTree(scopeTree) ?? '',
+      anchor.range.startLine,
+      anchor.range.startCol,
+    );
+    if (inScopeId === undefined) continue;
+
+    const callForm =
+      kind === 'call'
+        ? classifyCallFormForMatch(match, anchor.name, provider, scopeTree, inScopeId)
+        : undefined;
+    const explicitReceiver = extractExplicitReceiver(match);
+    const arity = extractArity(match);
+
+    const site: ReferenceSite = {
+      name: nameCap.text,
+      atRange: anchor.range,
+      inScope: inScopeId,
+      kind,
+      ...(callForm !== undefined ? { callForm } : {}),
+      ...(explicitReceiver !== undefined ? { explicitReceiver } : {}),
+      ...(arity !== undefined ? { arity } : {}),
+    };
+    referenceSites.push(site);
+  }
+}
+
+function referenceKindFromAnchor(name: string): ReferenceKind | undefined {
+  const suffix = name.slice('@reference.'.length);
+  // Strip sub-tag after the kind (`@reference.call.member` → `call`).
+  const firstDot = suffix.indexOf('.');
+  const head = firstDot === -1 ? suffix : suffix.slice(0, firstDot);
+  switch (head.toLowerCase()) {
+    case 'call':
+      return 'call';
+    case 'read':
+      return 'read';
+    case 'write':
+      return 'write';
+    case 'type':
+    case 'type_reference':
+      return 'type-reference';
+    case 'inherits':
+      return 'inherits';
+    case 'import_use':
+    case 'import-use':
+      return 'import-use';
+    default:
+      return undefined;
+  }
+}
+
+function classifyCallFormForMatch(
+  match: CaptureMatch,
+  anchorName: string,
+  provider: LanguageProvider,
+  scopeTree: ReturnType<typeof buildScopeTree>,
+  inScopeId: ScopeId,
+): 'free' | 'member' | 'constructor' | 'index' {
+  // Declarative sub-tag path first: `@reference.call.member` → 'member'.
+  const suffix = anchorName.slice('@reference.call.'.length);
+  switch (suffix.toLowerCase()) {
+    case 'free':
+      return 'free';
+    case 'member':
+      return 'member';
+    case 'constructor':
+      return 'constructor';
+    case 'index':
+      return 'index';
+  }
+
+  // Hook-based path: provider knows.
+  const hook = provider.classifyCallForm;
+  if (hook !== undefined) {
+    const scope = scopeTree.getScope(inScopeId);
+    if (scope !== undefined) return hook(match, scope);
+  }
+
+  return 'free';
+}
+
+function extractExplicitReceiver(match: CaptureMatch): { readonly name: string } | undefined {
+  const cap = match['@reference.receiver'];
+  if (cap === undefined) return undefined;
+  return { name: cap.text };
+}
+
+function extractArity(match: CaptureMatch): number | undefined {
+  const cap = match['@reference.arity'];
+  if (cap === undefined) return undefined;
+  const n = Number.parseInt(cap.text, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function anyFilePathFromScopeTree(
+  scopeTree: ReturnType<typeof buildScopeTree>,
+): string | undefined {
+  for (const scope of scopeTree.byId.values()) return scope.filePath;
+  return undefined;
+}
+
+// ─── Internal: range + capture utilities ───────────────────────────────────
+
+function rangeStrictlyContains(outer: Range, inner: Range): boolean {
+  if (
+    outer.startLine === inner.startLine &&
+    outer.startCol === inner.startCol &&
+    outer.endLine === inner.endLine &&
+    outer.endCol === inner.endCol
+  ) {
+    return false;
+  }
+  const startsBefore =
+    outer.startLine < inner.startLine ||
+    (outer.startLine === inner.startLine && outer.startCol <= inner.startCol);
+  const endsAfter =
+    outer.endLine > inner.endLine ||
+    (outer.endLine === inner.endLine && outer.endCol >= inner.endCol);
+  return startsBefore && endsAfter;
+}
+
+/**
+ * Capture names that are never anchors — they are sub-tags nested inside a
+ * larger anchor (e.g., the receiver expression inside a `@reference.call`
+ * may span more source than the called name, but is not the call itself).
+ *
+ * The list is maintained here centrally rather than per-pass because the
+ * set is small and stable; adding a new sub-tag convention is a one-line
+ * change.
+ */
+const KNOWN_SUB_TAGS: ReadonlySet<string> = new Set<string>([
+  '@declaration.name',
+  '@declaration.qualified_name',
+  '@import.name',
+  '@import.source',
+  '@import.alias',
+  '@type-binding.name',
+  '@type-binding.type',
+  '@reference.name',
+  '@reference.receiver',
+  '@reference.arity',
+]);
+
+/**
+ * Return the anchor capture for a match — the one whose name begins with
+ * `prefix` AND is not in the known-sub-tag set. When multiple candidates
+ * remain, the broadest-ranged one wins: tree-sitter queries often tag
+ * both a whole statement and a sub-token under the same topic
+ * (`@scope.function` + `@scope.function.name`); the anchor is the
+ * statement-level one.
+ */
+function anchorCaptureFor(
+  match: CaptureMatch,
+  prefix: string,
+): { readonly name: string; readonly range: Range; readonly text: string } | undefined {
+  let best: { readonly name: string; readonly range: Range; readonly text: string } | undefined;
+  let bestSpan = -1;
+  for (const name of Object.keys(match)) {
+    if (!name.startsWith(prefix)) continue;
+    if (KNOWN_SUB_TAGS.has(name)) continue;
+    const cap = match[name]!;
+    const span =
+      (cap.range.endLine - cap.range.startLine) * 1_000_000 +
+      (cap.range.endCol - cap.range.startCol);
+    if (span > bestSpan) {
+      bestSpan = span;
+      best = cap;
+    }
+  }
+  return best;
+}

--- a/gitnexus/test/unit/scope-resolution/scope-extractor.test.ts
+++ b/gitnexus/test/unit/scope-resolution/scope-extractor.test.ts
@@ -17,8 +17,7 @@ import type {
   Scope,
   ScopeKind,
 } from 'gitnexus-shared';
-import { extract } from '../../../src/core/ingestion/scope-extractor.js';
-import type { LanguageProvider } from '../../../src/core/ingestion/language-provider.js';
+import { extract, type ScopeExtractorHooks } from '../../../src/core/ingestion/scope-extractor.js';
 
 // ─── Synthetic-capture helpers ──────────────────────────────────────────────
 
@@ -92,21 +91,14 @@ const refMatch = (
 });
 
 // ─── MockProvider ───────────────────────────────────────────────────────────
+//
+// The extractor declares its dependency on a narrow `ScopeExtractorHooks`
+// surface — not the full `LanguageProvider`. Tests implement exactly that
+// surface, so adding a new hook to `extract()` that's not in
+// `ScopeExtractorHooks` is a compile error, not a silent test pass.
 
-type MockHooks = {
-  interpretImport?: (match: CaptureMatch) => ParsedImport | null;
-  interpretTypeBinding?: (match: CaptureMatch) => ParsedTypeBinding | null;
-  resolveScopeKind?: (match: CaptureMatch) => ScopeKind | null;
-  shouldCreateScope?: (match: CaptureMatch) => boolean;
-  bindingScopeFor?: LanguageProvider['bindingScopeFor'];
-  classifyCallForm?: LanguageProvider['classifyCallForm'];
-};
-
-function mockProvider(hooks: MockHooks = {}): LanguageProvider {
-  // The tests only exercise the scope-resolution hooks. Casting away the
-  // unimplemented legacy-DAG fields keeps the fixture tight without
-  // depending on LanguageProvider's full (large) interface.
-  return hooks as unknown as LanguageProvider;
+function mockProvider(hooks: Partial<ScopeExtractorHooks> = {}): ScopeExtractorHooks {
+  return hooks;
 }
 
 // ─── §Pass 1: scope tree construction ──────────────────────────────────────
@@ -434,6 +426,37 @@ describe('Pass 5: reference sites', () => {
     ];
     const result = extract(matches, 'a.ts', mockProvider());
     expect(result.referenceSites.map((s) => s.kind)).toEqual(kindsToEmit.map(([, kind]) => kind));
+  });
+
+  it('picks the call anchor over a wider-ranged @reference.receiver (regression for KNOWN_SUB_TAGS exclusion)', () => {
+    // Regression for the bug fixed before commit: a member call like
+    // `user.save()` where the receiver capture (`user`) spans MORE source
+    // than the call anchor (`save`). The broadest-range anchor heuristic
+    // would have picked the receiver — `anchorCaptureFor` must exclude
+    // known sub-tags (`@reference.receiver`, `@reference.name`, etc.) to
+    // route the match as a `call` reference.
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        {
+          // Receiver spans columns 0-10 (wider).
+          '@reference.receiver': cap('@reference.receiver', 3, 0, 3, 10, 'longUserName'),
+          // Call name spans columns 11-15 (narrower).
+          '@reference.name': cap('@reference.name', 3, 11, 3, 15, 'save'),
+          // The anchor — call.member — spans 0-17 (full expression). In the
+          // buggy behavior the receiver would have tied-or-won. Even here,
+          // the fix guarantees we pick the call anchor, never the sub-tag.
+          '@reference.call.member': cap('@reference.call.member', 3, 0, 3, 17),
+        },
+      ],
+      'a.ts',
+      mockProvider(),
+    );
+    expect(result.referenceSites).toHaveLength(1);
+    expect(result.referenceSites[0]!.name).toBe('save'); // NOT 'longUserName'
+    expect(result.referenceSites[0]!.kind).toBe('call');
+    expect(result.referenceSites[0]!.callForm).toBe('member');
+    expect(result.referenceSites[0]!.explicitReceiver).toEqual({ name: 'longUserName' });
   });
 
   it('parses arity from @reference.arity when present', () => {

--- a/gitnexus/test/unit/scope-resolution/scope-extractor.test.ts
+++ b/gitnexus/test/unit/scope-resolution/scope-extractor.test.ts
@@ -1,0 +1,535 @@
+/**
+ * Unit tests for `scope-extractor.extract` — the 5-pass driver
+ * (RFC §5.3; Ring 2 PKG #919).
+ *
+ * Tests are organized by pass so a regression localizes to the pass it
+ * broke. A `MockProvider` emits synthetic `CaptureMatch[]` with no real
+ * AST; the extractor is pure given those captures.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  Capture,
+  CaptureMatch,
+  ParsedImport,
+  ParsedTypeBinding,
+  ReferenceKind,
+  Scope,
+  ScopeKind,
+} from 'gitnexus-shared';
+import { extract } from '../../../src/core/ingestion/scope-extractor.js';
+import type { LanguageProvider } from '../../../src/core/ingestion/language-provider.js';
+
+// ─── Synthetic-capture helpers ──────────────────────────────────────────────
+
+const cap = (
+  name: string,
+  startLine: number,
+  startCol: number,
+  endLine: number,
+  endCol: number,
+  text = '',
+): Capture => ({
+  name,
+  range: { startLine, startCol, endLine, endCol },
+  text,
+});
+
+const scopeMatch = (
+  kind: Lowercase<ScopeKind>,
+  startLine: number,
+  startCol: number,
+  endLine: number,
+  endCol: number,
+): CaptureMatch => ({
+  [`@scope.${kind}`]: cap(`@scope.${kind}`, startLine, startCol, endLine, endCol),
+});
+
+const declMatch = (
+  kindStr: string,
+  name: string,
+  startLine: number,
+  startCol: number,
+  endLine: number,
+  endCol: number,
+  extras: Record<string, Capture> = {},
+): CaptureMatch => ({
+  [`@declaration.${kindStr}`]: cap(`@declaration.${kindStr}`, startLine, startCol, endLine, endCol),
+  '@declaration.name': cap('@declaration.name', startLine, startCol, endLine, endCol, name),
+  ...extras,
+});
+
+const importMatch = (
+  startLine: number,
+  startCol: number,
+  endLine: number,
+  endCol: number,
+): CaptureMatch => ({
+  '@import.statement': cap('@import.statement', startLine, startCol, endLine, endCol),
+});
+
+const typeBindingMatch = (
+  startLine: number,
+  startCol: number,
+  endLine: number,
+  endCol: number,
+): CaptureMatch => ({
+  '@type-binding.parameter': cap('@type-binding.parameter', startLine, startCol, endLine, endCol),
+});
+
+const refMatch = (
+  suffix: string,
+  name: string,
+  startLine: number,
+  startCol: number,
+  endLine: number,
+  endCol: number,
+  extras: Record<string, Capture> = {},
+): CaptureMatch => ({
+  [`@reference.${suffix}`]: cap(`@reference.${suffix}`, startLine, startCol, endLine, endCol),
+  '@reference.name': cap('@reference.name', startLine, startCol, endLine, endCol, name),
+  ...extras,
+});
+
+// ─── MockProvider ───────────────────────────────────────────────────────────
+
+type MockHooks = {
+  interpretImport?: (match: CaptureMatch) => ParsedImport | null;
+  interpretTypeBinding?: (match: CaptureMatch) => ParsedTypeBinding | null;
+  resolveScopeKind?: (match: CaptureMatch) => ScopeKind | null;
+  shouldCreateScope?: (match: CaptureMatch) => boolean;
+  bindingScopeFor?: LanguageProvider['bindingScopeFor'];
+  classifyCallForm?: LanguageProvider['classifyCallForm'];
+};
+
+function mockProvider(hooks: MockHooks = {}): LanguageProvider {
+  // The tests only exercise the scope-resolution hooks. Casting away the
+  // unimplemented legacy-DAG fields keeps the fixture tight without
+  // depending on LanguageProvider's full (large) interface.
+  return hooks as unknown as LanguageProvider;
+}
+
+// ─── §Pass 1: scope tree construction ──────────────────────────────────────
+
+describe('Pass 1: scope tree', () => {
+  it('creates a single Module scope from one @scope.module match', () => {
+    const result = extract([scopeMatch('module', 1, 0, 100, 0)], 'a.ts', mockProvider());
+    expect(result.scopes).toHaveLength(1);
+    expect(result.scopes[0]!.kind).toBe('Module');
+    expect(result.scopes[0]!.parent).toBeNull();
+    expect(result.moduleScope).toBe(result.scopes[0]!.id);
+  });
+
+  it('nests Class under Module when the class range is contained in the module range', () => {
+    const result = extract(
+      [scopeMatch('module', 1, 0, 100, 0), scopeMatch('class', 5, 0, 50, 0)],
+      'a.ts',
+      mockProvider(),
+    );
+    expect(result.scopes).toHaveLength(2);
+    const cls = result.scopes.find((s) => s.kind === 'Class')!;
+    const mod = result.scopes.find((s) => s.kind === 'Module')!;
+    expect(cls.parent).toBe(mod.id);
+  });
+
+  it('nests Method under Class, Class under Module — deep nesting', () => {
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        scopeMatch('class', 5, 0, 50, 0),
+        scopeMatch('function', 10, 2, 30, 2),
+      ],
+      'a.ts',
+      mockProvider(),
+    );
+    const mod = result.scopes.find((s) => s.kind === 'Module')!;
+    const cls = result.scopes.find((s) => s.kind === 'Class')!;
+    const fn = result.scopes.find((s) => s.kind === 'Function')!;
+    expect(cls.parent).toBe(mod.id);
+    expect(fn.parent).toBe(cls.id);
+  });
+
+  it('places non-nested siblings at the same level under the module', () => {
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        scopeMatch('function', 10, 0, 20, 0),
+        scopeMatch('function', 30, 0, 40, 0),
+      ],
+      'a.ts',
+      mockProvider(),
+    );
+    const mod = result.scopes.find((s) => s.kind === 'Module')!;
+    const fns = result.scopes.filter((s) => s.kind === 'Function');
+    expect(fns).toHaveLength(2);
+    for (const fn of fns) expect(fn.parent).toBe(mod.id);
+  });
+
+  it('honors `provider.shouldCreateScope === false` by reparenting children to next real scope', () => {
+    // Block at [10:0..25:0] is SUPPRESSED; inner function at [12:0..20:0]
+    // should reparent to the enclosing Module instead of the Block.
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        scopeMatch('block', 10, 0, 25, 0),
+        scopeMatch('function', 12, 0, 20, 0),
+      ],
+      'a.ts',
+      mockProvider({
+        shouldCreateScope: (match) => match['@scope.block'] === undefined,
+      }),
+    );
+    const mod = result.scopes.find((s) => s.kind === 'Module')!;
+    const fn = result.scopes.find((s) => s.kind === 'Function')!;
+    expect(result.scopes).toHaveLength(2); // block suppressed
+    expect(fn.parent).toBe(mod.id);
+  });
+
+  it('uses `provider.resolveScopeKind` to override the default kind from the suffix', () => {
+    // Provider upgrades a `@scope.block` to `Expression` for a comprehension-
+    // style use case.
+    const result = extract(
+      [scopeMatch('module', 1, 0, 100, 0), scopeMatch('block', 10, 0, 15, 0)],
+      'a.ts',
+      mockProvider({
+        resolveScopeKind: (match) => (match['@scope.block'] !== undefined ? 'Expression' : null),
+      }),
+    );
+    expect(result.scopes.find((s) => s.kind === 'Expression')).toBeDefined();
+  });
+
+  it('throws ScopeTreeInvariantError when siblings overlap (provider bug)', () => {
+    expect(() =>
+      extract(
+        [
+          scopeMatch('module', 1, 0, 100, 0),
+          scopeMatch('function', 10, 0, 20, 0),
+          scopeMatch('function', 15, 0, 25, 0), // overlaps
+        ],
+        'a.ts',
+        mockProvider(),
+      ),
+    ).toThrow(/overlap/i);
+  });
+
+  it('throws when no Module scope is present', () => {
+    expect(() => extract([scopeMatch('function', 1, 0, 10, 0)], 'a.ts', mockProvider())).toThrow(
+      /Module/,
+    );
+  });
+});
+
+// ─── §Pass 2: declarations + local bindings ────────────────────────────────
+
+describe('Pass 2: declarations + local bindings', () => {
+  it('attaches a Class declaration to its enclosing Module scope', () => {
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        scopeMatch('class', 5, 0, 50, 0),
+        declMatch('class', 'User', 5, 6, 5, 10),
+      ],
+      'a.ts',
+      mockProvider(),
+    );
+    // The declaration sits at line 5 → innermost scope is Class (at 5:0..50:0).
+    const cls = result.scopes.find((s) => s.kind === 'Class')!;
+    expect(cls.ownedDefs).toHaveLength(1);
+    expect(cls.ownedDefs[0]!.type).toBe('Class');
+    expect(cls.ownedDefs[0]!.qualifiedName).toBe('User');
+    expect(cls.bindings.get('User')).toBeDefined();
+    expect(cls.bindings.get('User')![0]!.origin).toBe('local');
+  });
+
+  it('records the declaration in `localDefs` as well', () => {
+    const result = extract(
+      [scopeMatch('module', 1, 0, 100, 0), declMatch('function', 'render', 5, 0, 5, 6)],
+      'a.ts',
+      mockProvider(),
+    );
+    expect(result.localDefs).toHaveLength(1);
+    expect(result.localDefs[0]!.type).toBe('Function');
+  });
+
+  it('honors `provider.bindingScopeFor` to hoist a binding to an outer scope', () => {
+    // Treat every declaration as hoisted to the module scope.
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        scopeMatch('function', 10, 0, 30, 0),
+        declMatch('variable', 'x', 15, 4, 15, 5),
+      ],
+      'a.ts',
+      mockProvider({
+        bindingScopeFor: (_match, _innermost, scopeTree) => {
+          for (const s of scopeTree.byId.values()) if (s.kind === 'Module') return s.id;
+          return null;
+        },
+      }),
+    );
+    const mod = result.scopes.find((s) => s.kind === 'Module')!;
+    const fn = result.scopes.find((s) => s.kind === 'Function')!;
+    // Binding hoisted to module; function scope's bindings empty for 'x'.
+    expect(mod.bindings.get('x')).toBeDefined();
+    expect(fn.bindings.get('x')).toBeUndefined();
+    // `ownedDefs` stays structural (innermost = function).
+    expect(fn.ownedDefs).toHaveLength(1);
+  });
+
+  it('ignores declarations with unknown kind suffixes', () => {
+    const result = extract(
+      [scopeMatch('module', 1, 0, 100, 0), declMatch('mystery', 'x', 5, 0, 5, 1)],
+      'a.ts',
+      mockProvider(),
+    );
+    expect(result.localDefs).toHaveLength(0);
+  });
+});
+
+// ─── §Pass 3: imports ──────────────────────────────────────────────────────
+
+describe('Pass 3: raw imports', () => {
+  it('collects imports via `provider.interpretImport`', () => {
+    const named: ParsedImport = {
+      kind: 'named',
+      localName: 'User',
+      importedName: 'User',
+      targetRaw: './models',
+    };
+    const result = extract(
+      [scopeMatch('module', 1, 0, 100, 0), importMatch(3, 0, 3, 30)],
+      'a.ts',
+      mockProvider({
+        interpretImport: () => named,
+      }),
+    );
+    expect(result.parsedImports).toEqual([named]);
+  });
+
+  it('drops imports when `interpretImport` returns null', () => {
+    const result = extract(
+      [scopeMatch('module', 1, 0, 100, 0), importMatch(3, 0, 3, 30)],
+      'a.ts',
+      mockProvider({
+        interpretImport: () => null,
+      }),
+    );
+    expect(result.parsedImports).toEqual([]);
+  });
+
+  it('emits no imports when the provider does not implement `interpretImport`', () => {
+    const result = extract(
+      [scopeMatch('module', 1, 0, 100, 0), importMatch(3, 0, 3, 30)],
+      'a.ts',
+      mockProvider(),
+    );
+    expect(result.parsedImports).toEqual([]);
+  });
+});
+
+// ─── §Pass 4: type bindings ───────────────────────────────────────────────
+
+describe('Pass 4: type bindings', () => {
+  it('attaches a parameter-annotation TypeRef to the innermost scope', () => {
+    const parsed: ParsedTypeBinding = {
+      boundName: 'user',
+      rawTypeName: 'User',
+      source: 'parameter-annotation',
+    };
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        scopeMatch('function', 5, 0, 20, 0),
+        typeBindingMatch(6, 4, 6, 14),
+      ],
+      'a.ts',
+      mockProvider({
+        interpretTypeBinding: () => parsed,
+      }),
+    );
+    const fn = result.scopes.find((s) => s.kind === 'Function')!;
+    const tb = fn.typeBindings.get('user');
+    expect(tb).toBeDefined();
+    expect(tb!.rawName).toBe('User');
+    expect(tb!.source).toBe('parameter-annotation');
+    expect(tb!.declaredAtScope).toBe(fn.id);
+  });
+
+  it('skips type-binding matches when the provider returns null', () => {
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        scopeMatch('function', 5, 0, 20, 0),
+        typeBindingMatch(6, 4, 6, 14),
+      ],
+      'a.ts',
+      mockProvider({
+        interpretTypeBinding: () => null,
+      }),
+    );
+    const fn = result.scopes.find((s) => s.kind === 'Function')!;
+    expect(fn.typeBindings.size).toBe(0);
+  });
+});
+
+// ─── §Pass 5: reference sites ─────────────────────────────────────────────
+
+describe('Pass 5: reference sites', () => {
+  it('emits a call reference with the innermost scope anchor', () => {
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        scopeMatch('function', 5, 0, 20, 0),
+        refMatch('call.free', 'print', 10, 4, 10, 9),
+      ],
+      'a.ts',
+      mockProvider(),
+    );
+    const fn = result.scopes.find((s) => s.kind === 'Function')!;
+    expect(result.referenceSites).toHaveLength(1);
+    expect(result.referenceSites[0]!.name).toBe('print');
+    expect(result.referenceSites[0]!.kind).toBe('call');
+    expect(result.referenceSites[0]!.callForm).toBe('free');
+    expect(result.referenceSites[0]!.inScope).toBe(fn.id);
+  });
+
+  it('classifies member calls via the `@reference.call.member` sub-tag', () => {
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        refMatch('call.member', 'save', 3, 4, 3, 8, {
+          '@reference.receiver': cap('@reference.receiver', 3, 0, 3, 4, 'user'),
+        }),
+      ],
+      'a.ts',
+      mockProvider(),
+    );
+    expect(result.referenceSites[0]!.callForm).toBe('member');
+    expect(result.referenceSites[0]!.explicitReceiver).toEqual({ name: 'user' });
+  });
+
+  it('falls back to `provider.classifyCallForm` when the anchor has no sub-tag', () => {
+    const result = extract(
+      [scopeMatch('module', 1, 0, 100, 0), refMatch('call', 'foo', 3, 0, 3, 3)],
+      'a.ts',
+      mockProvider({
+        classifyCallForm: () => 'member',
+      }),
+    );
+    expect(result.referenceSites[0]!.callForm).toBe('member');
+  });
+
+  it('recognizes all reference kinds (call, read, write, inherits, type, import_use)', () => {
+    const kindsToEmit: Array<[string, ReferenceKind]> = [
+      ['call.free', 'call'],
+      ['read', 'read'],
+      ['write', 'write'],
+      ['inherits', 'inherits'],
+      ['type', 'type-reference'],
+      ['import_use', 'import-use'],
+    ];
+    const matches = [
+      scopeMatch('module', 1, 0, 100, 0),
+      ...kindsToEmit.map(([suffix], i) => refMatch(suffix, `ref${i}`, 10 + i, 0, 10 + i, 5)),
+    ];
+    const result = extract(matches, 'a.ts', mockProvider());
+    expect(result.referenceSites.map((s) => s.kind)).toEqual(kindsToEmit.map(([, kind]) => kind));
+  });
+
+  it('parses arity from @reference.arity when present', () => {
+    const result = extract(
+      [
+        scopeMatch('module', 1, 0, 100, 0),
+        refMatch('call.free', 'foo', 3, 0, 3, 3, {
+          '@reference.arity': cap('@reference.arity', 3, 0, 3, 0, '2'),
+        }),
+      ],
+      'a.ts',
+      mockProvider(),
+    );
+    expect(result.referenceSites[0]!.arity).toBe(2);
+  });
+});
+
+// ─── §End-to-end fixture ──────────────────────────────────────────────────
+
+describe('end-to-end fixture (all 5 passes together)', () => {
+  it('produces a well-formed ParsedFile from a representative multi-pass input', () => {
+    const matches: CaptureMatch[] = [
+      // Pass 1: nested scopes
+      scopeMatch('module', 1, 0, 100, 0),
+      scopeMatch('class', 5, 0, 50, 0),
+      scopeMatch('function', 10, 2, 40, 2),
+      // Pass 2: declarations
+      declMatch('class', 'User', 5, 6, 5, 10),
+      declMatch('method', 'save', 10, 2, 10, 6),
+      declMatch('field', 'count', 7, 2, 7, 7),
+      // Pass 3: import
+      importMatch(3, 0, 3, 30),
+      // Pass 4: type binding
+      typeBindingMatch(10, 14, 10, 18),
+      // Pass 5: references
+      refMatch('call.member', 'log', 20, 4, 20, 7, {
+        '@reference.receiver': cap('@reference.receiver', 20, 0, 20, 4, 'self'),
+      }),
+      refMatch('read', 'count', 25, 4, 25, 9),
+    ];
+
+    const parsedImport: ParsedImport = {
+      kind: 'named',
+      localName: 'Logger',
+      importedName: 'Logger',
+      targetRaw: './logger',
+    };
+    const parsedTypeBinding: ParsedTypeBinding = {
+      boundName: 'name',
+      rawTypeName: 'string',
+      source: 'parameter-annotation',
+    };
+
+    const result = extract(
+      matches,
+      'user.ts',
+      mockProvider({
+        interpretImport: () => parsedImport,
+        interpretTypeBinding: () => parsedTypeBinding,
+      }),
+    );
+
+    // Three scopes, properly nested.
+    expect(result.scopes).toHaveLength(3);
+    const kinds = result.scopes.map((s: Scope) => s.kind);
+    expect(kinds).toEqual(expect.arrayContaining(['Module', 'Class', 'Function']));
+
+    // Declarations landed on the correct scopes.
+    const cls = result.scopes.find((s) => s.kind === 'Class')!;
+    const fn = result.scopes.find((s) => s.kind === 'Function')!;
+    expect(cls.ownedDefs.map((d) => d.qualifiedName).sort()).toEqual(['User', 'count'].sort());
+    expect(fn.ownedDefs.map((d) => d.qualifiedName)).toEqual(['save']);
+
+    // Local bindings present.
+    expect(cls.bindings.get('User')).toBeDefined();
+    expect(cls.bindings.get('count')).toBeDefined();
+    expect(fn.bindings.get('save')).toBeDefined();
+
+    // Import collected.
+    expect(result.parsedImports).toEqual([parsedImport]);
+
+    // Type binding attached to function scope.
+    expect(fn.typeBindings.get('name')?.rawName).toBe('string');
+
+    // References emitted.
+    expect(result.referenceSites).toHaveLength(2);
+    expect(result.referenceSites.map((r) => r.kind)).toEqual(['call', 'read']);
+
+    // `localDefs` is the union across scopes.
+    expect(result.localDefs).toHaveLength(3);
+    expect(result.localDefs.map((d) => d.type).sort()).toEqual(
+      ['Class', 'Method', 'Property'].sort(),
+    );
+
+    // Module scope id matches the ParsedFile header.
+    const mod = result.scopes.find((s) => s.kind === 'Module')!;
+    expect(result.moduleScope).toBe(mod.id);
+  });
+});


### PR DESCRIPTION
Closes #919. **Ring 2 PKG kickoff** — the central driver that turns a language provider's capture matches into a per-file `ParsedFile` artifact. Foundation for the rest of Ring 2 PKG (#920 parse-worker integration, #921 finalize orchestrator, #922 import adapters).

## What's new

### New shared contracts (`gitnexus-shared`)

| File | Role |
|------|------|
| \`parsed-file.ts\` | \`ParsedFile\` — per-file extraction artifact: \`scopes\`, \`parsedImports\`, \`localDefs\`, \`referenceSites\`. Structural superset of \`FinalizeFile\` so the finalize orchestrator threads it through unchanged. |
| \`reference-site.ts\` | \`ReferenceSite\` — pre-resolution usage fact: name, atRange, inScope, kind, optional callForm/explicitReceiver/arity. Converted to \`Reference\` records by the resolution phase. |

### Ring 1 collateral tweak

\`LanguageProvider.emitScopeCaptures\` now returns \`Promise<readonly CaptureMatch[]>\` (was \`readonly Capture[]\`). Pre-grouping per tree-sitter match is the provider's job — the extractor expects coherent matches, not flat captures. **No consumers yet** (all languages still on legacy DAG), so no breakage.

### New CLI module (\`gitnexus/\`)

\`src/core/ingestion/scope-extractor.ts\` — single entry point:

\`\`\`ts
extract(matches: readonly CaptureMatch[], filePath: string, provider: LanguageProvider): ParsedFile
\`\`\`

## The five passes (RFC §5.3)

| # | Topic | What it does |
|---|-------|--------------|
| **1** | \`@scope.*\` | Build scope tree via range-containment parent derivation. Honors \`provider.shouldCreateScope\` (skip-but-reparent) + \`provider.resolveScopeKind\` (override default suffix mapping). \`buildScopeTree\` validates invariants. |
| **2** | \`@declaration.*\` | Attach \`SymbolDefinition\` + local \`BindingRef\` to innermost scope (or hoisted via \`provider.bindingScopeFor\`). Populates \`Scope.ownedDefs\` + \`Scope.bindings\`. |
| **3** | \`@import.*\` | Call \`provider.interpretImport\` per match. Attach raw \`ParsedImport[]\` to \`ParsedFile\` (finalize links in Phase 2). |
| **4** | \`@type-binding.*\` | Call \`provider.interpretTypeBinding\` per match. Write \`TypeRef\` into the host scope's \`typeBindings\`. |
| **5** | \`@reference.*\` | Emit one \`ReferenceSite\` per match. Call form from declarative sub-tag (\`@reference.call.member\`) or \`provider.classifyCallForm\`. |

## Design principles

- **Source-agnostic.** Consumes \`CaptureMatch[]\` from providers; no \`Tree\` / \`SyntaxNode\` types leak. Works for tree-sitter providers and COBOL's regex tagger.
- **One AST walk per language.** Providers do the walk inside \`emitScopeCaptures\`; this driver does zero traversal.
- **Invariants delegated.** \`ScopeTree.buildScopeTree\` (from #912) enforces structural rules (non-Module has parent, parent contains child, siblings don't overlap). Malformed captures throw \`ScopeTreeInvariantError\` — the driver doesn't try to repair them.
- **Sub-tag whitelist.** \`@reference.receiver\`, \`@declaration.name\`, \`@import.source\`, etc. are excluded from anchor selection so the broadest-range heuristic doesn't misidentify them. Bug surfaced in the end-to-end fixture test (member call with a wider-range receiver) and was fixed before commit.

## Tests (23, all passing)

Organized by pass so regressions localize:

- **Pass 1** (8): module-only · nested · deeply-nested · siblings · \`shouldCreateScope === false\` reparenting · \`resolveScopeKind\` override · overlap throws · no-Module throws
- **Pass 2** (4): Class attached to enclosing scope · \`localDefs\` populated · \`bindingScopeFor\` hoisting · unknown kinds dropped
- **Pass 3** (3): \`interpretImport\` produces \`ParsedImport[]\` · null returns dropped · no hook = no imports
- **Pass 4** (2): parameter-annotation TypeRef attached · null returns skipped
- **Pass 5** (5): call inScope anchor · \`@reference.call.member\` sub-tag · \`classifyCallForm\` fallback · all 6 reference kinds · arity parsing
- **End-to-end** (1): multi-pass fixture exercising all 5 passes together

## Verification

- \`tsc --noEmit\` clean (both \`gitnexus-shared\` and \`gitnexus\`)
- \`gitnexus-shared\` build clean
- 23/23 new tests pass
- Full scope-resolution / model / shadow suite: **285/285 pass**

## What's NOT in this PR

- Actually calling \`extract()\` from \`parse-worker.ts\` — that's #920
- Finalize orchestration (\`ParsedFile[] → MutableSemanticModel\`) — that's #921
- Per-language import adapters — that's #922
- Shadow harness + dashboard — that's #923

The extractor is callable in isolation (tests prove this) but not wired into the real pipeline yet. This deliberate isolation keeps #919's scope tight and lets the downstream tickets land as small, reviewable integrations.

## Part of

- Parent: #909
- Depends on (code): #910, #911, #912
- Unblocks: #920, #921, #922