### PR TITLE
feat(ingestion): shadow-mode parity harness + static dashboard (#923, RFC #909 Ring 2 PKG)

### DIFF
--- a/gitnexus/shadow-parity-dashboard/index.html
+++ b/gitnexus/shadow-parity-dashboard/index.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>GitNexus — Shadow Parity Dashboard</title>
+    <!--
+      Static dashboard for the RFC #909 shadow-mode parity report.
+
+      Reads `latest.json` from this directory and renders a per-language
+      parity table. Zero build step, zero runtime dependencies — a
+      single file that any browser or file:// context can open.
+
+      Usage:
+          # from repo root, after a shadow-mode run
+          cp .gitnexus/shadow-parity/latest.json gitnexus/shadow-parity-dashboard/
+          open gitnexus/shadow-parity-dashboard/index.html
+
+      CI artifact wiring (follow-up): the CI job publishes a snapshot
+      of this directory + latest.json as a downloadable bundle per run.
+    -->
+    <style>
+      :root {
+        color-scheme: light dark;
+        --fg: #1f2937;
+        --fg-muted: #6b7280;
+        --bg: #ffffff;
+        --bg-muted: #f9fafb;
+        --border: #e5e7eb;
+        --good: #16a34a;
+        --warn: #d97706;
+        --bad: #dc2626;
+        --primary-tag-legacy: #7c3aed;
+        --primary-tag-registry: #0ea5e9;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --fg: #e5e7eb;
+          --fg-muted: #9ca3af;
+          --bg: #111827;
+          --bg-muted: #1f2937;
+          --border: #374151;
+        }
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font:
+          14px/1.45 system-ui,
+          -apple-system,
+          sans-serif;
+      }
+      main {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px 16px;
+      }
+      h1 {
+        font-size: 20px;
+        margin: 0 0 4px;
+      }
+      .meta {
+        color: var(--fg-muted);
+        font-size: 12px;
+        margin-bottom: 20px;
+      }
+      .cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 10px;
+        margin-bottom: 20px;
+      }
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 10px 12px;
+        background: var(--bg-muted);
+      }
+      .card .k {
+        color: var(--fg-muted);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .card .v {
+        font-size: 20px;
+        font-weight: 600;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-variant-numeric: tabular-nums;
+      }
+      th,
+      td {
+        padding: 6px 10px;
+        text-align: right;
+        border-bottom: 1px solid var(--border);
+      }
+      th:first-child,
+      td:first-child {
+        text-align: left;
+      }
+      thead th {
+        font-weight: 600;
+        color: var(--fg-muted);
+        font-size: 12px;
+        background: var(--bg-muted);
+      }
+      tbody tr:hover {
+        background: var(--bg-muted);
+      }
+      .parity {
+        font-weight: 600;
+      }
+      .parity.good {
+        color: var(--good);
+      }
+      .parity.warn {
+        color: var(--warn);
+      }
+      .parity.bad {
+        color: var(--bad);
+      }
+      .tag {
+        display: inline-block;
+        padding: 1px 6px;
+        border-radius: 10px;
+        font-size: 10px;
+        margin-left: 6px;
+        color: white;
+      }
+      .tag.legacy {
+        background: var(--primary-tag-legacy);
+      }
+      .tag.registry {
+        background: var(--primary-tag-registry);
+      }
+      .empty {
+        padding: 40px;
+        text-align: center;
+        color: var(--fg-muted);
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        background: var(--bg-muted);
+        padding: 1px 4px;
+        border-radius: 3px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Shadow Parity — RFC #909</h1>
+      <div class="meta" id="meta">loading <code>latest.json</code>…</div>
+      <div class="cards" id="cards"></div>
+      <table id="per-language">
+        <thead>
+          <tr>
+            <th>Language</th>
+            <th>Total</th>
+            <th>Agree</th>
+            <th>Only legacy</th>
+            <th>Only new</th>
+            <th>Disagree</th>
+            <th>Both empty</th>
+            <th>Parity</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <div id="empty" class="empty" style="display: none">
+        No records yet. Enable <code>GITNEXUS_SHADOW_MODE=1</code> and run ingestion to populate.
+      </div>
+    </main>
+    <script>
+      /* global fetch, document */
+      (async function () {
+        const tbody = document.querySelector('#per-language tbody');
+        const cards = document.getElementById('cards');
+        const meta = document.getElementById('meta');
+        const empty = document.getElementById('empty');
+        const table = document.getElementById('per-language');
+
+        let payload;
+        try {
+          const r = await fetch('./latest.json', { cache: 'no-store' });
+          if (!r.ok) throw new Error('HTTP ' + r.status);
+          payload = await r.json();
+        } catch (err) {
+          meta.textContent = 'Failed to load latest.json: ' + err.message;
+          table.style.display = 'none';
+          empty.style.display = 'block';
+          return;
+        }
+
+        const primary = payload.primaryByLanguage || {};
+        const report = payload.report || {};
+        const perLang = report.perLanguage || [];
+        const overall = report.overall || {};
+
+        meta.textContent =
+          'Run ' + payload.runId + ' — generated ' + payload.generatedAt + ' (schema v' + payload.schemaVersion + ')';
+
+        // Overall summary cards.
+        cards.innerHTML = '';
+        const overallParity = overall.parity !== undefined ? overall.parity : 0;
+        cards.appendChild(makeCard('Total calls', overall.totalCalls ?? 0));
+        cards.appendChild(makeCard('Both agree', overall.bothAgree ?? 0));
+        cards.appendChild(makeCard('Disagree', overall.bothDisagree ?? 0));
+        cards.appendChild(makeCard('Overall parity', formatPct(overallParity)));
+
+        if (!perLang.length) {
+          table.style.display = 'none';
+          empty.style.display = 'block';
+          return;
+        }
+
+        for (const row of perLang) {
+          const tr = document.createElement('tr');
+          const primaryTag = primary[row.language];
+          const tag = primaryTag
+            ? '<span class="tag ' + primaryTag + '">primary: ' + primaryTag + '</span>'
+            : '';
+          const parityClass = parityClassFor(row.parity);
+          tr.innerHTML =
+            '<td>' + escape(row.language) + tag + '</td>' +
+            '<td>' + row.totalCalls + '</td>' +
+            '<td>' + row.bothAgree + '</td>' +
+            '<td>' + row.onlyLegacy + '</td>' +
+            '<td>' + row.onlyNew + '</td>' +
+            '<td>' + row.bothDisagree + '</td>' +
+            '<td>' + row.bothEmpty + '</td>' +
+            '<td class="parity ' + parityClass + '">' + formatPct(row.parity) + '</td>';
+          tbody.appendChild(tr);
+        }
+
+        function makeCard(k, v) {
+          const div = document.createElement('div');
+          div.className = 'card';
+          div.innerHTML = '<div class="k">' + escape(k) + '</div><div class="v">' + escape(String(v)) + '</div>';
+          return div;
+        }
+        function formatPct(x) {
+          if (typeof x !== 'number' || !isFinite(x)) return '—';
+          return (x * 100).toFixed(1) + '%';
+        }
+        function parityClassFor(x) {
+          if (typeof x !== 'number') return '';
+          if (x >= 0.95) return 'good';
+          if (x >= 0.8) return 'warn';
+          return 'bad';
+        }
+        function escape(s) {
+          return String(s).replace(/[&<>"']/g, function (c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+          });
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/gitnexus/shadow-parity-dashboard/index.html
+++ b/gitnexus/shadow-parity-dashboard/index.html
@@ -203,7 +203,13 @@
         const overall = report.overall || {};
 
         meta.textContent =
-          'Run ' + payload.runId + ' — generated ' + payload.generatedAt + ' (schema v' + payload.schemaVersion + ')';
+          'Run ' +
+          payload.runId +
+          ' — generated ' +
+          payload.generatedAt +
+          ' (schema v' +
+          payload.schemaVersion +
+          ')';
 
         // Overall summary cards.
         cards.innerHTML = '';
@@ -227,21 +233,41 @@
             : '';
           const parityClass = parityClassFor(row.parity);
           tr.innerHTML =
-            '<td>' + escape(row.language) + tag + '</td>' +
-            '<td>' + row.totalCalls + '</td>' +
-            '<td>' + row.bothAgree + '</td>' +
-            '<td>' + row.onlyLegacy + '</td>' +
-            '<td>' + row.onlyNew + '</td>' +
-            '<td>' + row.bothDisagree + '</td>' +
-            '<td>' + row.bothEmpty + '</td>' +
-            '<td class="parity ' + parityClass + '">' + formatPct(row.parity) + '</td>';
+            '<td>' +
+            escape(row.language) +
+            tag +
+            '</td>' +
+            '<td>' +
+            row.totalCalls +
+            '</td>' +
+            '<td>' +
+            row.bothAgree +
+            '</td>' +
+            '<td>' +
+            row.onlyLegacy +
+            '</td>' +
+            '<td>' +
+            row.onlyNew +
+            '</td>' +
+            '<td>' +
+            row.bothDisagree +
+            '</td>' +
+            '<td>' +
+            row.bothEmpty +
+            '</td>' +
+            '<td class="parity ' +
+            parityClass +
+            '">' +
+            formatPct(row.parity) +
+            '</td>';
           tbody.appendChild(tr);
         }
 
         function makeCard(k, v) {
           const div = document.createElement('div');
           div.className = 'card';
-          div.innerHTML = '<div class="k">' + escape(k) + '</div><div class="v">' + escape(String(v)) + '</div>';
+          div.innerHTML =
+            '<div class="k">' + escape(k) + '</div><div class="v">' + escape(String(v)) + '</div>';
           return div;
         }
         function formatPct(x) {

--- a/gitnexus/src/core/ingestion/shadow-harness.ts
+++ b/gitnexus/src/core/ingestion/shadow-harness.ts
@@ -1,0 +1,222 @@
+/**
+ * Shadow-mode parity harness — dual-run observability for the RFC #909
+ * registry rollout (RFC §6.3; Ring 2 PKG #923).
+ *
+ * ## What it does
+ *
+ *   - Exposes `record({ language, callsite, legacy, newResult })` for
+ *     every call site where the caller has BOTH a legacy-DAG resolution
+ *     and a new `Registry.lookup` resolution.
+ *   - Computes a `ShadowDiff` per record via shared `diffResolutions`
+ *     (#918) and accumulates them in a per-language bucket.
+ *   - At the end of a run, aggregates into a `ShadowParityReport` via
+ *     shared `aggregateDiffs` (#918) — per-language parity %,
+ *     evidence-kind breakdown of divergences, grand-total overall row.
+ *   - Optionally persists the report as JSON under
+ *     `.gitnexus/shadow-parity/` so the static dashboard at
+ *     `gitnexus/shadow-parity-dashboard/` can render it offline.
+ *
+ * ## What it does NOT do
+ *
+ *   - **Invoke either resolution path itself.** The caller must run
+ *     legacy + `Registry.lookup` and pass results in. The harness is a
+ *     side-car, not a dispatcher — this keeps call-processor integration
+ *     surgical when it lands (tracked as a follow-up; the shared model
+ *     doesn't dual-invoke on its own).
+ *   - **Flip anything.** `REGISTRY_PRIMARY_<LANG>` lives in
+ *     `registry-primary-flag.ts` (#924); the harness records the
+ *     caller-supplied "which side is primary" bit for each record so the
+ *     dashboard can label rows, but it does not consult the flag itself.
+ *
+ * ## Activation
+ *
+ * `GITNEXUS_SHADOW_MODE=1` (or `'true'`, `'yes'`, case-insensitive,
+ * trimmed) enables the harness. When disabled, `record()` is a cheap
+ * no-op: no accumulation, no allocation beyond the harness object
+ * itself. Callers can always construct a harness and hand it through;
+ * the "off" overhead is near-zero.
+ *
+ * ## Persistence shape
+ *
+ * When `persist()` is called, the harness writes TWO files:
+ *
+ *   - `<outputDir>/<runId>.json` — the timestamped snapshot (immutable)
+ *   - `<outputDir>/latest.json`  — a pointer that the dashboard reads
+ *
+ * Both files contain the same `PersistedShadowReport` payload:
+ *
+ *   {
+ *     schemaVersion: 1,
+ *     runId: "<iso-8601>-<rand>",
+ *     generatedAt: "<iso-8601>",
+ *     primaryByLanguage: { [lang]: "legacy" | "registry" },
+ *     report: <ShadowParityReport>
+ *   }
+ *
+ * Schema-version-gated so future format changes don't silently confuse
+ * older dashboards. The dashboard renders `report.perLanguage` rows and
+ * annotates each with `primaryByLanguage[lang]`.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  aggregateDiffs,
+  diffResolutions,
+  type Resolution,
+  type ShadowCallsite,
+  type ShadowDiff,
+  type ShadowParityReport,
+  type SupportedLanguages,
+} from 'gitnexus-shared';
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+/** Which side of the dual-run is considered authoritative for this language. */
+export type PrimarySide = 'legacy' | 'registry';
+
+/** One record per call site the caller dual-runs. */
+export interface ShadowRecordInput {
+  readonly language: SupportedLanguages;
+  readonly callsite: ShadowCallsite;
+  readonly legacy: readonly Resolution[];
+  readonly newResult: readonly Resolution[];
+  /**
+   * Which side drove the actual runtime answer for this record. Lets the
+   * dashboard distinguish "registry-primary, legacy is shadow" from the
+   * default "legacy-primary, registry is shadow" without re-reading
+   * `REGISTRY_PRIMARY_<LANG>` env vars at render time.
+   */
+  readonly primary: PrimarySide;
+}
+
+/** Persisted JSON shape. Schema-versioned for future migrations. */
+export interface PersistedShadowReport {
+  readonly schemaVersion: 1;
+  readonly runId: string;
+  readonly generatedAt: string;
+  readonly primaryByLanguage: Readonly<Partial<Record<SupportedLanguages, PrimarySide>>>;
+  readonly report: ShadowParityReport;
+}
+
+export interface ShadowHarness {
+  /** `true` iff `GITNEXUS_SHADOW_MODE` is truthy. When `false`, `record()` is a no-op. */
+  readonly enabled: boolean;
+  /** Accumulate a dual-run observation. No-op when `enabled === false`. */
+  record(input: ShadowRecordInput): void;
+  /** Number of records accumulated so far. Useful for diagnostics / tests. */
+  size(): number;
+  /**
+   * Aggregate the accumulated records into a `ShadowParityReport`
+   * without persisting. Returns a deterministic snapshot each call;
+   * idempotent with respect to `record()` ordering.
+   */
+  snapshot(now?: Date): ShadowParityReport;
+  /**
+   * Write the aggregated snapshot to JSON. Resolves to the path of the
+   * per-run file. Also writes/overwrites `latest.json` alongside.
+   *
+   * Creates `outputDir` if it doesn't exist.
+   */
+  persist(outputDir: string, now?: Date): Promise<string>;
+  /** Reset the accumulator. Preserves `enabled`. */
+  clear(): void;
+}
+
+/**
+ * Construct a harness. Reads `GITNEXUS_SHADOW_MODE` at construction time
+ * (not per-`record()` call) so repeated no-op records don't re-check the
+ * env var in the hot path.
+ */
+export function createShadowHarness(): ShadowHarness {
+  const enabled = parseShadowModeEnv(process.env['GITNEXUS_SHADOW_MODE']);
+
+  interface Accumulated {
+    readonly language: SupportedLanguages;
+    readonly diff: ShadowDiff;
+  }
+  const records: Accumulated[] = [];
+  const primaryByLanguage: Partial<Record<SupportedLanguages, PrimarySide>> = {};
+
+  const recordImpl = (input: ShadowRecordInput): void => {
+    if (!enabled) return;
+    const diff = diffResolutions(input.callsite, input.legacy, input.newResult);
+    records.push({ language: input.language, diff });
+    // Primary per-language is resolved by last-write. In practice a run
+    // is single-threaded with respect to flag readings, so this is
+    // deterministic; a language's primary cannot change mid-run.
+    primaryByLanguage[input.language] = input.primary;
+  };
+
+  const snapshotImpl = (now: Date = new Date()): ShadowParityReport => {
+    return aggregateDiffs(records, now);
+  };
+
+  const persistImpl = async (outputDir: string, now: Date = new Date()): Promise<string> => {
+    await fs.mkdir(outputDir, { recursive: true });
+    const report = snapshotImpl(now);
+    const runId = makeRunId(now);
+    const payload: PersistedShadowReport = {
+      schemaVersion: 1,
+      runId,
+      generatedAt: now.toISOString(),
+      primaryByLanguage,
+      report,
+    };
+    const json = JSON.stringify(payload, null, 2);
+    const perRunPath = path.join(outputDir, `${runId}.json`);
+    const latestPath = path.join(outputDir, 'latest.json');
+    await fs.writeFile(perRunPath, json, 'utf8');
+    await fs.writeFile(latestPath, json, 'utf8');
+    return perRunPath;
+  };
+
+  const clearImpl = (): void => {
+    records.length = 0;
+    for (const key of Object.keys(primaryByLanguage)) {
+      delete primaryByLanguage[key as SupportedLanguages];
+    }
+  };
+
+  return {
+    enabled,
+    record: recordImpl,
+    size: () => records.length,
+    snapshot: snapshotImpl,
+    persist: persistImpl,
+    clear: clearImpl,
+  };
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────
+
+/**
+ * Env-var parser for `GITNEXUS_SHADOW_MODE`. Accepts the same truthy
+ * conventions as `REGISTRY_PRIMARY_<LANG>` from #924: `'true'` / `'1'` /
+ * `'yes'`, case-insensitive, whitespace-trimmed. Anything else — including
+ * `undefined`, `''`, `'false'`, `'off'`, typos — is false.
+ */
+function parseShadowModeEnv(raw: string | undefined): boolean {
+  if (raw === undefined) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes';
+}
+
+/**
+ * Deterministic run id derived from the timestamp plus 4 random bytes
+ * of entropy. The timestamp comes first so files sort chronologically;
+ * the entropy suffix prevents collisions when multiple runs share a
+ * clock-second. Shape: `YYYYMMDD-HHMMSS-xxxxxxxx`.
+ */
+function makeRunId(now: Date): string {
+  const y = now.getUTCFullYear().toString().padStart(4, '0');
+  const m = (now.getUTCMonth() + 1).toString().padStart(2, '0');
+  const d = now.getUTCDate().toString().padStart(2, '0');
+  const h = now.getUTCHours().toString().padStart(2, '0');
+  const min = now.getUTCMinutes().toString().padStart(2, '0');
+  const s = now.getUTCSeconds().toString().padStart(2, '0');
+  const entropy = Math.floor(Math.random() * 0xffffffff)
+    .toString(16)
+    .padStart(8, '0');
+  return `${y}${m}${d}-${h}${min}${s}-${entropy}`;
+}

--- a/gitnexus/test/unit/scope-resolution/shadow-harness.test.ts
+++ b/gitnexus/test/unit/scope-resolution/shadow-harness.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for `shadow-harness` (RFC #909 Ring 2 PKG #923).
+ *
+ * Covers flag detection, record accumulation, aggregation, and JSON
+ * persistence (real fs in a per-test tmpdir).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  EvidenceWeights,
+  SupportedLanguages,
+  type Resolution,
+  type ShadowCallsite,
+  type SymbolDefinition,
+} from 'gitnexus-shared';
+import {
+  createShadowHarness,
+  type PersistedShadowReport,
+  type ShadowHarness,
+} from '../../../src/core/ingestion/shadow-harness.js';
+
+// ─── Env isolation — GITNEXUS_SHADOW_MODE bleeds between tests otherwise ──
+
+let savedEnv: string | undefined;
+beforeEach(() => {
+  savedEnv = process.env['GITNEXUS_SHADOW_MODE'];
+  delete process.env['GITNEXUS_SHADOW_MODE'];
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env['GITNEXUS_SHADOW_MODE'];
+  else process.env['GITNEXUS_SHADOW_MODE'] = savedEnv;
+});
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────
+
+const callsite = (filePath = 'a.ts', line = 1): ShadowCallsite => ({
+  filePath,
+  range: { startLine: line, startCol: 0, endLine: line, endCol: 10 },
+});
+
+const def = (nodeId: string): SymbolDefinition => ({
+  nodeId,
+  filePath: 'x.ts',
+  type: 'Class',
+});
+
+const resolution = (nodeId: string): Resolution => ({
+  def: def(nodeId),
+  confidence: EvidenceWeights.local,
+  evidence: [{ kind: 'local', weight: EvidenceWeights.local }],
+});
+
+function enable(): void {
+  process.env['GITNEXUS_SHADOW_MODE'] = 'true';
+}
+
+function freshHarness(): ShadowHarness {
+  return createShadowHarness();
+}
+
+// ─── Flag detection ───────────────────────────────────────────────────────
+
+describe('createShadowHarness: enabled flag', () => {
+  it('is disabled by default (no env var set)', () => {
+    expect(freshHarness().enabled).toBe(false);
+  });
+
+  it("is enabled when GITNEXUS_SHADOW_MODE is 'true' / '1' / 'yes' / case-insensitive", () => {
+    for (const value of ['true', '1', 'yes', 'TRUE', '  Yes  ']) {
+      process.env['GITNEXUS_SHADOW_MODE'] = value;
+      expect(freshHarness().enabled).toBe(true);
+    }
+  });
+
+  it('stays disabled for falsy-looking or typo values', () => {
+    for (const value of ['', 'false', '0', 'off', 'tru']) {
+      process.env['GITNEXUS_SHADOW_MODE'] = value;
+      expect(freshHarness().enabled).toBe(false);
+    }
+  });
+
+  it('record() is a no-op when disabled', () => {
+    const h = freshHarness(); // disabled
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite(),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'legacy',
+    });
+    expect(h.size()).toBe(0);
+  });
+
+  it('does NOT re-check the env var per call (constructed-once semantics)', () => {
+    const h = freshHarness(); // disabled at construction
+    process.env['GITNEXUS_SHADOW_MODE'] = 'true'; // flip AFTER construction
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite(),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'legacy',
+    });
+    // Still disabled — the harness captured its `enabled` at construction.
+    expect(h.size()).toBe(0);
+  });
+});
+
+// ─── Record + snapshot ────────────────────────────────────────────────────
+
+describe('record + snapshot', () => {
+  it('accumulates records across languages', () => {
+    enable();
+    const h = freshHarness();
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite(),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'legacy',
+    });
+    h.record({
+      language: SupportedLanguages.TypeScript,
+      callsite: callsite('b.ts'),
+      legacy: [resolution('def:b')],
+      newResult: [],
+      primary: 'registry',
+    });
+    expect(h.size()).toBe(2);
+  });
+
+  it('snapshot reports per-language rows with correct outcomes', () => {
+    enable();
+    const h = freshHarness();
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite(),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'legacy',
+    });
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite('a.py', 2),
+      legacy: [resolution('def:b')],
+      newResult: [],
+      primary: 'legacy',
+    });
+    const report = h.snapshot(new Date('2026-04-18T00:00:00Z'));
+    expect(report.perLanguage).toHaveLength(1);
+    const py = report.perLanguage[0]!;
+    expect(py.language).toBe(SupportedLanguages.Python);
+    expect(py.totalCalls).toBe(2);
+    expect(py.bothAgree).toBe(1);
+    expect(py.onlyLegacy).toBe(1);
+  });
+
+  it('snapshot is deterministic across repeated calls', () => {
+    enable();
+    const h = freshHarness();
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite(),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'legacy',
+    });
+    const now = new Date('2026-04-18T12:00:00Z');
+    const a = h.snapshot(now);
+    const b = h.snapshot(now);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('clear() resets the accumulator and primaryByLanguage', async () => {
+    enable();
+    const h = freshHarness();
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite(),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'registry',
+    });
+    expect(h.size()).toBe(1);
+    h.clear();
+    expect(h.size()).toBe(0);
+    // Verify primary is also cleared: persist after a fresh record with a
+    // different primary should reflect the new value only.
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite('a.py'),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'legacy',
+    });
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'gn-sh-clear-'));
+    try {
+      await h.persist(dir);
+      const payload = JSON.parse(fs.readFileSync(path.join(dir, 'latest.json'), 'utf8'));
+      expect(payload.primaryByLanguage.python).toBe('legacy');
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Persistence ──────────────────────────────────────────────────────────
+
+describe('persist', () => {
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'gn-shadow-harness-'));
+  });
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates outputDir if it does not exist', async () => {
+    enable();
+    const h = freshHarness();
+    const nested = path.join(tmpDir, 'nested', 'a', 'b');
+    await h.persist(nested);
+    expect(fs.existsSync(nested)).toBe(true);
+    expect(fs.existsSync(path.join(nested, 'latest.json'))).toBe(true);
+  });
+
+  it('writes BOTH a timestamped file and latest.json with the same payload', async () => {
+    enable();
+    const h = freshHarness();
+    h.record({
+      language: SupportedLanguages.Python,
+      callsite: callsite(),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'legacy',
+    });
+    const perRunPath = await h.persist(tmpDir, new Date('2026-04-18T12:34:56Z'));
+    const latestPath = path.join(tmpDir, 'latest.json');
+
+    expect(fs.existsSync(perRunPath)).toBe(true);
+    expect(fs.existsSync(latestPath)).toBe(true);
+    expect(fs.readFileSync(perRunPath, 'utf8')).toBe(fs.readFileSync(latestPath, 'utf8'));
+  });
+
+  it('persisted payload matches the schema v1 shape', async () => {
+    enable();
+    const h = freshHarness();
+    h.record({
+      language: SupportedLanguages.TypeScript,
+      callsite: callsite('a.ts'),
+      legacy: [resolution('def:a')],
+      newResult: [resolution('def:a')],
+      primary: 'registry',
+    });
+    const now = new Date('2026-04-18T00:00:00Z');
+    await h.persist(tmpDir, now);
+    const payload: PersistedShadowReport = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, 'latest.json'), 'utf8'),
+    );
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.runId).toMatch(/^\d{8}-\d{6}-[0-9a-f]{8}$/);
+    expect(payload.generatedAt).toBe('2026-04-18T00:00:00.000Z');
+    expect(payload.primaryByLanguage.typescript).toBe('registry');
+    expect(payload.report.overall.totalCalls).toBe(1);
+    expect(payload.report.overall.bothAgree).toBe(1);
+  });
+
+  it('runId embeds the run timestamp for chronological sorting', async () => {
+    enable();
+    const h1 = freshHarness();
+    const h2 = freshHarness();
+    const p1 = await h1.persist(tmpDir, new Date('2026-04-18T00:00:00Z'));
+    const p2 = await h2.persist(tmpDir, new Date('2026-04-18T01:00:00Z'));
+    // Timestamp prefix means the second file sorts after the first.
+    expect(path.basename(p2) > path.basename(p1)).toBe(true);
+  });
+
+  it('persists an empty report gracefully (no records, no error)', async () => {
+    enable();
+    const h = freshHarness();
+    await h.persist(tmpDir);
+    const payload = JSON.parse(fs.readFileSync(path.join(tmpDir, 'latest.json'), 'utf8'));
+    expect(payload.report.overall.totalCalls).toBe(0);
+    expect(payload.report.perLanguage).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #923. Side-car observability for the RFC #909 registry rollout. Callers that dual-run legacy-DAG + \`Registry.lookup\` feed result pairs into the harness; the harness diffs via shared \`diffResolutions\` (#918), aggregates via \`aggregateDiffs\`, and persists a per-language parity report that the static dashboard can render offline.

## What ships

### \`gitnexus/src/core/ingestion/shadow-harness.ts\` (new)

```ts
createShadowHarness(): ShadowHarness
```

| Method | Role |
|---|---|
| \`enabled\` | \`true\` iff \`GITNEXUS_SHADOW_MODE\` is truthy at construction. Captured once (no per-call env reads in the hot path) |
| \`record(input)\` | Accumulator. No-op when \`enabled === false\` (near-zero overhead) |
| \`size()\` | Diagnostic counter |
| \`snapshot(now?)\` | Deterministic \`ShadowParityReport\` from accumulated diffs |
| \`persist(dir, now?)\` | Writes BOTH \`<runId>.json\` + \`latest.json\`; creates dir if absent; returns per-run path |
| \`clear()\` | Resets accumulator; preserves \`enabled\` |

**Activation.** \`GITNEXUS_SHADOW_MODE\` accepts \`'true'\` / \`'1'\` / \`'yes'\` (case-insensitive, trimmed) — same truthy convention as \`REGISTRY_PRIMARY_<LANG>\` from #924. Typos fail-safe to off.

**Schema-versioned persistence**:

```jsonc
{
  "schemaVersion": 1,
  "runId": "YYYYMMDD-HHMMSS-xxxxxxxx",
  "generatedAt": "ISO 8601",
  "primaryByLanguage": { "python": "legacy", "typescript": "registry", ... },
  "report": { /* ShadowParityReport from #918 aggregateDiffs */ }
}
```

\`runId\` prefix is the timestamp (chronological sort); entropy suffix prevents clock-second collisions.

### \`gitnexus/shadow-parity-dashboard/index.html\` (new)

Minimal static dashboard — **one HTML file, zero build step, zero runtime deps**. Fetches \`./latest.json\` and renders:

- Overall summary cards: total calls / both agree / disagree / overall parity %
- Per-language table: language tag (\`primary: legacy\` or \`primary: registry\` pill) · total · agree · only-legacy · only-new · disagree · both-empty · parity %
- Parity cells color-coded: ≥95% green · ≥80% amber · <80% red
- Light/dark via \`prefers-color-scheme\`
- Graceful empty state when no records yet

Usage: \`cp .gitnexus/shadow-parity/latest.json gitnexus/shadow-parity-dashboard/ && open gitnexus/shadow-parity-dashboard/index.html\`

## Tests (14, all passing)

- **Flag detection** (5): default off · truthy variants · falsy/typo → off · \`record()\` no-op when disabled · constructed-once semantics (env flip after construction doesn't enable)
- **Record + snapshot** (4): multi-language accumulation · per-language row outcomes · snapshot determinism · \`clear()\` resets accumulator AND \`primaryByLanguage\`
- **Persistence** (5): mkdir-p on missing dir · per-run + latest.json match byte-for-byte · schema v1 shape verified · runId timestamp sorts chronologically · empty report persists gracefully

Per-test \`fs.mkdtemp\` tmpdirs keep parallel vitest runs isolated; \`GITNEXUS_SHADOW_MODE\` is saved/restored per-test.

## What's deliberately deferred (called out in docstring)

- **Dual-run dispatch.** The harness is a side-car — it does NOT invoke either resolution path. Call-processor integration that actually runs legacy + registry paths lands as a follow-up. Without that integration, \`record()\` is never called in production today. The harness is tested in isolation with synthetic inputs.
- **CI artifact publishing.** Config work to upload \`latest.json\` + dashboard HTML per CI run. The harness + dashboard are ready when the CI job wires in.
- **Fixture-level drill-down.** MVP dashboard shows per-language rows only; drill-down (AST snippet + evidence trace per divergent call) extends the static JSON format + dashboard JS in a focused follow-up.

## Verification

- \`tsc --noEmit\` clean (both \`gitnexus-shared\` and \`gitnexus\`)
- 14/14 new tests pass
- Full scope-resolution / shadow / model / flag suite: **335/335 pass**

## Part of

- Parent: #909
- Depends on (code): #917 (registries), #918 (diff + aggregate)
- **Unblocks**: Ring 3 language flips. The parity dashboard becomes the checkpoint before flipping \`REGISTRY_PRIMARY_<LANG>=true\` — once per-language parity stabilizes, the flip ships.