### PR TITLE
fix(group): bubble local-impact phase errors in groupImpact (#1004)

### DIFF
--- a/gitnexus/src/core/group/cross-impact.ts
+++ b/gitnexus/src/core/group/cross-impact.ts
@@ -380,24 +380,13 @@ export async function runGroupImpact(
 
   const localObj = local as Record<string, unknown> | null;
   if (localObj?.error && typeof localObj.error === 'string') {
-    const empty: GroupImpactResult = {
-      local,
-      group: name,
-      cross: [],
-      outOfScope: [],
-      truncated: false,
-      truncatedRepos: [],
-      summary: {
-        direct: 0,
-        processes_affected: 0,
-        modules_affected: 0,
-        cross_repo_hits: 0,
-      },
-      risk: 'UNKNOWN',
-      timeoutMs,
-      crossDepthWarning,
-    };
-    return empty;
+    // Fail closed: the local-impact phase errored (missing symbol, graph-load
+    // failure, thrown exception wrapped by safeLocalImpact, or port-returned
+    // `{ error }`). Do NOT wrap it into a zero-hit success payload — callers
+    // branch on top-level `error`, and a blast-radius tool reporting "no
+    // impact" on the failure path is a false negative on a safety-critical
+    // signal. Bubble the error so consumers treat it as a failure.
+    return { error: `Local impact failed for ${repoPath}: ${localObj.error}` };
   }
 
   if (servicePrefix) {

--- a/gitnexus/test/unit/group/cross-impact.test.ts
+++ b/gitnexus/test/unit/group/cross-impact.test.ts
@@ -149,6 +149,92 @@ describe('cross-impact', () => {
     }
   });
 
+  it('test_runGroupImpact_local_phase_error_bubbles_as_top_level_error', async () => {
+    // Regression for #1004: when the local-impact phase returns a structured
+    // `{ error: ... }` payload, groupImpact MUST surface it as a top-level
+    // `{ error }` instead of a zero-hit GroupImpactResult. Otherwise callers
+    // that branch on top-level `error` silently treat a failed analysis as
+    // "no impact across the group" — a false negative on the failure path
+    // of a blast-radius tool.
+    const { tmpDir, cleanup } = tmpGroup();
+    vi.stubEnv('GITNEXUS_HOME', tmpDir);
+    try {
+      const port: GroupToolPort = {
+        resolveRepo: vi.fn(async () => ({
+          id: 'be',
+          name: 'reg-be',
+          repoPath: '/r',
+          storagePath: '/r/.gitnexus',
+        })),
+        impact: vi.fn(async () => ({ error: 'symbol not found: Sym' })),
+        query: vi.fn(),
+        impactByUid: vi.fn(),
+        context: vi.fn(),
+      };
+      const r = await runGroupImpact(
+        { port, gitnexusDir: tmpDir },
+        {
+          name: 'g1',
+          repo: 'app/backend',
+          target: 'Sym',
+          direction: 'upstream',
+        },
+      );
+      expect('error' in r).toBe(true);
+      if ('error' in r) {
+        expect(r.error).toContain('symbol not found: Sym');
+        expect(r.error).toContain('app/backend');
+      }
+      // And ensure we didn't silently fall back to a zero-hit success payload.
+      expect((r as { summary?: unknown }).summary).toBeUndefined();
+      expect((r as { cross?: unknown }).cross).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+      cleanup();
+    }
+  });
+
+  it('test_runGroupImpact_local_phase_thrown_exception_bubbles_as_top_level_error', async () => {
+    // Companion to the #1004 regression: safeLocalImpact wraps thrown
+    // exceptions from port.impact() as `{ error }` payloads. Those must
+    // bubble to the caller as top-level errors too, not be swallowed into
+    // an empty success payload.
+    const { tmpDir, cleanup } = tmpGroup();
+    vi.stubEnv('GITNEXUS_HOME', tmpDir);
+    try {
+      const port: GroupToolPort = {
+        resolveRepo: vi.fn(async () => ({
+          id: 'be',
+          name: 'reg-be',
+          repoPath: '/r',
+          storagePath: '/r/.gitnexus',
+        })),
+        impact: vi.fn(async () => {
+          throw new Error('graph-load failure: .gitnexus missing');
+        }),
+        query: vi.fn(),
+        impactByUid: vi.fn(),
+        context: vi.fn(),
+      };
+      const r = await runGroupImpact(
+        { port, gitnexusDir: tmpDir },
+        {
+          name: 'g1',
+          repo: 'app/backend',
+          target: 'Sym',
+          direction: 'upstream',
+        },
+      );
+      expect('error' in r).toBe(true);
+      if ('error' in r) {
+        expect(r.error).toContain('graph-load failure');
+      }
+    } finally {
+      vi.unstubAllEnvs();
+      cleanup();
+    }
+  });
+
   it('test_runGroupImpact_bridge_schema_mismatch_returns_error', async () => {
     const { tmpDir, groupDir, cleanup } = tmpGroup();
     vi.stubEnv('GITNEXUS_HOME', tmpDir);


### PR DESCRIPTION
## Summary

Fixes #1004.

`runGroupImpact` (`gitnexus/src/core/group/cross-impact.ts:381-400`) was swallowing Phase 1 local-impact errors as **zero-hit success payloads**. When `safeLocalImpact` returned a structured `{ error: ... }` (missing symbol, graph-load failure, or an exception it wrapped from `port.impact()`), the function built a `GroupImpactResult` with `cross: []`, `outOfScope: []`, `summary.cross_repo_hits: 0`, `risk: 'UNKNOWN'` — and the error ended up buried inside `local`.

Callers branch on **top-level** `error` (CLI `gitnexus/src/cli/group.ts:241`, MCP wrapper in `local-backend.ts`). So a failed local impact surfaced as **"no impact across the group"** — a false negative on the failure path of a safety-critical blast-radius tool. Exactly the opposite of what the tool exists to do.

## Fix

Fail closed. Bubble the error as a top-level `{ error }` prefixed with the `repoPath` (so consumers can tell which group member failed), matching how `runGroupImpact` already handles `resolveGroupRepo`, `loadGroupConfig`, and `ensureBridgeReady` failures.

Chose **option 1 (bubble the error)** from the issue over option 2 (partial-result discriminant) because `runGroupImpact` only runs local impact for a **single** member repo at this point — the cross-repo fan-out happens later via the bridge, after `collectImpactSymbolUids` runs. There is no partial-success data to preserve on the local-phase failure path.

## Changes

- `gitnexus/src/core/group/cross-impact.ts` — replace the zero-hit empty `GroupImpactResult` branch with `return { error: \`Local impact failed for ${repoPath}: ${localObj.error}\` }`.
- `gitnexus/test/unit/group/cross-impact.test.ts` — two regression tests:
  - `test_runGroupImpact_local_phase_error_bubbles_as_top_level_error` — port returns `{ error: 'symbol not found: Sym' }`; asserts top-level `error` with repo prefix, and that `summary` / `cross` are **not** present (no zero-hit payload leak).
  - `test_runGroupImpact_local_phase_thrown_exception_bubbles_as_top_level_error` — port throws; `safeLocalImpact` wraps as `{ error }`; asserts it bubbles to top level too.

## Test plan

- [x] `npx tsc --noEmit` in `gitnexus/` — clean.
- [x] `npx vitest run test/unit/group/cross-impact.test.ts` — 9/9 passed (7 existing + 2 new).
- [x] `npx vitest run test/unit/group test/integration/group` — 316/316 passed across 23 files.
- [ ] Reviewer: confirm MCP tool description (`gitnexus_impact({repo: "@<group>"})`) doesn't need updating — public contract for successful payloads is unchanged; only the failure path changes from false-success to explicit error.

## Not in scope (per issue)

- Auditing `groupContracts`, `groupContext`, etc. for the same pattern — worth a follow-up scan but issue explicitly scopes it out.
- Option 2 (partial-result discriminant on `GroupImpactResult`) — not needed here; see rationale above.
