### PR TITLE
fix(ci): Change docker base image from alpine to debian

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,8 @@ coverage
 .env.local
 .env.*.local
 
+**/*.tsbuildinfo
+
 .gitnexus
 gitnexus-web/playwright-report
 gitnexus-web/test-results

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 make g+
 COPY gitnexus-shared/package.json gitnexus-shared/package-lock.json ./gitnexus-shared/
 RUN npm ci --prefix gitnexus-shared
 COPY gitnexus-shared ./gitnexus-shared
+RUN rm -f gitnexus-shared/tsconfig.tsbuildinfo
 RUN npm run build --prefix gitnexus-shared
 
 # Copy the full gitnexus package before installing — `npm ci` triggers
@@ -29,6 +30,14 @@ RUN npm prune --omit=dev --prefix gitnexus
 
 # ── Runtime ────────────────────────────────────────────────────────────
 FROM node:22-slim AS runtime
+
+# @ladybugdb/core needs GLIBCXX_3.4.31 (GCC 13+); Bookworm only ships 3.4.30.
+# Pull libstdc++6 from Debian Trixie, then remove the source list so later
+# packages (curl, git) still come from stable Bookworm.
+RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends -t trixie libstdc++6 && \
+    rm /etc/apt/sources.list.d/trixie.list
 
 # curl for the healthcheck; git so `gitnexus` can clone repos at runtime.
 RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -4,7 +4,7 @@ ARG TARGETPLATFORM
 # ── Builder ────────────────────────────────────────────────────────────
 # Native modules (tree-sitter-*, onnxruntime-node, node-gyp builds for
 # tree-sitter-proto / tree-sitter-swift) require python3 + a C/C++ toolchain.
-FROM node:22-slim AS builder
+FROM node:22-trixie-slim AS builder
 
 WORKDIR /app
 
@@ -29,15 +29,7 @@ RUN npm ci --prefix gitnexus
 RUN npm prune --omit=dev --prefix gitnexus
 
 # ── Runtime ────────────────────────────────────────────────────────────
-FROM node:22-slim AS runtime
-
-# @ladybugdb/core needs GLIBCXX_3.4.31 (GCC 13+); Bookworm only ships 3.4.30.
-# Pull libstdc++6 from Debian Trixie, then remove the source list so later
-# packages (curl, git) still come from stable Bookworm.
-RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends -t trixie libstdc++6 && \
-    rm /etc/apt/sources.list.d/trixie.list
+FROM node:22-trixie-slim AS runtime
 
 # curl for the healthcheck; git so `gitnexus` can clone repos at runtime.
 RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -4,12 +4,12 @@ ARG TARGETPLATFORM
 # ── Builder ────────────────────────────────────────────────────────────
 # Native modules (tree-sitter-*, onnxruntime-node, node-gyp builds for
 # tree-sitter-proto / tree-sitter-swift) require python3 + a C/C++ toolchain.
-FROM node:22-alpine AS builder
+FROM node:22-slim AS builder
 
 WORKDIR /app
 
 # Toolchain for node-gyp / native builds.
-RUN apk add --no-cache python3 make g++ git
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ git && rm -rf /var/lib/apt/lists/*
 
 # Build gitnexus-shared first — gitnexus depends on it as a workspace.
 COPY gitnexus-shared/package.json gitnexus-shared/package-lock.json ./gitnexus-shared/
@@ -28,10 +28,10 @@ RUN npm ci --prefix gitnexus
 RUN npm prune --omit=dev --prefix gitnexus
 
 # ── Runtime ────────────────────────────────────────────────────────────
-FROM node:22-alpine AS runtime
+FROM node:22-slim AS runtime
 
 # curl for the healthcheck; git so `gitnexus` can clone repos at runtime.
-RUN apk add --no-cache curl git
+RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what does this PR change? -->

## Motivation / context

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [ ] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- <!-- bullets -->

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [ ] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [ ] No secrets, tokens, or machine-specific paths committed
