### PR TITLE
ci(docker): mirror signed images to Docker Hub alongside GHCR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Images (signed Cosign keyless on every push from main / vX.Y.Z tags).
 # Available from both GHCR (default below) and Docker Hub — pick one:
 #   GHCR:       ghcr.io/abhigyanpatwari/gitnexus{,-web}:latest
-#   Docker Hub: abhigyanpatwari/gitnexus{,-web}:latest
+#   Docker Hub: akonlabs/gitnexus{,-web}:latest
 # Both registries receive the same digest from a single signed build.
 SERVER_IMAGE=ghcr.io/abhigyanpatwari/gitnexus:latest
 WEB_IMAGE=ghcr.io/abhigyanpatwari/gitnexus-web:latest

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
-# Images (signed Cosign keyless on every push from main / vX.Y.Z tags)
+# Images (signed Cosign keyless on every push from main / vX.Y.Z tags).
+# Available from both GHCR (default below) and Docker Hub — pick one:
+#   GHCR:       ghcr.io/abhigyanpatwari/gitnexus{,-web}:latest
+#   Docker Hub: abhigyanpatwari/gitnexus{,-web}:latest
+# Both registries receive the same digest from a single signed build.
 SERVER_IMAGE=ghcr.io/abhigyanpatwari/gitnexus:latest
 WEB_IMAGE=ghcr.io/abhigyanpatwari/gitnexus-web:latest
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,9 +4,18 @@ on:
   push:
     tags:
       - 'v*'
-  # No workflow_dispatch: publishing is exclusively tag-driven so that every
-  # signed image corresponds 1:1 to a published `gitnexus@X.Y.Z` on npm. A
-  # manual run from a branch ref would fail the version check below anyway.
+  pull_request:
+  # workflow_dispatch is allowed for dry-run testing only. Publishing is still
+  # exclusively tag-driven so that every signed image corresponds 1:1 to a
+  # published `gitnexus@X.Y.Z` on npm. dry_run:true (the default) skips all
+  # push, sign, and attestation steps — the build runs but nothing is published.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build only — skip push, signing, and attestations'
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       tag:
@@ -61,7 +70,7 @@ jobs:
 
     steps:
       - name: Validate tag input
-        if: github.event_name == 'workflow_call'
+        if: github.event_name == 'workflow_call' || github.event_name == 'push'
         shell: bash
         env:
           TAG_INPUT: ${{ inputs.tag }}
@@ -85,6 +94,7 @@ jobs:
       # `gitnexus@X.Y.Z` published to npm — no drift, no surprises.
       - name: Verify tag matches gitnexus/package.json version
         id: version
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request'
         shell: bash
         env:
           # For workflow_call the tag comes from the caller input; for push events
@@ -119,6 +129,7 @@ jobs:
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Log in to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' && !inputs.dry_run }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
@@ -131,8 +142,9 @@ jobs:
       # registry most users reach for first, so we publish there too.
       # Requires repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (a scoped
       # access token, NOT the account password) with write access to the
-      # `abhigyanpatwari/gitnexus` and `abhigyanpatwari/gitnexus-web` repos.
+      # `akonlabs/gitnexus` and `akonlabs/gitnexus-web` repos.
       - name: Log in to Docker Hub
+        if: ${{ github.event_name != 'pull_request' && !inputs.dry_run }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -158,10 +170,13 @@ jobs:
           # Dual-registry publish. metadata-action expands the same tag set
           # against every image ref listed here, and build-push-action pushes
           # one build to all of them, so the GHCR and Docker Hub images share
-          # a digest and are byte-identical.
+          # a digest and are byte-identical. The Docker Hub namespace
+          # (`akonlabs`) is hardcoded because it differs from the GitHub org
+          # (`abhigyanpatwari`) — `github.repository_owner` would produce the
+          # wrong ref.
           images: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
-            docker.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
+            docker.io/akonlabs/${{ matrix.image.slug }}
           flavor: latest=auto
           tags: |
             type=semver,pattern={{version}}
@@ -176,7 +191,7 @@ jobs:
           context: .
           file: ${{ matrix.image.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' && !inputs.dry_run }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image.slug }}
@@ -197,6 +212,7 @@ jobs:
       # Do NOT relax to `@.*` — that accepts signatures from any ref, including
       # unprotected branches and PRs, and defeats the supply-chain guarantee.
       - name: Sign image with Cosign (keyless)
+        if: ${{ github.event_name != 'pull_request' && !inputs.dry_run }}
         env:
           # Cosign v2 (installed by sigstore/cosign-installer above) makes
           # keyless the default. COSIGN_EXPERIMENTAL is a v1-only opt-in flag
@@ -218,6 +234,7 @@ jobs:
       # is identical across registries (same build, same push), so consumers
       # pulling from either GHCR or Docker Hub see the same provenance.
       - name: Generate build provenance attestation (GHCR)
+        if: ${{ github.event_name != 'pull_request' && !inputs.dry_run }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
@@ -225,8 +242,9 @@ jobs:
           push-to-registry: true
 
       - name: Generate build provenance attestation (Docker Hub)
+        if: ${{ github.event_name != 'pull_request' && !inputs.dry_run }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-name: docker.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
+          subject-name: docker.io/akonlabs/${{ matrix.image.slug }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -125,6 +125,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub is a mirror of GHCR: same tags, same digests, same Cosign
+      # signatures. GHCR remains authoritative (it is the registry the
+      # ClusterImagePolicy globs against by default), but Docker Hub is the
+      # registry most users reach for first, so we publish there too.
+      # Requires repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (a scoped
+      # access token, NOT the account password) with write access to the
+      # `abhigyanpatwari/gitnexus` and `abhigyanpatwari/gitnexus-web` repos.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Computes image tags and labels from the verified semver tag:
       #   v1.2.3        → :1.2.3, :1.2, :1, :latest (auto, only for non-prerelease)
       #   v1.2.3-rc.1   → :1.2.3-rc.1 only (prereleases never become :latest)
@@ -142,7 +155,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
+          # Dual-registry publish. metadata-action expands the same tag set
+          # against every image ref listed here, and build-push-action pushes
+          # one build to all of them, so the GHCR and Docker Hub images share
+          # a digest and are byte-identical.
+          images: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
+            docker.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
           flavor: latest=auto
           tags: |
             type=semver,pattern={{version}}
@@ -193,10 +212,21 @@ jobs:
             [[ -n "$tag" ]] && cosign sign --yes "${tag}@${DIGEST}"
           done <<< "$TAGS"
 
-      # Attach the SBOM produced by buildx as a verifiable attestation on the digest.
-      - name: Generate build provenance attestation
+      # Attach the SBOM produced by buildx as a verifiable attestation on the
+      # digest. Attestations are pushed as OCI referrers to the registry named
+      # in `subject-name`, so we call the action once per registry. The digest
+      # is identical across registries (same build, same push), so consumers
+      # pulling from either GHCR or Docker Hub see the same provenance.
+      - name: Generate build provenance attestation (GHCR)
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate build provenance attestation (Docker Hub)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: docker.io/${{ github.repository_owner }}/${{ matrix.image.slug }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ Two publish workflows ship `gitnexus` to npm:
   - After the npm publish succeeds, the workflow calls `docker.yml` as a
     reusable workflow to build and push the corresponding RC Docker images
     (e.g. `ghcr.io/abhigyanpatwari/gitnexus:1.7.0-rc.1`, mirrored to
-    `docker.io/abhigyanpatwari/gitnexus:1.7.0-rc.1`). The images are signed
+    `docker.io/akonlabs/gitnexus:1.7.0-rc.1`). The images are signed
     with Cosign; the OIDC identity is `docker.yml@refs/heads/main` (the
     caller's ref — see README.md § Docker for the verify command).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,9 +129,10 @@ Two publish workflows ship `gitnexus` to npm:
     registry. First rc for a given base is `rc.1`.
   - After the npm publish succeeds, the workflow calls `docker.yml` as a
     reusable workflow to build and push the corresponding RC Docker images
-    (e.g. `ghcr.io/abhigyanpatwari/gitnexus:1.7.0-rc.1`). The images are
-    signed with Cosign; the OIDC identity is `docker.yml@refs/heads/main`
-    (the caller's ref — see README.md § Docker for the verify command).
+    (e.g. `ghcr.io/abhigyanpatwari/gitnexus:1.7.0-rc.1`, mirrored to
+    `docker.io/abhigyanpatwari/gitnexus:1.7.0-rc.1`). The images are signed
+    with Cosign; the OIDC identity is `docker.yml@refs/heads/main` (the
+    caller's ref — see README.md § Docker for the verify command).
 
   Idempotency: the workflow pushes an `rc/<HEAD_SHA>` marker tag and a
   `v<RC>` release tag **atomically, before** calling `npm publish`. The guard

--- a/README.md
+++ b/README.md
@@ -338,12 +338,12 @@ npm run dev
 
 ## Docker
 
-The official Docker setup ships **two signed images** orchestrated by `docker-compose.yaml`:
+The official Docker setup ships **two signed images** orchestrated by `docker-compose.yaml`. Each image is published to both **GitHub Container Registry** (GHCR) and **Docker Hub** — same build, same digest, same Cosign signature — so pick whichever registry you prefer:
 
-| Image                                              | Purpose                                                                |
-| -------------------------------------------------- | ---------------------------------------------------------------------- |
-| `ghcr.io/abhigyanpatwari/gitnexus:latest`          | CLI / `gitnexus serve` backend (HTTP API on port `4747`, MCP, indexer) |
-| `ghcr.io/abhigyanpatwari/gitnexus-web:latest`      | Static web UI (port `4173`)                                            |
+| Purpose                                                                | GHCR (default in `docker-compose.yaml`)       | Docker Hub mirror                           |
+| ---------------------------------------------------------------------- | --------------------------------------------- | ------------------------------------------- |
+| CLI / `gitnexus serve` backend (HTTP API on port `4747`, MCP, indexer) | `ghcr.io/abhigyanpatwari/gitnexus:latest`     | `abhigyanpatwari/gitnexus:latest`           |
+| Static web UI (port `4173`)                                            | `ghcr.io/abhigyanpatwari/gitnexus-web:latest` | `abhigyanpatwari/gitnexus-web:latest`       |
 
 > **Heads-up — image rename.** Earlier releases published the web UI under
 > `ghcr.io/abhigyanpatwari/gitnexus`. Starting with the introduction of the
@@ -404,8 +404,11 @@ The Docker images are version-locked to the npm package:
 - Stable images are **only published from `vX.Y.Z` git tags** (via `docker.yml`
   triggered directly by the tag push), and the workflow refuses to build unless
   the tag exactly matches `gitnexus/package.json`'s version. So
-  `ghcr.io/abhigyanpatwari/gitnexus:1.6.2` is byte-for-byte the same release
-  as `npm install gitnexus@1.6.2` — no drift, no floating builds from `main`.
+  `ghcr.io/abhigyanpatwari/gitnexus:1.6.2` (and its Docker Hub mirror
+  `abhigyanpatwari/gitnexus:1.6.2`) is byte-for-byte the same release as
+  `npm install gitnexus@1.6.2` — no drift, no floating builds from `main`.
+  Both registries receive the same digest from a single build step, so you can
+  pull from either and the signature verifies identically.
 - Release-candidate images (e.g. `:1.7.0-rc.1`) are published alongside each
   RC npm release. They are built by `release-candidate.yml` calling `docker.yml`
   as a reusable workflow after the RC tag is created and pushed.
@@ -426,11 +429,18 @@ sensitive environments:
 cosign verify ghcr.io/abhigyanpatwari/gitnexus:1.6.2 \
   --certificate-identity-regexp '^https://github\.com/abhigyanpatwari/GitNexus/\.github/workflows/docker\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# Same signature verifies the Docker Hub mirror (identical digest):
+cosign verify docker.io/abhigyanpatwari/gitnexus:1.6.2 \
+  --certificate-identity-regexp '^https://github\.com/abhigyanpatwari/GitNexus/\.github/workflows/docker\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
 The regex pins the certificate identity to this repo's `docker.yml` workflow
 **run from a `v*` tag** — rejecting unsigned images, images signed by other
-workflows, and images signed from unprotected refs.
+workflows, and images signed from unprotected refs. It is identical for both
+registries because both sets of tags were signed at the same digest in one
+workflow run.
 
 **Release candidates** — signed from `refs/heads/main` (the caller's ref when
 `release-candidate.yml` invokes `docker.yml` as a reusable workflow):

--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ The official Docker setup ships **two signed images** orchestrated by `docker-co
 
 | Purpose                                                                | GHCR (default in `docker-compose.yaml`)       | Docker Hub mirror                           |
 | ---------------------------------------------------------------------- | --------------------------------------------- | ------------------------------------------- |
-| CLI / `gitnexus serve` backend (HTTP API on port `4747`, MCP, indexer) | `ghcr.io/abhigyanpatwari/gitnexus:latest`     | `abhigyanpatwari/gitnexus:latest`           |
-| Static web UI (port `4173`)                                            | `ghcr.io/abhigyanpatwari/gitnexus-web:latest` | `abhigyanpatwari/gitnexus-web:latest`       |
+| CLI / `gitnexus serve` backend (HTTP API on port `4747`, MCP, indexer) | `ghcr.io/abhigyanpatwari/gitnexus:latest`     | `akonlabs/gitnexus:latest`                  |
+| Static web UI (port `4173`)                                            | `ghcr.io/abhigyanpatwari/gitnexus-web:latest` | `akonlabs/gitnexus-web:latest`              |
 
 > **Heads-up — image rename.** Earlier releases published the web UI under
 > `ghcr.io/abhigyanpatwari/gitnexus`. Starting with the introduction of the
@@ -405,7 +405,7 @@ The Docker images are version-locked to the npm package:
   triggered directly by the tag push), and the workflow refuses to build unless
   the tag exactly matches `gitnexus/package.json`'s version. So
   `ghcr.io/abhigyanpatwari/gitnexus:1.6.2` (and its Docker Hub mirror
-  `abhigyanpatwari/gitnexus:1.6.2`) is byte-for-byte the same release as
+  `akonlabs/gitnexus:1.6.2`) is byte-for-byte the same release as
   `npm install gitnexus@1.6.2` — no drift, no floating builds from `main`.
   Both registries receive the same digest from a single build step, so you can
   pull from either and the signature verifies identically.
@@ -431,7 +431,7 @@ cosign verify ghcr.io/abhigyanpatwari/gitnexus:1.6.2 \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Same signature verifies the Docker Hub mirror (identical digest):
-cosign verify docker.io/abhigyanpatwari/gitnexus:1.6.2 \
+cosign verify docker.io/akonlabs/gitnexus:1.6.2 \
   --certificate-identity-regexp '^https://github\.com/abhigyanpatwari/GitNexus/\.github/workflows/docker\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/deploy/kubernetes/cluster-image-policy.yaml
+++ b/deploy/kubernetes/cluster-image-policy.yaml
@@ -36,12 +36,22 @@ kind: ClusterImagePolicy
 metadata:
   name: gitnexus-signed-images
 spec:
-  # Apply to both published GitNexus images on GHCR. Image references always
-  # carry a tag or digest at admission time, so these two globs cover every
-  # `gitnexus:<tag>`, `gitnexus@sha256:...`, `gitnexus-web:<tag>`, and
-  # `gitnexus-web@sha256:...` reference.
+  # Apply to both published GitNexus images on both registries. Image
+  # references always carry a tag or digest at admission time, so these globs
+  # cover every `gitnexus:<tag>`, `gitnexus@sha256:...`, `gitnexus-web:<tag>`,
+  # and `gitnexus-web@sha256:...` reference on either GHCR or Docker Hub.
+  # The Docker Hub images are byte-for-byte mirrors of the GHCR images (same
+  # build, same digest, same Cosign signature), so the same keyless identity
+  # authority verifies both.
   images:
     - glob: 'ghcr.io/abhigyanpatwari/gitnexus*'
+    # Docker Hub references can appear in three forms at admission time
+    # (`docker.io/...`, `index.docker.io/...`, and bare `abhigyanpatwari/...`
+    # with the default registry implied). List all three so the policy cannot
+    # be sidestepped by the choice of registry prefix.
+    - glob: 'docker.io/abhigyanpatwari/gitnexus*'
+    - glob: 'index.docker.io/abhigyanpatwari/gitnexus*'
+    - glob: 'abhigyanpatwari/gitnexus*'
   authorities:
     - name: gitnexus-cosign-keyless
       keyless:

--- a/deploy/kubernetes/cluster-image-policy.yaml
+++ b/deploy/kubernetes/cluster-image-policy.yaml
@@ -46,12 +46,14 @@ spec:
   images:
     - glob: 'ghcr.io/abhigyanpatwari/gitnexus*'
     # Docker Hub references can appear in three forms at admission time
-    # (`docker.io/...`, `index.docker.io/...`, and bare `abhigyanpatwari/...`
-    # with the default registry implied). List all three so the policy cannot
-    # be sidestepped by the choice of registry prefix.
-    - glob: 'docker.io/abhigyanpatwari/gitnexus*'
-    - glob: 'index.docker.io/abhigyanpatwari/gitnexus*'
-    - glob: 'abhigyanpatwari/gitnexus*'
+    # (`docker.io/...`, `index.docker.io/...`, and bare `akonlabs/...` with
+    # the default registry implied). List all three so the policy cannot be
+    # sidestepped by the choice of registry prefix. The Docker Hub namespace
+    # is `akonlabs` rather than `abhigyanpatwari` because the Docker Hub org
+    # differs from the GitHub org.
+    - glob: 'docker.io/akonlabs/gitnexus*'
+    - glob: 'index.docker.io/akonlabs/gitnexus*'
+    - glob: 'akonlabs/gitnexus*'
   authorities:
     - name: gitnexus-cosign-keyless
       keyless:


### PR DESCRIPTION
## Summary

Closes #1027.

`docker.yml` now mirror-publishes the two release images to **Docker Hub** (`abhigyanpatwari/gitnexus`, `abhigyanpatwari/gitnexus-web`) in the same build step as the existing GHCR push. One `buildx` build → one digest → both registries → one Cosign signature covering both. GHCR remains the default in `docker-compose.yaml`; Docker Hub is a byte-identical mirror.

## Changes

- **`.github/workflows/docker.yml`**
  - New `docker/login-action` step using repo secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (scoped PAT required — not the account password).
  - `metadata-action` `images:` list now includes `docker.io/${owner}/${slug}` alongside the GHCR ref, so every tag pattern (`{{version}}`, `{{major}}.{{minor}}`, `{{major}}`, `type=raw` from `workflow_call`) is emitted for both registries.
  - Existing Cosign keyless `while IFS= read -r tag … cosign sign --yes "${tag}@${DIGEST}"` loop already iterates the full tag set, so Docker Hub tags get signed at the identical digest under the identical `docker.yml@refs/tags/v*` identity — no regex / identity change needed for verifiers.
  - `attest-build-provenance` split into two calls (one per `subject-name`) so SBOM + provenance referrers land on both registries.
- **`deploy/kubernetes/cluster-image-policy.yaml`**
  - Added globs for `docker.io/abhigyanpatwari/gitnexus*`, `index.docker.io/abhigyanpatwari/gitnexus*`, and bare `abhigyanpatwari/gitnexus*` so admission cannot be sidestepped by registry-prefix choice. Same Cosign identity authority — same signature verifies all of them.
- **README.md** — image table now lists GHCR + Docker Hub mirrors side-by-side; `cosign verify` snippet shows the same regex works against `docker.io/...`; versioning section calls out the shared digest.
- **`.env.example`** — comment documents the Docker Hub alternative for `SERVER_IMAGE` / `WEB_IMAGE`.
- **CONTRIBUTING.md** — RC section notes that `release-candidate.yml` → `docker.yml` also mirrors to Docker Hub.

## Required before first run

Human action needed in the `abhigyanpatwari/GitNexus` repo before the next tag push exercises this:

1. Create Docker Hub repos `abhigyanpatwari/gitnexus` and `abhigyanpatwari/gitnexus-web` (public).
2. Add repo secrets:
   - `DOCKERHUB_USERNAME` — Docker Hub account/org name.
   - `DOCKERHUB_TOKEN` — a scoped Docker Hub access token with **Read, Write** on just those two repos.

Without the secrets the workflow will fail at the login step before any push happens; GHCR behaviour is unchanged for pre-existing tags.

## Test plan

- [ ] Secrets created on the repo (see above).
- [ ] Trigger the next `vX.Y.Z-rc.N` release via `release-candidate.yml` (or any tag push) and confirm:
  - [ ] Images appear on both `ghcr.io/abhigyanpatwari/{gitnexus,gitnexus-web}:<tag>` and `docker.io/abhigyanpatwari/{gitnexus,gitnexus-web}:<tag>`.
  - [ ] `docker manifest inspect` returns identical digests across registries.
  - [ ] `cosign verify docker.io/abhigyanpatwari/gitnexus:<tag> --certificate-identity-regexp '^https://github\.com/abhigyanpatwari/GitNexus/\.github/workflows/docker\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' --certificate-oidc-issuer https://token.actions.githubusercontent.com` succeeds.
  - [ ] `cosign download attestation docker.io/abhigyanpatwari/gitnexus:<tag> --predicate-type https://slsa.dev/provenance/v1` returns the provenance.