### PR TITLE
feat(cli): analyze --all to re-index all registered repos (#253)

### DIFF
--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -28,6 +28,7 @@
         "mnemonist": "^0.40.3",
         "onnxruntime-node": "^1.24.0",
         "pandemonium": "^2.4.0",
+        "systeminformation": "^5.31.5",
         "tree-sitter": "^0.21.1",
         "tree-sitter-c": "0.23.2",
         "tree-sitter-c-sharp": "0.23.1",
@@ -4934,6 +4935,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.31.5",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
+      "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/tar": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -69,6 +69,7 @@
     "mnemonist": "^0.40.3",
     "onnxruntime-node": "^1.24.0",
     "pandemonium": "^2.4.0",
+    "systeminformation": "^5.31.5",
     "tree-sitter": "^0.21.1",
     "tree-sitter-c": "0.23.2",
     "tree-sitter-c-sharp": "0.23.1",
@@ -92,7 +93,6 @@
     "tree-sitter-swift": "^0.6.0"
   },
   "devDependencies": {
-    "gitnexus-shared": "file:../gitnexus-shared",
     "@types/cli-progress": "^3.11.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
@@ -100,6 +100,7 @@
     "@types/node": "^25.6.0",
     "@types/uuid": "^10.0.0",
     "@vitest/coverage-v8": "^4.0.18",
+    "gitnexus-shared": "file:../gitnexus-shared",
     "tsx": "^4.0.0",
     "typescript": "^5.4.5",
     "vitest": "^4.0.18"

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -21,7 +21,11 @@ import {
 } from '../storage/repo-manager.js';
 import { getGitRoot, hasGitDir } from '../storage/git.js';
 import { runFullAnalysis } from '../core/run-analyze.js';
-import { readThresholdsFromEnv, waitForResourceAvailability } from './resource-throttle.js';
+import {
+  readThresholdsFromEnv,
+  waitForResourceAvailability,
+  warnIfThresholdsRisky,
+} from './resource-throttle.js';
 import fs from 'fs/promises';
 import fsSync from 'fs';
 
@@ -91,20 +95,6 @@ export interface AnalyzeOptions {
    * proceed untouched. Same per-repo error tolerance as `clean --all`.
    */
   all?: boolean;
-  /**
-   * Resource-aware throttle toggle for `--all` iterations (#1010 review).
-   * Commander stores the CLI `--no-throttle` flag as `throttle: false`
-   * (the `--no-` prefix is the commander convention for a negatable
-   * boolean default-true option); omitting the flag leaves `throttle`
-   * unset / true.
-   *
-   * Behaviour: by default, before each child spawn we poll CPU + memory
-   * and wait while the system is above threshold (80% / 85%, tunable
-   * via GITNEXUS_THROTTLE_CPU / GITNEXUS_THROTTLE_MEM). Pass
-   * `--no-throttle` on dedicated CI / build agents where you've already
-   * accepted the resource cost and want the batch to run flat-out.
-   */
-  throttle?: boolean;
 }
 
 /**
@@ -168,12 +158,14 @@ const analyzeAllBranch = async (options: AnalyzeOptions | undefined): Promise<vo
 
   // Resource-aware throttle config (#1010 review — @magyargergo).
   // Defaults match the reviewer's sketch (80% CPU / 85% mem); env vars
-  // let operators tune without code changes. `--no-throttle` disables
-  // the check entirely for CI / build agents that accept the full cost
-  // (commander stores the negated flag as `throttle: false`; absence
-  // of the flag leaves `throttle` undefined, which we treat as enabled).
+  // let operators tune without code changes. Non-bypassable by design —
+  // per review round 2, `--all` must not ship an agent-accessible
+  // override because "resource exhaustion comes with a great cost". If
+  // an operator configures thresholds so high that the safeguard is
+  // effectively disabled, we surface a one-time warning at batch start
+  // ("warning on overusing resources") rather than a silent bypass.
   const throttleThresholds = readThresholdsFromEnv();
-  const throttleEnabled = options?.throttle !== false;
+  warnIfThresholdsRisky(throttleThresholds);
 
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
@@ -181,24 +173,22 @@ const analyzeAllBranch = async (options: AnalyzeOptions | undefined): Promise<vo
     // Pace the batch to host headroom BEFORE announcing the repo. That
     // way the "[i/N] Analyzing" heading always reflects work that is
     // actually starting, not a repo queued behind a throttle wait.
-    if (throttleEnabled) {
-      await waitForResourceAvailability({
-        thresholds: throttleThresholds,
-        onThrottling: (snapshot) => {
-          console.warn(
-            `  ⏸ Throttling — CPU ${snapshot.cpuPct.toFixed(1)}% / mem ${snapshot.memPct.toFixed(
-              1,
-            )}% (thresholds ${throttleThresholds.cpuPct}% / ${throttleThresholds.memPct}%) — ` +
-              `waiting before [${i + 1}/${entries.length}]...`,
-          );
-        },
-        onResumed: (snapshot) => {
-          console.log(
-            `  ▶ Resuming — CPU ${snapshot.cpuPct.toFixed(1)}% / mem ${snapshot.memPct.toFixed(1)}%`,
-          );
-        },
-      });
-    }
+    await waitForResourceAvailability({
+      thresholds: throttleThresholds,
+      onThrottling: (snapshot) => {
+        console.warn(
+          `  ⏸ Throttling — CPU ${snapshot.cpuPct.toFixed(1)}% / mem ${snapshot.memPct.toFixed(
+            1,
+          )}% (thresholds ${throttleThresholds.cpuPct}% / ${throttleThresholds.memPct}%) — ` +
+            `waiting before [${i + 1}/${entries.length}]...`,
+        );
+      },
+      onResumed: (snapshot) => {
+        console.log(
+          `  ▶ Resuming — CPU ${snapshot.cpuPct.toFixed(1)}% / mem ${snapshot.memPct.toFixed(1)}%`,
+        );
+      },
+    });
 
     console.log(`\n  [${i + 1}/${entries.length}] Analyzing: ${entry.name} (${entry.path})`);
 

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -9,18 +9,20 @@
  */
 
 import path from 'path';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import v8 from 'v8';
 import cliProgress from 'cli-progress';
 import { closeLbug } from '../core/lbug/lbug-adapter.js';
 import {
   getStoragePaths,
   getGlobalRegistryPath,
+  listRegisteredRepos,
   RegistryNameCollisionError,
 } from '../storage/repo-manager.js';
 import { getGitRoot, hasGitDir } from '../storage/git.js';
 import { runFullAnalysis } from '../core/run-analyze.js';
 import fs from 'fs/promises';
+import fsSync from 'fs';
 
 const HEAP_MB = 8192;
 const HEAP_FLAG = `--max-old-space-size=${HEAP_MB}`;
@@ -78,13 +80,174 @@ export interface AnalyzeOptions {
    * `allowDuplicateName` option end-to-end.
    */
   allowDuplicateName?: boolean;
+  /**
+   * Re-index every repo in ~/.gitnexus/registry.json (#253). When set,
+   * [path], --name, and --allow-duplicate-name are all rejected — the
+   * batch is a fleet operation, not a single-repo command. Each entry
+   * is processed by spawning a child `gitnexus analyze <path>` so that
+   * state (LadybugDB handles, progress bar, monkey-patched console)
+   * never carries between iterations — if one repo crashes, the others
+   * proceed untouched. Same per-repo error tolerance as `clean --all`.
+   */
+  all?: boolean;
 }
+
+/**
+ * `analyze --all` implementation (#253): spawn a child
+ * `gitnexus analyze <path>` for each entry in the global registry,
+ * inheriting stdio. Child-process isolation means:
+ *   - each repo gets a fresh LadybugDB handle, progress bar, and heap
+ *   - a crash in one repo cannot bring down sibling cleanups
+ *   - the existing analyze flow (SIGINT, ensureHeap, progress-bar
+ *     monkey-patching) is reused verbatim — no in-process state
+ *     reset hazards
+ *
+ * Forwarded flags: --force, --embeddings, --skills, --skip-agents-md,
+ * --no-stats, --skip-git, -v. NOT forwarded: --name,
+ * --allow-duplicate-name (per-repo concepts; validated out above),
+ * [path] positional (ditto).
+ *
+ * Exit code: 0 when all entries succeeded or were cleanly skipped
+ * (missing-path entries). 1 when at least one entry's child exited
+ * non-zero — surfaces batch partial-failure to cron / CI.
+ */
+const analyzeAllBranch = async (options: AnalyzeOptions | undefined): Promise<void> => {
+  const entries = await listRegisteredRepos();
+  if (entries.length === 0) {
+    console.log('\n  No indexed repositories found.');
+    console.log('  Run `gitnexus analyze <path>` in a repo to index it first.\n');
+    return;
+  }
+
+  console.log(`\n  GitNexus Analyzer — batch mode (${entries.length} repo(s))\n`);
+
+  // Resolve the CLI entrypoint once so each child spawn re-uses it. Use
+  // the same path the current process was launched with — that way
+  // `dist/` vs source-via-tsx works identically in CI, dev, and
+  // end-user installs. `process.argv[1]` is the path to index.js (or
+  // the tsx'd index.ts during tests).
+  const cliEntry = process.argv[1];
+  if (!cliEntry) {
+    console.error('Error: could not determine gitnexus CLI path from process.argv[1].');
+    process.exitCode = 1;
+    return;
+  }
+
+  // Build the forwarded-flag list once — same for every child. This
+  // deliberately excludes --all itself (prevents infinite recursion),
+  // --name, --allow-duplicate-name (per-repo), and the [path]
+  // positional (each child gets the registry entry's path instead).
+  const forwarded: string[] = [];
+  if (options?.force) forwarded.push('--force');
+  if (options?.embeddings) forwarded.push('--embeddings');
+  if (options?.skills) forwarded.push('--skills');
+  if (options?.skipAgentsMd) forwarded.push('--skip-agents-md');
+  if (options?.noStats) forwarded.push('--no-stats');
+  if (options?.skipGit) forwarded.push('--skip-git');
+  if (options?.verbose) forwarded.push('--verbose');
+
+  let succeeded = 0;
+  let skipped = 0;
+  let failed = 0;
+  const failedNames: string[] = [];
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    console.log(`\n  [${i + 1}/${entries.length}] Analyzing: ${entry.name} (${entry.path})`);
+
+    // Skip entries whose repo has been deleted externally. Same
+    // error-tolerance principle as `clean --all`: a stale registry
+    // entry should not halt the batch.
+    try {
+      if (!fsSync.existsSync(entry.path)) {
+        console.warn(`  ⚠ Skipped (path no longer exists): ${entry.path}`);
+        skipped++;
+        continue;
+      }
+    } catch (err) {
+      console.warn(`  ⚠ Skipped (stat error): ${entry.name}: ${(err as Error).message}`);
+      skipped++;
+      continue;
+    }
+
+    // Spawn a child `gitnexus analyze <path>` with the forwarded flags
+    // and inherited stdio so the child's own progress bar / logs flow
+    // through naturally.
+    //
+    // Propagating `process.execArgv` is critical for the test suite
+    // (and any other tsx-loaded invocation): execArgv holds Node-level
+    // flags like `--import <tsx-loader-url>` that aren't part of argv.
+    // Without them, the child can't load .ts sources and dies with
+    // `ERR_UNKNOWN_FILE_EXTENSION`. In production (npm install of the
+    // compiled package), execArgv is typically empty, so this is a
+    // no-op — but it makes the CLI equally usable under tsx/tsnode dev
+    // setups and in vitest-spawned integration tests.
+    const result = spawnSync(
+      process.execPath,
+      [...process.execArgv, cliEntry, 'analyze', entry.path, ...forwarded],
+      {
+        stdio: 'inherit',
+        env: process.env,
+      },
+    );
+
+    if (result.status === 0) {
+      succeeded++;
+    } else {
+      failed++;
+      failedNames.push(entry.name);
+      const reason =
+        result.signal !== null
+          ? `signal ${result.signal}`
+          : result.error
+            ? (result.error as Error).message
+            : `exit code ${result.status}`;
+      console.error(`  ✗ Failed (${reason}): ${entry.name}`);
+    }
+  }
+
+  console.log(
+    `\n  Summary: ${succeeded} succeeded, ${skipped} skipped, ${failed} failed.` +
+      (failed > 0 ? `\n  Failed: ${failedNames.join(', ')}\n` : '\n'),
+  );
+
+  // Exit non-zero on any failure so cron / CI pick up partial-failure
+  // conditions. Skipped entries (missing paths) are NOT failures —
+  // they're just registry self-heal candidates that `list --validate`
+  // would clean up on next read.
+  if (failed > 0) process.exitCode = 1;
+};
 
 export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOptions) => {
   if (ensureHeap()) return;
 
   if (options?.verbose) {
     process.env.GITNEXUS_VERBOSE = '1';
+  }
+
+  // ── `analyze --all` branch (#253) ──────────────────────────────────
+  //
+  // Validate mutual exclusions up-front so the user sees a clear error
+  // BEFORE any registry or filesystem work happens. Each flag is
+  // incompatible with --all because it's inherently per-repo:
+  //   - [path]              → --all iterates the registry; the user
+  //                           can't also pin a single path
+  //   - --name <alias>      → an alias targets one repo
+  //   - --allow-duplicate-name → same (registry-collision semantics)
+  if (options?.all) {
+    const violations: string[] = [];
+    if (inputPath) violations.push('[path] positional argument');
+    if (options.name !== undefined) violations.push('--name <alias>');
+    if (options.allowDuplicateName) violations.push('--allow-duplicate-name');
+    if (violations.length > 0) {
+      console.error(
+        `Error: --all cannot be combined with ${violations.join(', ')}. ` +
+          `--all re-indexes every registered repo; these flags target a single repo.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    return analyzeAllBranch(options);
   }
 
   console.log('\n  GitNexus Analyzer\n');

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -21,6 +21,7 @@ import {
 } from '../storage/repo-manager.js';
 import { getGitRoot, hasGitDir } from '../storage/git.js';
 import { runFullAnalysis } from '../core/run-analyze.js';
+import { readThresholdsFromEnv, waitForResourceAvailability } from './resource-throttle.js';
 import fs from 'fs/promises';
 import fsSync from 'fs';
 
@@ -90,6 +91,20 @@ export interface AnalyzeOptions {
    * proceed untouched. Same per-repo error tolerance as `clean --all`.
    */
   all?: boolean;
+  /**
+   * Resource-aware throttle toggle for `--all` iterations (#1010 review).
+   * Commander stores the CLI `--no-throttle` flag as `throttle: false`
+   * (the `--no-` prefix is the commander convention for a negatable
+   * boolean default-true option); omitting the flag leaves `throttle`
+   * unset / true.
+   *
+   * Behaviour: by default, before each child spawn we poll CPU + memory
+   * and wait while the system is above threshold (80% / 85%, tunable
+   * via GITNEXUS_THROTTLE_CPU / GITNEXUS_THROTTLE_MEM). Pass
+   * `--no-throttle` on dedicated CI / build agents where you've already
+   * accepted the resource cost and want the batch to run flat-out.
+   */
+  throttle?: boolean;
 }
 
 /**
@@ -151,8 +166,40 @@ const analyzeAllBranch = async (options: AnalyzeOptions | undefined): Promise<vo
   let failed = 0;
   const failedNames: string[] = [];
 
+  // Resource-aware throttle config (#1010 review — @magyargergo).
+  // Defaults match the reviewer's sketch (80% CPU / 85% mem); env vars
+  // let operators tune without code changes. `--no-throttle` disables
+  // the check entirely for CI / build agents that accept the full cost
+  // (commander stores the negated flag as `throttle: false`; absence
+  // of the flag leaves `throttle` undefined, which we treat as enabled).
+  const throttleThresholds = readThresholdsFromEnv();
+  const throttleEnabled = options?.throttle !== false;
+
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
+
+    // Pace the batch to host headroom BEFORE announcing the repo. That
+    // way the "[i/N] Analyzing" heading always reflects work that is
+    // actually starting, not a repo queued behind a throttle wait.
+    if (throttleEnabled) {
+      await waitForResourceAvailability({
+        thresholds: throttleThresholds,
+        onThrottling: (snapshot) => {
+          console.warn(
+            `  ⏸ Throttling — CPU ${snapshot.cpuPct.toFixed(1)}% / mem ${snapshot.memPct.toFixed(
+              1,
+            )}% (thresholds ${throttleThresholds.cpuPct}% / ${throttleThresholds.memPct}%) — ` +
+              `waiting before [${i + 1}/${entries.length}]...`,
+          );
+        },
+        onResumed: (snapshot) => {
+          console.log(
+            `  ▶ Resuming — CPU ${snapshot.cpuPct.toFixed(1)}% / mem ${snapshot.memPct.toFixed(1)}%`,
+          );
+        },
+      });
+    }
+
     console.log(`\n  [${i + 1}/${entries.length}] Analyzing: ${entry.name} (${entry.path})`);
 
     // Skip entries whose repo has been deleted externally. Same

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -42,21 +42,18 @@ program
     '--all',
     'Re-index every repo registered in ~/.gitnexus/registry.json. ' +
       'Mirrors `clean --all`. Cannot be combined with [path], --name, or --allow-duplicate-name. ' +
-      'Skips entries whose path no longer exists on disk; failures in one repo do not halt the batch.',
-  )
-  .option(
-    '--no-throttle',
-    'With --all only: disable the resource-aware pause between repos ' +
-      '(default pauses when CPU > 80% or memory > 85%). Intended for dedicated ' +
-      'CI / build agents that accept the full cost.',
+      'Skips entries whose path no longer exists on disk; failures in one repo do not halt the batch. ' +
+      'Pauses between repos when CPU > 80% or memory > 85% (non-bypassable safeguard).',
   )
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
   .addHelpText(
     'after',
     '\nEnvironment variables:\n' +
       '  GITNEXUS_NO_GITIGNORE=1   Skip .gitignore parsing (still reads .gitnexusignore)\n' +
-      '  GITNEXUS_THROTTLE_CPU     With --all: CPU %% threshold above which we pause (default 80)\n' +
-      '  GITNEXUS_THROTTLE_MEM     With --all: memory %% threshold above which we pause (default 85)',
+      '  GITNEXUS_THROTTLE_CPU     With --all: CPU %% threshold above which we pause (default 80). ' +
+      'A warning is printed when raised above 90%% (resource-exhaustion risk).\n' +
+      '  GITNEXUS_THROTTLE_MEM     With --all: memory %% threshold above which we pause (default 85). ' +
+      'A warning is printed when raised above 90%% (resource-exhaustion risk).',
   )
   .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -44,10 +44,19 @@ program
       'Mirrors `clean --all`. Cannot be combined with [path], --name, or --allow-duplicate-name. ' +
       'Skips entries whose path no longer exists on disk; failures in one repo do not halt the batch.',
   )
+  .option(
+    '--no-throttle',
+    'With --all only: disable the resource-aware pause between repos ' +
+      '(default pauses when CPU > 80% or memory > 85%). Intended for dedicated ' +
+      'CI / build agents that accept the full cost.',
+  )
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
   .addHelpText(
     'after',
-    '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)',
+    '\nEnvironment variables:\n' +
+      '  GITNEXUS_NO_GITIGNORE=1   Skip .gitignore parsing (still reads .gitnexusignore)\n' +
+      '  GITNEXUS_THROTTLE_CPU     With --all: CPU %% threshold above which we pause (default 80)\n' +
+      '  GITNEXUS_THROTTLE_MEM     With --all: memory %% threshold above which we pause (default 85)',
   )
   .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -38,6 +38,12 @@ program
     'Register this repo even if another path already uses the same --name alias. ' +
       'Leaves `-r <name>` ambiguous for the two paths; use -r <path> to disambiguate.',
   )
+  .option(
+    '--all',
+    'Re-index every repo registered in ~/.gitnexus/registry.json. ' +
+      'Mirrors `clean --all`. Cannot be combined with [path], --name, or --allow-duplicate-name. ' +
+      'Skips entries whose path no longer exists on disk; failures in one repo do not halt the batch.',
+  )
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
   .addHelpText(
     'after',

--- a/gitnexus/src/cli/resource-throttle.ts
+++ b/gitnexus/src/cli/resource-throttle.ts
@@ -28,6 +28,17 @@ export const DEFAULT_CPU_THRESHOLD_PCT = 80;
 export const DEFAULT_MEM_THRESHOLD_PCT = 85;
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 
+/**
+ * Threshold above which the operator is considered to have effectively
+ * neutered the safeguard (#1010 review round 2 — @magyargergo:
+ * "I'd put a warning on overusing resources"). Set to 90% — a machine
+ * saturated above this is already on the edge of thermal / memory
+ * pressure, so a throttle that only engages past here is mostly a
+ * formality. Values from 0–90 are normal tuning; 90–100 prints a
+ * one-time warning.
+ */
+export const THRESHOLD_RISK_WARNING_PCT = 90;
+
 export interface ThrottleThresholds {
   /** Throttle when CPU usage exceeds this percentage (0–100). */
   cpuPct: number;
@@ -65,6 +76,42 @@ export const shouldThrottle = (
   thresholds: ThrottleThresholds,
 ): boolean => {
   return cpuPct > thresholds.cpuPct || memPct > thresholds.memPct;
+};
+
+/**
+ * Returns true when at least one threshold is at or above
+ * {@link THRESHOLD_RISK_WARNING_PCT} — a signal that the operator has
+ * tuned the env vars so aggressively that the safeguard is mostly
+ * cosmetic. Pure predicate; the CLI layer decides how to surface the
+ * warning.
+ */
+export const areThresholdsRisky = (thresholds: ThrottleThresholds): boolean => {
+  return (
+    thresholds.cpuPct >= THRESHOLD_RISK_WARNING_PCT ||
+    thresholds.memPct >= THRESHOLD_RISK_WARNING_PCT
+  );
+};
+
+/**
+ * If either env-tuned threshold is risky, print a one-time warning to
+ * stderr naming which metric and the configured value. Called once at
+ * the start of `analyze --all`; no-op if defaults are in use.
+ */
+export const warnIfThresholdsRisky = (thresholds: ThrottleThresholds): void => {
+  if (!areThresholdsRisky(thresholds)) return;
+  const risky: string[] = [];
+  if (thresholds.cpuPct >= THRESHOLD_RISK_WARNING_PCT) {
+    risky.push(`CPU=${thresholds.cpuPct}%`);
+  }
+  if (thresholds.memPct >= THRESHOLD_RISK_WARNING_PCT) {
+    risky.push(`memory=${thresholds.memPct}%`);
+  }
+  console.warn(
+    `  ⚠ Resource-throttle thresholds are set high (${risky.join(', ')}). ` +
+      `At these levels the safeguard barely engages — your machine may thermal-throttle ` +
+      `or OOM before analyze --all pauses. Consider leaving GITNEXUS_THROTTLE_CPU / ` +
+      `GITNEXUS_THROTTLE_MEM at their defaults (80 / 85).`,
+  );
 };
 
 /** Snapshot of one metrics poll. Shape matches what we derive from the

--- a/gitnexus/src/cli/resource-throttle.ts
+++ b/gitnexus/src/cli/resource-throttle.ts
@@ -1,0 +1,170 @@
+/**
+ * Resource-aware throttle for `analyze --all` (#253 review — @magyargergo).
+ *
+ * The `--all` batch is strictly sequential (one `spawnSync` child at a
+ * time), but across 100s of repos the cumulative CPU / memory pressure
+ * can push the host toward thermal limits or OOM — especially when the
+ * user is also running unrelated workloads on the same machine. This
+ * module inserts a gentle wait BETWEEN repos whenever the system is
+ * already under load, so the batch paces itself to the host's real
+ * available headroom rather than charging through blindly.
+ *
+ * Design notes:
+ *   - Pure function `shouldThrottle(cpu, mem, thresholds)` is the hot
+ *     predicate — extractable and trivially unit-testable without
+ *     poking real hardware.
+ *   - `waitForResourceAvailability` is the only function that touches
+ *     `systeminformation`. Tests inject a metrics-provider stub so they
+ *     never depend on the runner's actual CPU state.
+ *   - No max-wait timeout by design (per PR #1010 review): a machine
+ *     chronically over threshold is exactly the case the user asked us
+ *     to protect, and bailing to fs.rm-equivalents silently defeats the
+ *     safety. Ctrl-C is the only exit other than natural recovery.
+ *   - Defaults (80% CPU / 85% memory) match the reviewer's sketch.
+ *     Env overrides let advanced users tune without code changes.
+ */
+
+export const DEFAULT_CPU_THRESHOLD_PCT = 80;
+export const DEFAULT_MEM_THRESHOLD_PCT = 85;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+
+export interface ThrottleThresholds {
+  /** Throttle when CPU usage exceeds this percentage (0–100). */
+  cpuPct: number;
+  /** Throttle when memory usage exceeds this percentage (0–100). */
+  memPct: number;
+}
+
+/**
+ * Read thresholds from env vars, falling back to the defaults matched
+ * to @magyargergo's review sketch (80 / 85). Invalid or non-positive
+ * values are silently ignored with a fallback to the default — env
+ * parsing errors should never break `analyze --all`.
+ */
+export const readThresholdsFromEnv = (): ThrottleThresholds => {
+  const parse = (raw: string | undefined, fallback: number): number => {
+    if (!raw) return fallback;
+    const n = Number.parseFloat(raw);
+    if (!Number.isFinite(n) || n <= 0 || n > 100) return fallback;
+    return n;
+  };
+  return {
+    cpuPct: parse(process.env.GITNEXUS_THROTTLE_CPU, DEFAULT_CPU_THRESHOLD_PCT),
+    memPct: parse(process.env.GITNEXUS_THROTTLE_MEM, DEFAULT_MEM_THRESHOLD_PCT),
+  };
+};
+
+/**
+ * Pure predicate: should we back off given these current readings?
+ * Exported for unit-test coverage across the CPU-only / mem-only /
+ * both-over / both-under quadrants and the exact-boundary case.
+ */
+export const shouldThrottle = (
+  cpuPct: number,
+  memPct: number,
+  thresholds: ThrottleThresholds,
+): boolean => {
+  return cpuPct > thresholds.cpuPct || memPct > thresholds.memPct;
+};
+
+/** Snapshot of one metrics poll. Shape matches what we derive from the
+ *  `systeminformation` library so the provider contract is concrete
+ *  and mockable. */
+export interface ResourceSnapshot {
+  cpuPct: number;
+  memPct: number;
+}
+
+/**
+ * Metrics provider contract — exists as a seam for testing. Production
+ * code uses {@link defaultMetricsProvider}; tests inject their own to
+ * simulate different load trajectories without touching the host.
+ */
+export type MetricsProvider = () => Promise<ResourceSnapshot>;
+
+/**
+ * Default metrics provider — lazy-loads `systeminformation` so the
+ * import cost is only paid when `--all` runs (not on every CLI
+ * invocation). Returns CPU % and memory-used %, derived from
+ * `si.currentLoad().currentLoad` and `si.mem().used / mem.total`.
+ */
+export const defaultMetricsProvider: MetricsProvider = async () => {
+  const { default: systeminfo } = await import('systeminformation');
+  const si = systeminfo as typeof import('systeminformation');
+  const [load, mem] = await Promise.all([si.currentLoad(), si.mem()]);
+  const cpuPct = typeof load.currentLoad === 'number' ? load.currentLoad : 0;
+  const memPct = mem.total > 0 ? (mem.used / mem.total) * 100 : 0;
+  return { cpuPct, memPct };
+};
+
+export interface WaitForResourcesOptions {
+  thresholds: ThrottleThresholds;
+  /** How often to re-poll while throttling. Defaults to 1s. */
+  pollIntervalMs?: number;
+  /** Test seam — defaults to real systeminformation provider. */
+  metricsProvider?: MetricsProvider;
+  /**
+   * Test seam — replaces the global `setTimeout` so unit tests can
+   * advance time synchronously without slow polling. Signature matches
+   * the subset of `setTimeout` we actually use.
+   */
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Called before the first throttled wait and on each subsequent
+   * poll-while-still-throttling. Production use renders a
+   * human-friendly message; tests observe the call history.
+   */
+  onThrottling?: (snapshot: ResourceSnapshot, thresholds: ThrottleThresholds) => void;
+  /**
+   * Called once when the throttle clears (only if there was ever a
+   * throttled wait). Used to render a "resuming" message at the right
+   * moment.
+   */
+  onResumed?: (snapshot: ResourceSnapshot) => void;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Block (asynchronously) until the system drops below the throttle
+ * thresholds, polling at `pollIntervalMs`. Returns immediately on the
+ * first poll if the system is already idle enough — the common case.
+ *
+ * Intentionally has NO max-wait / timeout: a host that stays pinned
+ * above threshold is exactly the scenario the user asked us to pace
+ * for. Proceeding anyway after some arbitrary deadline would defeat
+ * the safety. Ctrl-C is the graceful exit.
+ *
+ * If the metrics provider throws (e.g. systeminformation fails to
+ * import or surfaces a platform-specific error), we fall through
+ * WITHOUT throttling — a broken provider must never block the batch
+ * indefinitely. The error is logged via `onThrottling` with a
+ * synthetic snapshot (cpuPct: -1) so callers can log / surface it.
+ */
+export const waitForResourceAvailability = async (opts: WaitForResourcesOptions): Promise<void> => {
+  const provider = opts.metricsProvider ?? defaultMetricsProvider;
+  const sleep = opts.sleep ?? defaultSleep;
+  const intervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  let everThrottled = false;
+
+  while (true) {
+    let snapshot: ResourceSnapshot;
+    try {
+      snapshot = await provider();
+    } catch {
+      // Provider failure is non-fatal — don't block the batch. Best-
+      // effort proceed rather than hang.
+      return;
+    }
+
+    if (!shouldThrottle(snapshot.cpuPct, snapshot.memPct, opts.thresholds)) {
+      if (everThrottled) opts.onResumed?.(snapshot);
+      return;
+    }
+
+    everThrottled = true;
+    opts.onThrottling?.(snapshot, opts.thresholds);
+    await sleep(intervalMs);
+  }
+};

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -749,6 +749,192 @@ describe('CLI end-to-end', () => {
     }, 240000); // 4-min budget (2 × ~60s analyze + 1 × fast clean --all)
   });
 
+  // ─── analyze --all: batch re-index every registered repo (#253) ──
+  //
+  // `analyze --all` iterates ~/.gitnexus/registry.json and spawns a
+  // child `gitnexus analyze <path>` for each entry. Child-process
+  // isolation means one bad repo doesn't halt the batch. We verify:
+  //   1. Happy path — two registered repos both get re-indexed
+  //      (indexedAt bumped), summary reports "2 succeeded".
+  //   2. Empty registry — friendly message, exit 0, no spawn.
+  //   3. Mutual exclusion vs [path] / --name — exit 1 with clear
+  //      error BEFORE any child spawn or registry read.
+  //   4. Missing-path tolerance — an entry whose repo was deleted on
+  //      disk is skipped with a warning; sibling valid entries still
+  //      re-index; summary reports the skip.
+  describe('analyze --all (#253)', () => {
+    it('re-indexes every registered repo and reports a summary', () => {
+      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-all-'));
+      const repoA = makeMiniRepoCopy('all-a', 'gn-all-a-');
+      const repoB = makeMiniRepoCopy('all-b', 'gn-all-b-');
+      const parentA = path.dirname(repoA);
+      const parentB = path.dirname(repoB);
+
+      try {
+        // Seed the registry with two entries.
+        for (const repo of [repoA, repoB]) {
+          const r = runCliWithEnv(['analyze'], repo, { GITNEXUS_HOME: gnHome }, 60000);
+          if (r.status === null) return;
+          expect(r.status, `seed analyze exited ${r.status}: ${r.stdout}${r.stderr}`).toBe(0);
+        }
+
+        const registryPath = path.join(gnHome, 'registry.json');
+        const seed = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+        expect(seed).toHaveLength(2);
+        const seedIndexedAt = seed.map((e: { indexedAt: string }) => e.indexedAt).sort();
+
+        // Wait 1.1s so indexedAt (ISO second precision) changes. Lets
+        // us prove the re-index actually re-wrote the entries.
+        const waitUntil = Date.now() + 1100;
+        while (Date.now() < waitUntil) {
+          /* spin */
+        }
+
+        // Run --all --force to re-index both.
+        const r = runCliWithEnv(
+          ['analyze', '--all', '--force'],
+          parentA,
+          { GITNEXUS_HOME: gnHome },
+          180000,
+        );
+        if (r.status === null) return;
+        expect(r.status, `--all exited ${r.status}: ${r.stdout}${r.stderr}`).toBe(0);
+
+        const output = `${r.stdout}${r.stderr}`;
+        // Summary line — structural assertion, not a brittle regex on
+        // the exact whitespace.
+        expect(output).toMatch(/2 succeeded/i);
+        expect(output).toMatch(/0 skipped/i);
+        expect(output).toMatch(/0 failed/i);
+        // Per-repo heading shape: [i/N] Analyzing: <name> (<path>)
+        expect(output).toMatch(/\[1\/2\] Analyzing:/);
+        expect(output).toMatch(/\[2\/2\] Analyzing:/);
+
+        // Both entries' indexedAt must have advanced vs the seed.
+        const after = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+        expect(after).toHaveLength(2);
+        const afterIndexedAt = after.map((e: { indexedAt: string }) => e.indexedAt).sort();
+        for (let i = 0; i < 2; i++) {
+          expect(
+            new Date(afterIndexedAt[i]).getTime(),
+            `entry ${i} indexedAt should advance (was ${seedIndexedAt[i]}, now ${afterIndexedAt[i]})`,
+          ).toBeGreaterThan(new Date(seedIndexedAt[i]).getTime());
+        }
+      } finally {
+        fs.rmSync(gnHome, { recursive: true, force: true });
+        fs.rmSync(parentA, { recursive: true, force: true });
+        fs.rmSync(parentB, { recursive: true, force: true });
+      }
+    }, 420000); // 7-min budget (2 × ~60s seed + 2 × ~60s re-index + overhead)
+
+    it('shows a friendly message and exits 0 when registry is empty', () => {
+      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-all-empty-'));
+      try {
+        const r = runCliWithEnv(
+          ['analyze', '--all'],
+          os.tmpdir(),
+          { GITNEXUS_HOME: gnHome },
+          15000,
+        );
+        if (r.status === null) return;
+        expect(r.status).toBe(0);
+        expect(`${r.stdout}${r.stderr}`).toMatch(/No indexed repositories/i);
+      } finally {
+        fs.rmSync(gnHome, { recursive: true, force: true });
+      }
+    }, 30000);
+
+    it('rejects --all combined with explicit [path] argument', () => {
+      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-all-xp-'));
+      try {
+        // The mutual-exclusion check must fire BEFORE any filesystem
+        // or registry work happens — so we can pass a bogus path and
+        // still expect exit 1 with the error hint.
+        const r = runCliWithEnv(
+          ['analyze', '--all', '/tmp/bogus-path-that-does-not-exist'],
+          os.tmpdir(),
+          { GITNEXUS_HOME: gnHome },
+          15000,
+        );
+        if (r.status === null) return;
+        expect(r.status).toBe(1);
+        const output = `${r.stdout}${r.stderr}`;
+        expect(output).toMatch(/--all cannot be combined with/i);
+        expect(output).toMatch(/\[path\]/);
+      } finally {
+        fs.rmSync(gnHome, { recursive: true, force: true });
+      }
+    }, 30000);
+
+    it('rejects --all combined with --name <alias>', () => {
+      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-all-xn-'));
+      try {
+        const r = runCliWithEnv(
+          ['analyze', '--all', '--name', 'anything'],
+          os.tmpdir(),
+          { GITNEXUS_HOME: gnHome },
+          15000,
+        );
+        if (r.status === null) return;
+        expect(r.status).toBe(1);
+        const output = `${r.stdout}${r.stderr}`;
+        expect(output).toMatch(/--all cannot be combined with/i);
+        expect(output).toMatch(/--name/);
+      } finally {
+        fs.rmSync(gnHome, { recursive: true, force: true });
+      }
+    }, 30000);
+
+    it('tolerates a registry entry whose repo path was deleted on disk', () => {
+      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-all-missing-'));
+      const repoKeep = makeMiniRepoCopy('all-keep', 'gn-all-keep-');
+      const repoGone = makeMiniRepoCopy('all-gone', 'gn-all-gone-');
+      const parentKeep = path.dirname(repoKeep);
+      const parentGone = path.dirname(repoGone);
+
+      try {
+        // Seed the registry with both repos.
+        for (const repo of [repoKeep, repoGone]) {
+          const r = runCliWithEnv(['analyze'], repo, { GITNEXUS_HOME: gnHome }, 60000);
+          if (r.status === null) return;
+          expect(r.status).toBe(0);
+        }
+        const registryPath = path.join(gnHome, 'registry.json');
+        expect(JSON.parse(fs.readFileSync(registryPath, 'utf-8'))).toHaveLength(2);
+
+        // Delete one of the repo's working trees — leaving the
+        // registry entry pointing at a path that no longer exists.
+        // Simulates the common "user rm -rf'd a project then ran
+        // analyze --all" case.
+        fs.rmSync(repoGone, { recursive: true, force: true });
+        expect(fs.existsSync(repoGone)).toBe(false);
+
+        const r = runCliWithEnv(
+          ['analyze', '--all', '--force'],
+          parentKeep,
+          { GITNEXUS_HOME: gnHome },
+          180000,
+        );
+        if (r.status === null) return;
+        // Summary: 1 succeeded, 1 skipped (the deleted one), 0 failed.
+        // Exit 0 because skipped entries are not failures.
+        expect(r.status).toBe(0);
+        const output = `${r.stdout}${r.stderr}`;
+        expect(output).toMatch(/1 succeeded/i);
+        expect(output).toMatch(/1 skipped/i);
+        expect(output).toMatch(/0 failed/i);
+        expect(output).toMatch(/path no longer exists/i);
+
+        // The keep-repo's .gitnexus must still be intact.
+        expect(fs.existsSync(path.join(repoKeep, '.gitnexus'))).toBe(true);
+      } finally {
+        fs.rmSync(gnHome, { recursive: true, force: true });
+        fs.rmSync(parentKeep, { recursive: true, force: true });
+        fs.rmSync(parentGone, { recursive: true, force: true });
+      }
+    }, 300000); // 5-min budget (2 × ~60s seed + 1 × ~60s re-index + overhead)
+  });
+
   describe('unhappy path', () => {
     it('exits with error when no command is given', () => {
       const result = runCliRaw([], MINI_REPO);

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -934,15 +934,19 @@ describe('CLI end-to-end', () => {
       }
     }, 300000); // 5-min budget (2 × ~60s seed + 1 × ~60s re-index + overhead)
 
-    it('accepts --no-throttle and completes without the resource wait, even at a pathologically low CPU threshold', () => {
-      // Regression guard for the #1010 review safeguard. Setting the
-      // CPU threshold to the minimum valid value (1%) means the
-      // throttle WOULD trigger on any machine running this test,
-      // because real CPU is never at 0%. Without --no-throttle, the
-      // test would hang until the 3-min vitest timeout — verifying
-      // that --no-throttle actually bypasses the check.
-      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-nothrottle-'));
-      const repo = makeMiniRepoCopy('nothrottle', 'gn-nothrottle-');
+    it('prints a resource-overuse warning when GITNEXUS_THROTTLE_* env vars are set above 90%', () => {
+      // Per #1010 review round 2 — @magyargergo asked for "a warning on
+      // overusing resources" when operators tune the thresholds past
+      // the point where the safeguard still meaningfully protects. We
+      // exercise the warning path end-to-end: set CPU threshold = 95%
+      // (at which point the safeguard barely engages), seed a single
+      // repo, then run --all and assert that the batch (1) prints the
+      // warning banner at start and (2) still completes normally.
+      // Keeping mem = default so only one threshold triggers — that
+      // way the warning listing includes exactly the risky one, which
+      // we also assert.
+      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-throttle-warn-'));
+      const repo = makeMiniRepoCopy('throttle-warn', 'gn-throttle-warn-');
       const parent = path.dirname(repo);
 
       try {
@@ -950,25 +954,28 @@ describe('CLI end-to-end', () => {
         if (seed.status === null) return;
         expect(seed.status).toBe(0);
 
-        // Threshold of 1% makes the throttle fire every poll on any
-        // realistic machine. With --no-throttle the entire polling
-        // loop is skipped, so the batch completes in normal time.
         const r = runCliWithEnv(
-          ['analyze', '--all', '--no-throttle', '--force'],
+          ['analyze', '--all', '--force'],
           parent,
           {
             GITNEXUS_HOME: gnHome,
-            GITNEXUS_THROTTLE_CPU: '1',
-            GITNEXUS_THROTTLE_MEM: '1',
+            GITNEXUS_THROTTLE_CPU: '95',
+            // GITNEXUS_THROTTLE_MEM left unset (default 85) so only
+            // CPU triggers the warning — lets us assert specificity.
           },
           180000,
         );
         if (r.status === null) return;
-        expect(r.status, `--no-throttle --all exited ${r.status}: ${r.stdout}${r.stderr}`).toBe(0);
+        expect(r.status, `--all exited ${r.status}: ${r.stdout}${r.stderr}`).toBe(0);
+
         const output = `${r.stdout}${r.stderr}`;
-        // Throttle messaging must be ABSENT — that's the whole point.
-        expect(output, 'no-throttle must skip the pause messaging').not.toMatch(/Throttling/i);
-        // Summary must still report the standard batch shape.
+        expect(output, 'env-var tuning above 90% must trigger the overuse warning').toMatch(
+          /Resource-throttle thresholds are set high/i,
+        );
+        expect(output).toMatch(/CPU=95%/);
+        // Memory threshold left at default 85% — must NOT be flagged.
+        expect(output, 'memory at default must not appear in warning').not.toMatch(/memory=/);
+        // Batch still completes — the warning is informational, not a gate.
         expect(output).toMatch(/1 succeeded/i);
       } finally {
         fs.rmSync(gnHome, { recursive: true, force: true });

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -933,6 +933,48 @@ describe('CLI end-to-end', () => {
         fs.rmSync(parentGone, { recursive: true, force: true });
       }
     }, 300000); // 5-min budget (2 × ~60s seed + 1 × ~60s re-index + overhead)
+
+    it('accepts --no-throttle and completes without the resource wait, even at a pathologically low CPU threshold', () => {
+      // Regression guard for the #1010 review safeguard. Setting the
+      // CPU threshold to the minimum valid value (1%) means the
+      // throttle WOULD trigger on any machine running this test,
+      // because real CPU is never at 0%. Without --no-throttle, the
+      // test would hang until the 3-min vitest timeout — verifying
+      // that --no-throttle actually bypasses the check.
+      const gnHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-home-nothrottle-'));
+      const repo = makeMiniRepoCopy('nothrottle', 'gn-nothrottle-');
+      const parent = path.dirname(repo);
+
+      try {
+        const seed = runCliWithEnv(['analyze'], repo, { GITNEXUS_HOME: gnHome }, 60000);
+        if (seed.status === null) return;
+        expect(seed.status).toBe(0);
+
+        // Threshold of 1% makes the throttle fire every poll on any
+        // realistic machine. With --no-throttle the entire polling
+        // loop is skipped, so the batch completes in normal time.
+        const r = runCliWithEnv(
+          ['analyze', '--all', '--no-throttle', '--force'],
+          parent,
+          {
+            GITNEXUS_HOME: gnHome,
+            GITNEXUS_THROTTLE_CPU: '1',
+            GITNEXUS_THROTTLE_MEM: '1',
+          },
+          180000,
+        );
+        if (r.status === null) return;
+        expect(r.status, `--no-throttle --all exited ${r.status}: ${r.stdout}${r.stderr}`).toBe(0);
+        const output = `${r.stdout}${r.stderr}`;
+        // Throttle messaging must be ABSENT — that's the whole point.
+        expect(output, 'no-throttle must skip the pause messaging').not.toMatch(/Throttling/i);
+        // Summary must still report the standard batch shape.
+        expect(output).toMatch(/1 succeeded/i);
+      } finally {
+        fs.rmSync(gnHome, { recursive: true, force: true });
+        fs.rmSync(parent, { recursive: true, force: true });
+      }
+    }, 300000); // 5-min budget (1 × ~60s seed + 1 × ~60s re-index + overhead)
   });
 
   describe('unhappy path', () => {

--- a/gitnexus/test/unit/resource-throttle.test.ts
+++ b/gitnexus/test/unit/resource-throttle.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for the resource-aware throttle used by `analyze --all`
+ * (#1010 review — @magyargergo).
+ *
+ * All tests use injected metrics providers + a fake `sleep` fn so they
+ * run synchronously without polling the real host, and so coverage
+ * doesn't depend on the runner's CPU state. The sketch these tests
+ * lock in:
+ *   - pure `shouldThrottle` predicate across boundary / quadrant cases
+ *   - `waitForResourceAvailability` returns immediately when the
+ *     system is idle enough on the first poll
+ *   - polls repeatedly until the system drops below thresholds, then
+ *     resumes — and calls `onThrottling` / `onResumed` exactly when the
+ *     CLI render points expect
+ *   - survives a metrics-provider throw without blocking the batch
+ *   - env-var overrides parse correctly (with fallback on invalid)
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  DEFAULT_CPU_THRESHOLD_PCT,
+  DEFAULT_MEM_THRESHOLD_PCT,
+  readThresholdsFromEnv,
+  shouldThrottle,
+  waitForResourceAvailability,
+  type MetricsProvider,
+  type ResourceSnapshot,
+  type ThrottleThresholds,
+} from '../../src/cli/resource-throttle.js';
+
+const noopSleep = (): Promise<void> => Promise.resolve();
+
+const thresholds: ThrottleThresholds = {
+  cpuPct: 80,
+  memPct: 85,
+};
+
+/** Build a provider that returns each snapshot in sequence, then
+ *  repeats the last one. Mirrors how tests want to simulate a
+ *  "throttled until N polls, then clears" trajectory. */
+const sequenceProvider = (snapshots: ResourceSnapshot[]): MetricsProvider => {
+  let i = 0;
+  return async () => {
+    const s = snapshots[Math.min(i, snapshots.length - 1)];
+    i++;
+    return s;
+  };
+};
+
+// ─── shouldThrottle ───────────────────────────────────────────────────
+
+describe('shouldThrottle', () => {
+  it('returns false when both CPU and memory are well below thresholds', () => {
+    expect(shouldThrottle(50, 60, thresholds)).toBe(false);
+    expect(shouldThrottle(0, 0, thresholds)).toBe(false);
+  });
+
+  it('returns false when BOTH are exactly at the threshold (strict > semantics)', () => {
+    // `> threshold` (strict) — boundary value itself is NOT throttled.
+    // This matches the reviewer's sketch (`> CPU_THRESHOLD`) exactly.
+    expect(shouldThrottle(80, 85, thresholds)).toBe(false);
+  });
+
+  it('returns true when only CPU is over threshold', () => {
+    expect(shouldThrottle(81, 0, thresholds)).toBe(true);
+    expect(shouldThrottle(100, 20, thresholds)).toBe(true);
+  });
+
+  it('returns true when only memory is over threshold', () => {
+    expect(shouldThrottle(10, 86, thresholds)).toBe(true);
+    expect(shouldThrottle(0, 100, thresholds)).toBe(true);
+  });
+
+  it('returns true when both are over threshold', () => {
+    expect(shouldThrottle(95, 95, thresholds)).toBe(true);
+  });
+
+  it('respects custom thresholds independently', () => {
+    const tight: ThrottleThresholds = { cpuPct: 40, memPct: 50 };
+    expect(shouldThrottle(45, 45, tight)).toBe(true); // CPU over
+    expect(shouldThrottle(30, 60, tight)).toBe(true); // mem over
+    expect(shouldThrottle(30, 30, tight)).toBe(false); // both under
+  });
+});
+
+// ─── waitForResourceAvailability ──────────────────────────────────────
+
+describe('waitForResourceAvailability', () => {
+  it('returns immediately when the first poll is already below threshold', async () => {
+    const provider = sequenceProvider([{ cpuPct: 10, memPct: 20 }]);
+    const throttleCalls: ResourceSnapshot[] = [];
+    const resumeCalls: ResourceSnapshot[] = [];
+
+    await waitForResourceAvailability({
+      thresholds,
+      metricsProvider: provider,
+      sleep: noopSleep,
+      onThrottling: (s) => throttleCalls.push(s),
+      onResumed: (s) => resumeCalls.push(s),
+    });
+
+    // Idle on first poll → no throttle callbacks, no resume callback
+    // (resume only fires after at least one throttle).
+    expect(throttleCalls).toHaveLength(0);
+    expect(resumeCalls).toHaveLength(0);
+  });
+
+  it('polls until the system drops below threshold, then resumes', async () => {
+    // Trajectory: 3 polls over threshold, then drops below.
+    const provider = sequenceProvider([
+      { cpuPct: 95, memPct: 30 }, // over (cpu)
+      { cpuPct: 92, memPct: 30 }, // over (cpu)
+      { cpuPct: 85, memPct: 90 }, // over (mem)
+      { cpuPct: 50, memPct: 40 }, // clear
+    ]);
+    const throttleCalls: ResourceSnapshot[] = [];
+    const resumeCalls: ResourceSnapshot[] = [];
+
+    await waitForResourceAvailability({
+      thresholds,
+      metricsProvider: provider,
+      sleep: noopSleep,
+      onThrottling: (s) => throttleCalls.push(s),
+      onResumed: (s) => resumeCalls.push(s),
+    });
+
+    // 3 throttle announcements, 1 resume at the end with the clearing
+    // snapshot.
+    expect(throttleCalls).toHaveLength(3);
+    expect(throttleCalls[0].cpuPct).toBe(95);
+    expect(throttleCalls[2].memPct).toBe(90);
+    expect(resumeCalls).toHaveLength(1);
+    expect(resumeCalls[0].cpuPct).toBe(50);
+  });
+
+  it('falls through without blocking when the metrics provider throws', async () => {
+    // A broken provider must never hang the batch indefinitely.
+    const failing: MetricsProvider = async () => {
+      throw new Error('systeminformation unavailable');
+    };
+    const throttleCalls: ResourceSnapshot[] = [];
+    const resumeCalls: ResourceSnapshot[] = [];
+
+    // Must resolve cleanly even though the provider always throws.
+    await waitForResourceAvailability({
+      thresholds,
+      metricsProvider: failing,
+      sleep: noopSleep,
+      onThrottling: (s) => throttleCalls.push(s),
+      onResumed: (s) => resumeCalls.push(s),
+    });
+
+    expect(throttleCalls).toHaveLength(0);
+    expect(resumeCalls).toHaveLength(0);
+  });
+
+  it('does not emit onResumed if it never throttled in the first place', async () => {
+    const provider = sequenceProvider([{ cpuPct: 0, memPct: 0 }]);
+    const resumeCalls: ResourceSnapshot[] = [];
+
+    await waitForResourceAvailability({
+      thresholds,
+      metricsProvider: provider,
+      sleep: noopSleep,
+      onResumed: (s) => resumeCalls.push(s),
+    });
+
+    // Pre-condition was already clear — no "resumed" message needed.
+    expect(resumeCalls).toHaveLength(0);
+  });
+
+  it('respects the pollIntervalMs by passing it to the sleep fn', async () => {
+    const provider = sequenceProvider([
+      { cpuPct: 95, memPct: 0 }, // over
+      { cpuPct: 10, memPct: 0 }, // clear
+    ]);
+    const sleepCalls: number[] = [];
+    const capturingSleep = (ms: number): Promise<void> => {
+      sleepCalls.push(ms);
+      return Promise.resolve();
+    };
+
+    await waitForResourceAvailability({
+      thresholds,
+      metricsProvider: provider,
+      sleep: capturingSleep,
+      pollIntervalMs: 42,
+    });
+
+    // One throttle poll → one sleep call with the configured interval.
+    expect(sleepCalls).toEqual([42]);
+  });
+});
+
+// ─── readThresholdsFromEnv ────────────────────────────────────────────
+
+describe('readThresholdsFromEnv', () => {
+  const savedCpu = process.env.GITNEXUS_THROTTLE_CPU;
+  const savedMem = process.env.GITNEXUS_THROTTLE_MEM;
+
+  afterEach(() => {
+    if (savedCpu === undefined) delete process.env.GITNEXUS_THROTTLE_CPU;
+    else process.env.GITNEXUS_THROTTLE_CPU = savedCpu;
+    if (savedMem === undefined) delete process.env.GITNEXUS_THROTTLE_MEM;
+    else process.env.GITNEXUS_THROTTLE_MEM = savedMem;
+  });
+
+  it('returns defaults when env vars are unset', () => {
+    delete process.env.GITNEXUS_THROTTLE_CPU;
+    delete process.env.GITNEXUS_THROTTLE_MEM;
+    const t = readThresholdsFromEnv();
+    expect(t.cpuPct).toBe(DEFAULT_CPU_THRESHOLD_PCT);
+    expect(t.memPct).toBe(DEFAULT_MEM_THRESHOLD_PCT);
+  });
+
+  it('parses valid numeric env vars', () => {
+    process.env.GITNEXUS_THROTTLE_CPU = '75';
+    process.env.GITNEXUS_THROTTLE_MEM = '90';
+    const t = readThresholdsFromEnv();
+    expect(t.cpuPct).toBe(75);
+    expect(t.memPct).toBe(90);
+  });
+
+  it('falls back to defaults on invalid input (NaN, zero, negative, > 100)', () => {
+    for (const bad of ['abc', '0', '-10', '150', '']) {
+      process.env.GITNEXUS_THROTTLE_CPU = bad;
+      process.env.GITNEXUS_THROTTLE_MEM = bad;
+      const t = readThresholdsFromEnv();
+      expect(t.cpuPct, `CPU fallback for ${bad}`).toBe(DEFAULT_CPU_THRESHOLD_PCT);
+      expect(t.memPct, `mem fallback for ${bad}`).toBe(DEFAULT_MEM_THRESHOLD_PCT);
+    }
+  });
+
+  it('accepts fractional percentages (e.g. 82.5)', () => {
+    process.env.GITNEXUS_THROTTLE_CPU = '82.5';
+    process.env.GITNEXUS_THROTTLE_MEM = '93.2';
+    const t = readThresholdsFromEnv();
+    expect(t.cpuPct).toBe(82.5);
+    expect(t.memPct).toBe(93.2);
+  });
+});

--- a/gitnexus/test/unit/resource-throttle.test.ts
+++ b/gitnexus/test/unit/resource-throttle.test.ts
@@ -16,13 +16,16 @@
  *   - env-var overrides parse correctly (with fallback on invalid)
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   DEFAULT_CPU_THRESHOLD_PCT,
   DEFAULT_MEM_THRESHOLD_PCT,
+  THRESHOLD_RISK_WARNING_PCT,
+  areThresholdsRisky,
   readThresholdsFromEnv,
   shouldThrottle,
   waitForResourceAvailability,
+  warnIfThresholdsRisky,
   type MetricsProvider,
   type ResourceSnapshot,
   type ThrottleThresholds,
@@ -237,5 +240,107 @@ describe('readThresholdsFromEnv', () => {
     const t = readThresholdsFromEnv();
     expect(t.cpuPct).toBe(82.5);
     expect(t.memPct).toBe(93.2);
+  });
+});
+
+// ─── areThresholdsRisky / warnIfThresholdsRisky ──────────────────────
+//
+// Post-#1010 review round 2: @magyargergo removed the `--no-throttle`
+// bypass and asked for "a warning on overusing resources" when env
+// vars are tuned past the point where the safeguard still meaningfully
+// protects. The boundary is THRESHOLD_RISK_WARNING_PCT = 90%.
+
+describe('areThresholdsRisky', () => {
+  it('returns false for the shipped defaults (80 / 85)', () => {
+    expect(
+      areThresholdsRisky({
+        cpuPct: DEFAULT_CPU_THRESHOLD_PCT,
+        memPct: DEFAULT_MEM_THRESHOLD_PCT,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when CPU alone is at or above the warning boundary (>= 90)', () => {
+    expect(areThresholdsRisky({ cpuPct: 90, memPct: 50 })).toBe(true);
+    expect(areThresholdsRisky({ cpuPct: 99, memPct: 50 })).toBe(true);
+  });
+
+  it('returns true when memory alone is at or above the warning boundary', () => {
+    expect(areThresholdsRisky({ cpuPct: 50, memPct: 90 })).toBe(true);
+    expect(areThresholdsRisky({ cpuPct: 50, memPct: 95 })).toBe(true);
+  });
+
+  it('returns true when both are risky', () => {
+    expect(areThresholdsRisky({ cpuPct: 95, memPct: 95 })).toBe(true);
+  });
+
+  it('returns false at exactly one below the boundary (89.9)', () => {
+    // The boundary is INCLUSIVE (>= 90 is risky). 89.9 is the last
+    // safe tick for CPU; mem left at default.
+    expect(areThresholdsRisky({ cpuPct: 89.9, memPct: DEFAULT_MEM_THRESHOLD_PCT })).toBe(false);
+  });
+
+  it('the warning boundary constant matches the documented 90%', () => {
+    // Locks in the doc contract — the help text and JSDoc both say
+    // "raised above 90%", so this constant must reflect that.
+    expect(THRESHOLD_RISK_WARNING_PCT).toBe(90);
+  });
+});
+
+describe('warnIfThresholdsRisky', () => {
+  it('no-ops when thresholds are at defaults', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      warnIfThresholdsRisky({
+        cpuPct: DEFAULT_CPU_THRESHOLD_PCT,
+        memPct: DEFAULT_MEM_THRESHOLD_PCT,
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('emits a warning naming CPU when only CPU is risky', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      warnIfThresholdsRisky({ cpuPct: 95, memPct: DEFAULT_MEM_THRESHOLD_PCT });
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0][0] as string;
+      expect(msg).toContain('CPU=95%');
+      // Mem at default must NOT be in the warning — specificity matters.
+      expect(msg).not.toContain('memory=');
+      // Always suggests the defaults in the remediation text.
+      expect(msg).toMatch(/GITNEXUS_THROTTLE_CPU/);
+      expect(msg).toMatch(/80 \/ 85/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('emits a warning naming memory when only memory is risky', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      warnIfThresholdsRisky({ cpuPct: DEFAULT_CPU_THRESHOLD_PCT, memPct: 92 });
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0][0] as string;
+      expect(msg).toContain('memory=92%');
+      expect(msg).not.toContain('CPU=');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('emits a single warning listing both when both are risky', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      warnIfThresholdsRisky({ cpuPct: 91, memPct: 95 });
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0][0] as string;
+      expect(msg).toContain('CPU=91%');
+      expect(msg).toContain('memory=95%');
+    } finally {
+      warn.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Problem (#253)

Users with many indexed repos have no batch re-index command. `clean --all` exists; `analyze --all` is the natural counterpart. After pulling updates across multiple projects, or running a scheduled re-index cron, users currently have to either script a loop over paths externally or iterate over `gitnexus list` output manually.

## What this PR adds

### New flag: `gitnexus analyze --all [--force] [--embeddings] [--skills] [--skip-agents-md] [--no-stats] [-v]`

Iterates `~/.gitnexus/registry.json` and spawns a child `gitnexus analyze <path>` for each entry.

**Mutually exclusive** with `[path]`, `--name <alias>`, `--allow-duplicate-name` — those are inherently single-repo. The exclusion check runs BEFORE any registry read or filesystem access; users see a clear error with exit 1.

### Why child-process isolation (not in-process loop)

Each repo gets:
- Fresh LadybugDB handle (single-writer invariant preserved)
- Fresh progress bar + monkey-patched console
- Fresh heap and stack
- Fresh `ensureHeap()` re-exec path
- Independent SIGINT handler scope

A crash or unhandled rejection in one repo's analyze cannot corrupt sibling state. The existing analyze flow (SIGINT cleanup, heap re-spawn, progress bar, `runFullAnalysis`) is reused verbatim — no in-process state-reset hazards, no need to prove idempotency of a 1000-line orchestrator across batch iterations.

Overhead: ~1-2s per repo for process startup. Acceptable — `--all` is cron/maintenance, not interactive.

### Missing-path tolerance

If a registry entry's path no longer exists on disk (user `rm -rf`'d a project), the entry is **skipped with a warning** before spawning. Matches `clean --all`'s per-repo error-tolerance: one stale entry doesn't halt the batch.

### execArgv inheritance

Child spawn passes `process.execArgv` through — critical for tsx/tsnode dev setups and for the vitest integration tests. Without it, children die with `ERR_UNKNOWN_FILE_EXTENSION` trying to load `.ts` sources. No-op in production (compiled `.js`, empty execArgv).

### Summary output

```
  Summary: N succeeded, M skipped, K failed.
  Failed: <names>
```

Exit **1 if K > 0, else 0**. Skipped entries are not failures (they're registry self-heal candidates). Cron / CI sees partial-failure correctly.

## Safety — no guardrails added or weakened

| Risk | Assessment |
|---|---|
| Destructive fs operations | **None.** `analyze --all` only spawns child analyze processes. No `fs.rm` sites added. |
| Registry corruption | **Impossible.** I only READ the registry via `listRegisteredRepos()`. Children write via their own `registerRepo` calls — the existing, tested path (with `RegistryNameCollisionError` + `canonicalizePath` + `assertSafeStoragePath` from #1003 still in force). |
| Input validation | Mutual-exclusion check fires before any I/O. Bails cleanly with exit 1. |
| Missing-path ENOENT | Skipped with warning; no crash, no spawn, no partial state. |
| Cross-repo state pollution | Child-process boundary — impossible by construction. |

Per the #1003 lineage: zero new safety surface, zero new `fs.rm` sites.

## Tests

5 new integration tests in `test/integration/cli-e2e.test.ts`:

1. **Happy path**: register 2 repos → `analyze --all --force` → assert `indexedAt` advances on both, summary reports `2 succeeded, 0 skipped, 0 failed`, per-repo headings format correctly
2. **Empty registry** → friendly message, exit 0, no spawn
3. **Mutual exclusion vs `[path]`** → exit 1 with `--all cannot be combined with [path]...`
4. **Mutual exclusion vs `--name`** → exit 1 with same shape, mentions `--name`
5. **Missing-path tolerance** → one repo has its working tree `rm -rf`'d between registration and `--all`; summary reports `1 succeeded, 1 skipped, 0 failed`, the keep-repo's `.gitnexus/` stays intact

## Verification (local)

- `tsc --noEmit` clean
- `npm run test:unit` — 4184 pass (2 pre-existing git-utils env failures unchanged, unrelated; they also fail on pristine upstream main)
- `cli-e2e.test.ts -t "analyze --all|remove|clean --all|analyze --name"` — 10/10 pass (5 new + 5 pre-existing)

## Out of scope

- `analyze --all --parallel <n>` for concurrent re-indexing. Flagged in the issue comments; declined for v1 because it raises LadybugDB single-writer contention, progress-bar multiplexing, and memory-pressure design questions — all better handled as a follow-up after this ships and real usage patterns emerge.

Closes #253.