### PR TITLE
fix(embeddings): replace recursive AST traversal with iterative DFS

### DIFF
--- a/gitnexus/src/core/embeddings/ast-utils.ts
+++ b/gitnexus/src/core/embeddings/ast-utils.ts
@@ -64,16 +64,16 @@ const FUNCTION_LIKE_TYPES = new Set([
  * numbers don't apply.
  */
 export const findFunctionNode = (root: any): any | null => {
-  if (FUNCTION_LIKE_TYPES.has(root.type)) return root;
-
-  for (let i = 0; i < root.namedChildCount; i++) {
-    const child = root.namedChild(i);
-    if (!child) continue;
-    if (FUNCTION_LIKE_TYPES.has(child.type)) return child;
-    const found = findFunctionNode(child);
-    if (found) return found;
+  // Iterative DFS — avoids stack overflow on deeply nested ASTs.
+  const stack = [root];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (FUNCTION_LIKE_TYPES.has(node.type)) return node;
+    for (let i = node.namedChildCount - 1; i >= 0; i--) {
+      const child = node.namedChild(i);
+      if (child) stack.push(child);
+    }
   }
-
   return null;
 };
 
@@ -98,15 +98,15 @@ export const findDeclarationNode = (root: any): any | null => {
     'impl_item', // Rust: impl
   ]);
 
-  if (CLASS_LIKE_TYPES.has(root.type)) return root;
-
-  for (let i = 0; i < root.namedChildCount; i++) {
-    const child = root.namedChild(i);
-    if (!child) continue;
-    if (CLASS_LIKE_TYPES.has(child.type)) return child;
-    const found = findDeclarationNode(child);
-    if (found) return found;
+  // Iterative DFS — avoids stack overflow on deeply nested ASTs.
+  const stack = [root];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (CLASS_LIKE_TYPES.has(node.type)) return node;
+    for (let i = node.namedChildCount - 1; i >= 0; i--) {
+      const child = node.namedChild(i);
+      if (child) stack.push(child);
+    }
   }
-
   return null;
 };


### PR DESCRIPTION
## Summary           
                                                                                
  Replace recursive DFS with iterative DFS in `findFunctionNode` and                
  `findDeclarationNode` to eliminate stack overflow on deeply nested ASTs.
                                                                                    
  ## Motivation / context                                   
                                                                                    
  Both functions in `gitnexus/src/core/embeddings/ast-utils.ts` traversed the AST   
  tree via unbounded recursion. On deeply nested or auto-generated code (e.g.
  minified JS, generated protobuf classes), the call stack could be exhausted before
   traversal completed.                                     

  The problem is compounded by a gap in `analyze.ts`: `ensureHeap()` only re-execs  
  the process (and applies `--stack-size=4096`) when the heap is below the
  threshold. If a user already has a large heap configured via `NODE_OPTIONS`, the  
  guard exits early and `--stack-size` is never applied — leaving Node.js at its
  default ~984 KB stack.

  ## Areas touched

  - [x] `gitnexus/` (CLI / core / MCP server)                                       
  - [ ] `gitnexus-web/` (Vite / React UI)
  - [ ] `.github/` (workflows, actions)                                             
  - [ ] `eval/` or other tooling                                                    
  - [ ] Docs / agent config only
                                                                                    
  ## Scope & constraints                                    
                                                                                    
  **In scope**                                              

  - Convert `findFunctionNode` and `findDeclarationNode` to iterative DFS using an  
  explicit stack
  - Preserve original DFS traversal order (children pushed in reverse order)        
                                                                                    
  **Explicitly out of scope / not done here**
                                                                                    
  - Fixing the `ensureHeap()` guard to independently check for `--stack-size`       
  (separate concern, lower priority now that the root cause is fixed)
  - Other recursive traversals elsewhere in the codebase (`cobol-copy-expander.ts`  
  etc.)                                                                             
   
  ## Implementation notes                                                           
                                                            
  Children are pushed onto the explicit stack in reverse index order so the leftmost
   child is processed first, matching the original recursive behavior. The fix
  follows the same pattern already used in `resolve.ts` (`c3Linearize`), which has a
   comment explicitly noting the recursive version overflowed on deep Java/Android
  class hierarchies.

  ## Testing & verification

  - [x] `cd gitnexus && npx tsc --noEmit`                                           
  - [ ] `cd gitnexus && npm test`
  - [ ] `cd gitnexus && npm run test:integration`                                   
                                                                                    
  ## Risk & rollout                                                                 
                                                                                    
  Low risk — pure refactor, no behavior change. Both functions are used only during 
  the embedding pipeline (chunker and structural extractor); incorrect traversal
  order would surface as degraded embedding quality, not a crash.                   
                                                            
  ## Checklist

  - [x] PR body meets repo minimum length                                           
  - [x] No secrets, tokens, or machine-specific paths committed