### PR TITLE
fix: preserve comments and config in opencode.json during setup

### DIFF
--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -24,6 +24,7 @@
         "graphology-utils": "^2.3.0",
         "ignore": "^7.0.5",
         "js-yaml": "^4.1.1",
+        "jsonc-parser": "^3.3.1",
         "lru-cache": "^11.0.0",
         "mnemonist": "^0.40.3",
         "onnxruntime-node": "^1.24.0",
@@ -3613,6 +3614,12 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -65,6 +65,7 @@
     "graphology-utils": "^2.3.0",
     "ignore": "^7.0.5",
     "js-yaml": "^4.1.1",
+    "jsonc-parser": "^3.3.1",
     "lru-cache": "^11.0.0",
     "mnemonist": "^0.40.3",
     "onnxruntime-node": "^1.24.0",
@@ -92,7 +93,6 @@
     "tree-sitter-swift": "^0.6.0"
   },
   "devDependencies": {
-    "gitnexus-shared": "file:../gitnexus-shared",
     "@types/cli-progress": "^3.11.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
@@ -100,6 +100,7 @@
     "@types/node": "^20.0.0",
     "@types/uuid": "^10.0.0",
     "@vitest/coverage-v8": "^4.0.18",
+    "gitnexus-shared": "file:../gitnexus-shared",
     "tsx": "^4.0.0",
     "typescript": "^5.4.5",
     "vitest": "^4.0.18"

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -129,9 +129,19 @@ async function writeJsonFile(filePath: string, data: any): Promise<void> {
 }
 
 /**
+ * Detect indentation style from file content.
+ * Returns formatting options matching the file's existing style.
+ */
+function detectIndentation(raw: string): { tabSize: number; insertSpaces: boolean } {
+  const firstIndented = raw.match(/^( +|\t)/m);
+  if (!firstIndented) return { tabSize: 2, insertSpaces: true };
+  if (firstIndented[1] === '\t') return { tabSize: 1, insertSpaces: false };
+  return { tabSize: firstIndented[1].length, insertSpaces: true };
+}
+
+/**
  * Merge a key/value pair into a JSONC config file, preserving comments and formatting.
- * Falls back to JSON.parse + writeJsonFile for valid JSON that is not valid JSONC.
- * If the file is genuinely corrupt (not valid JSON or JSONC), leaves it untouched.
+ * If the file is genuinely corrupt (not valid JSONC), leaves it untouched.
  */
 async function mergeJsoncFile(
   filePath: string,
@@ -164,29 +174,14 @@ async function mergeJsoncFile(
   const tree = parseTree(raw, parseErrors);
 
   if (tree && tree.type === 'object' && parseErrors.length === 0) {
-    const detectedTabs = /^\t/m.test(raw);
-    const formattingOptions = detectedTabs
-      ? { tabSize: 1, insertSpaces: false }
-      : { tabSize: 2, insertSpaces: true };
+    const formattingOptions = detectIndentation(raw);
     const edits = modify(raw, keyPath, value, { formattingOptions });
     const result = applyEdits(raw, edits);
     await fs.writeFile(filePath, result, 'utf-8');
     return true;
   }
 
-  try {
-    const existing = JSON.parse(raw);
-    let parent = existing;
-    for (let i = 0; i < keyPath.length - 1; i++) {
-      if (!parent[keyPath[i]]) parent[keyPath[i]] = {};
-      parent = parent[keyPath[i]];
-    }
-    parent[keyPath[keyPath.length - 1]] = value;
-    await writeJsonFile(filePath, existing);
-    return true;
-  } catch {
-    return false;
-  }
+  return false;
 }
 
 /**

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -350,7 +350,9 @@ async function setupOpenCode(result: SetupResult): Promise<void> {
     if (ok) {
       result.configured.push('OpenCode');
     } else {
-      result.errors.push('OpenCode: opencode.json is corrupt — skipping to preserve existing content');
+      result.errors.push(
+        'OpenCode: opencode.json is corrupt — skipping to preserve existing content',
+      );
     }
   } catch (err: any) {
     result.errors.push(`OpenCode: ${err.message}`);

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -13,7 +13,7 @@ import { execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
 import { fileURLToPath } from 'url';
 import { glob } from 'glob';
-import { parseTree, modify, applyEdits } from 'jsonc-parser';
+import { parseTree, modify, applyEdits, ParseError } from 'jsonc-parser';
 import { getGlobalDir } from '../storage/repo-manager.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -130,7 +130,7 @@ async function writeJsonFile(filePath: string, data: any): Promise<void> {
 
 /**
  * Merge a key/value pair into a JSONC config file, preserving comments and formatting.
- * Falls back to readJsonFile + writeJsonFile for non-JSONC files that are valid JSON.
+ * Falls back to JSON.parse + writeJsonFile for valid JSON that is not valid JSONC.
  * If the file is genuinely corrupt (not valid JSON or JSONC), leaves it untouched.
  */
 async function mergeJsoncFile(
@@ -160,12 +160,15 @@ async function mergeJsoncFile(
     return true;
   }
 
-  const tree = parseTree(raw);
+  const parseErrors: ParseError[] = [];
+  const tree = parseTree(raw, parseErrors);
 
-  if (tree && tree.type === 'object' && (!(tree as any).errors || (tree as any).errors.length === 0)) {
-    const edits = modify(raw, keyPath, value, {
-      formattingOptions: { tabSize: 2, insertSpaces: true },
-    });
+  if (tree && tree.type === 'object' && parseErrors.length === 0) {
+    const detectedTabs = /^\t/m.test(raw);
+    const formattingOptions = detectedTabs
+      ? { tabSize: 1, insertSpaces: false }
+      : { tabSize: 2, insertSpaces: true };
+    const edits = modify(raw, keyPath, value, { formattingOptions });
     const result = applyEdits(raw, edits);
     await fs.writeFile(filePath, result, 'utf-8');
     return true;

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -13,6 +13,7 @@ import { execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
 import { fileURLToPath } from 'url';
 import { glob } from 'glob';
+import { parseTree, modify, applyEdits } from 'jsonc-parser';
 import { getGlobalDir } from '../storage/repo-manager.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,6 +77,23 @@ function getMcpEntry() {
 }
 
 /**
+ * OpenCode uses a different MCP format: { type: "local", command: [...] }
+ * where command is a flat array (command + args combined).
+ */
+function getOpenCodeMcpEntry() {
+  const bin = resolveGitnexusBin();
+
+  if (bin) {
+    return { type: 'local', command: [bin, 'mcp'] };
+  }
+
+  if (process.platform === 'win32') {
+    return { type: 'local', command: ['cmd', '/c', 'npx', '-y', 'gitnexus@latest', 'mcp'] };
+  }
+  return { type: 'local', command: ['npx', '-y', 'gitnexus@latest', 'mcp'] };
+}
+
+/**
  * Merge gitnexus entry into an existing MCP config JSON object.
  * Returns the updated config.
  */
@@ -108,6 +126,64 @@ async function readJsonFile(filePath: string): Promise<any | null> {
 async function writeJsonFile(filePath: string, data: any): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Merge a key/value pair into a JSONC config file, preserving comments and formatting.
+ * Falls back to readJsonFile + writeJsonFile for non-JSONC files that are valid JSON.
+ * If the file is genuinely corrupt (not valid JSON or JSONC), leaves it untouched.
+ */
+async function mergeJsoncFile(
+  filePath: string,
+  keyPath: string[],
+  value: unknown,
+): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch {
+    raw = '';
+  }
+
+  if (raw.trim().length === 0) {
+    const config: any = {};
+    let parent: any = config;
+    for (let i = 0; i < keyPath.length; i++) {
+      if (i === keyPath.length - 1) {
+        parent[keyPath[i]] = value;
+      } else {
+        parent[keyPath[i]] = {};
+        parent = parent[keyPath[i]];
+      }
+    }
+    await writeJsonFile(filePath, config);
+    return true;
+  }
+
+  const tree = parseTree(raw);
+
+  if (tree && tree.type === 'object' && (!(tree as any).errors || (tree as any).errors.length === 0)) {
+    const edits = modify(raw, keyPath, value, {
+      formattingOptions: { tabSize: 2, insertSpaces: true },
+    });
+    const result = applyEdits(raw, edits);
+    await fs.writeFile(filePath, result, 'utf-8');
+    return true;
+  }
+
+  try {
+    const existing = JSON.parse(raw);
+    let parent = existing;
+    for (let i = 0; i < keyPath.length - 1; i++) {
+      if (!parent[keyPath[i]]) parent[keyPath[i]] = {};
+      parent = parent[keyPath[i]];
+    }
+    parent[keyPath[keyPath.length - 1]] = value;
+    await writeJsonFile(filePath, existing);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -267,12 +343,12 @@ async function setupOpenCode(result: SetupResult): Promise<void> {
 
   const configPath = path.join(opencodeDir, 'opencode.json');
   try {
-    const existing = await readJsonFile(configPath);
-    const config = existing || {};
-    if (!config.mcp) config.mcp = {};
-    config.mcp.gitnexus = getMcpEntry();
-    await writeJsonFile(configPath, config);
-    result.configured.push('OpenCode');
+    const ok = await mergeJsoncFile(configPath, ['mcp', 'gitnexus'], getOpenCodeMcpEntry());
+    if (ok) {
+      result.configured.push('OpenCode');
+    } else {
+      result.errors.push('OpenCode: opencode.json is corrupt — skipping to preserve existing content');
+    }
   } catch (err: any) {
     result.errors.push(`OpenCode: ${err.message}`);
   }

--- a/gitnexus/test/unit/setup-jsonc.test.ts
+++ b/gitnexus/test/unit/setup-jsonc.test.ts
@@ -209,7 +209,8 @@ describe('setupOpenCode — JSONC preservation', () => {
     await setupCommand();
 
     const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
-    expect(raw).toContain('test');
+    expect(raw).toBe(corrupt);
+    expect(raw).not.toContain('gitnexus');
   });
 
   it('uses npx fallback format when gitnexus binary is not on PATH', async () => {

--- a/gitnexus/test/unit/setup-jsonc.test.ts
+++ b/gitnexus/test/unit/setup-jsonc.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { parse as parseJsonc } from 'jsonc-parser';
+
+const execFileMock = vi.fn((...args: any[]) => {
+  const callback = args.at(-1);
+  if (typeof callback === 'function') {
+    callback(null, '', '');
+  }
+});
+
+const execFileSyncMock = vi.fn(() => {
+  throw new Error('not found');
+});
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock,
+}));
+
+describe('setupOpenCode — JSONC preservation', () => {
+  let tempHome: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+  let platformDescriptor: PropertyDescriptor | undefined;
+
+  const setPlatform = (value: NodeJS.Platform) => {
+    Object.defineProperty(process, 'platform', {
+      value,
+      configurable: true,
+    });
+  };
+
+  const opencodeDir = () => path.join(tempHome, '.config', 'opencode');
+  const opencodeJsonPath = () => path.join(opencodeDir(), 'opencode.json');
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-opencode-jsonc-'));
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+
+    await fs.mkdir(opencodeDir(), { recursive: true });
+
+    platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    setPlatform('linux');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+
+    if (platformDescriptor) {
+      Object.defineProperty(process, 'platform', platformDescriptor);
+    }
+
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
+    await fs.rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('preserves line comments (//)', async () => {
+    const jsonc = `{
+  // This comment must survive
+  "model": "test"
+}`;
+    await fs.writeFile(opencodeJsonPath(), jsonc, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    expect(raw).toContain('This comment must survive');
+
+    const config = parseJsonc(raw);
+    expect(config.mcp.gitnexus).toBeDefined();
+    expect(config.model).toBe('test');
+  });
+
+  it('preserves block comments (/* */)', async () => {
+    const jsonc = `{
+  /* block comment */
+  "model": "test"
+}`;
+    await fs.writeFile(opencodeJsonPath(), jsonc, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    expect(raw).toContain('block comment');
+
+    const config = parseJsonc(raw);
+    expect(config.mcp.gitnexus).toBeDefined();
+    expect(config.model).toBe('test');
+  });
+
+  it('preserves trailing comments', async () => {
+    const jsonc = `{
+  "model": "test", // inline comment
+  "provider": "anthropic"
+}`;
+    await fs.writeFile(opencodeJsonPath(), jsonc, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    expect(raw).toContain('inline comment');
+
+    const config = parseJsonc(raw);
+    expect(config.model).toBe('test');
+    expect(config.provider).toBe('anthropic');
+    expect(config.mcp.gitnexus).toBeDefined();
+  });
+
+  it('handles plain JSON without comments (backwards compatible)', async () => {
+    const plain = JSON.stringify({ model: 'test', provider: 'openai' }, null, 2);
+    await fs.writeFile(opencodeJsonPath(), plain, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    const config = parseJsonc(raw);
+
+    expect(config.model).toBe('test');
+    expect(config.provider).toBe('openai');
+    expect(config.mcp.gitnexus).toBeDefined();
+  });
+
+  it('handles missing opencode.json (creates fresh)', async () => {
+    await fs.rm(opencodeJsonPath(), { force: true });
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    const config = parseJsonc(raw);
+
+    expect(config.mcp.gitnexus).toBeDefined();
+  });
+
+  it('preserves all existing top-level keys', async () => {
+    const jsonc = `{
+  // my config
+  "model": "claude-sonnet",
+  "instructions": "Be helpful",
+  "plugin": ["foo"],
+  "provider": "anthropic",
+  "mcp": { "other": { "command": "bar" } }
+}`;
+    await fs.writeFile(opencodeJsonPath(), jsonc, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    expect(raw).toContain('my config');
+
+    const config = parseJsonc(raw);
+    expect(config.model).toBe('claude-sonnet');
+    expect(config.instructions).toBe('Be helpful');
+    expect(config.plugin).toEqual(['foo']);
+    expect(config.provider).toBe('anthropic');
+    expect(config.mcp.other).toEqual({ command: 'bar' });
+    expect(config.mcp.gitnexus).toBeDefined();
+  });
+
+  it('updates existing gitnexus MCP entry without losing other keys', async () => {
+    execFileSyncMock.mockReturnValueOnce('/usr/local/bin/gitnexus\n');
+
+    const jsonc = `{
+  // config comment
+  "model": "test",
+  "mcp": {
+    "other": { "command": "keep" },
+    "gitnexus": { "command": "old-gitnexus", "args": ["old"] }
+  }
+}`;
+    await fs.writeFile(opencodeJsonPath(), jsonc, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    expect(raw).toContain('config comment');
+
+    const config = parseJsonc(raw);
+    expect(config.model).toBe('test');
+    expect(config.mcp.other).toEqual({ command: 'keep' });
+    expect(config.mcp.gitnexus).toEqual({
+      type: 'local',
+      command: ['/usr/local/bin/gitnexus', 'mcp'],
+    });
+  });
+
+  it('does not wipe corrupt file content', async () => {
+    const corrupt = '{ "model": "test" this is broken {{{';
+    await fs.writeFile(opencodeJsonPath(), corrupt, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    expect(raw).toContain('test');
+  });
+
+  it('uses npx fallback format when gitnexus binary is not on PATH', async () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    const jsonc = `{
+  "model": "test",
+  "mcp": {}
+}`;
+    await fs.writeFile(opencodeJsonPath(), jsonc, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    const config = parseJsonc(raw);
+
+    expect(config.mcp.gitnexus).toEqual({
+      type: 'local',
+      command: ['npx', '-y', 'gitnexus@latest', 'mcp'],
+    });
+  });
+
+  it('skips when ~/.config/opencode directory does not exist', async () => {
+    await fs.rm(opencodeDir(), { recursive: true, force: true });
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    await expect(fs.access(opencodeJsonPath())).rejects.toThrow();
+  });
+});

--- a/gitnexus/test/unit/setup-jsonc.test.ts
+++ b/gitnexus/test/unit/setup-jsonc.test.ts
@@ -236,6 +236,32 @@ describe('setupOpenCode — JSONC preservation', () => {
     });
   });
 
+  it('preserves tab indentation in existing file', async () => {
+    const tabbed = `{\n\t"model": "test"\n}`;
+    await fs.writeFile(opencodeJsonPath(), tabbed, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    expect(raw).toContain('\t"model"');
+    expect(raw).toContain('\t"gitnexus"');
+  });
+
+  it('preserves 4-space indentation in existing file', async () => {
+    const fourSpace = `{
+    "model": "test"
+}`;
+    await fs.writeFile(opencodeJsonPath(), fourSpace, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const raw = await fs.readFile(opencodeJsonPath(), 'utf-8');
+    const mcpLine = raw.split('\n').find((l) => l.includes('"gitnexus"'));
+    expect(mcpLine).toMatch(/^    /);
+  });
+
   it('skips when ~/.config/opencode directory does not exist', async () => {
     await fs.rm(opencodeDir(), { recursive: true, force: true });
 


### PR DESCRIPTION
## Summary

- Fix data-loss bug where `gitnexus setup` destroyed all content in `~/.config/opencode/opencode.json` by replacing the entire file when `JSON.parse` threw on JSONC comments
- Use `jsonc-parser` (Microsoft/VS Code library) to surgically merge the MCP entry while preserving comments, formatting, and all existing keys
- Update OpenCode MCP format to `{ type: "local", command: [...] }` (OpenCode's native format)

## Root Cause

`readJsonFile()` used `JSON.parse()` which throws on JSONC comments (`//` and `/* */`). The catch block returned `null`, then `setupOpenCode()` did `const config = existing || {}` — replacing the entire config with an empty object. Only `mcp.gitnexus` was added back, destroying everything else.

## Changes

- **`gitnexus/src/cli/setup.ts`**: Add `mergeJsoncFile()` using `jsonc-parser`'s `parseTree` → `modify` → `applyEdits` pipeline. Add `getOpenCodeMcpEntry()` for OpenCode's native MCP format. Replace the destructive `readJsonFile`+`writeJsonFile` path in `setupOpenCode()` with `mergeJsoncFile()`.
- **`gitnexus/test/unit/setup-jsonc.test.ts`**: 9 new tests covering JSONC comment preservation (line, block, trailing), plain JSON backwards compat, missing file creation, key preservation, entry update, corrupt file safety, and missing directory skip.
- **`gitnexus/package.json`**: Added `jsonc-parser@^3.3.1` dependency.

## Test Plan

- [x] `npx vitest run test/unit/setup-jsonc.test.ts` — 9/9 passing
- [x] `npx vitest run test/unit/setup.test.ts test/unit/setup-codex.test.ts` — 11/11 passing (no regression)
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npx vitest run test/unit/` — no new failures (4 pre-existing unrelated failures)