### PR TITLE
fix(cli): only match <!-- gitnexus:* --> markers at section position (#1041)

### DIFF
--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -33,6 +33,33 @@ const GITNEXUS_START_MARKER = '<!-- gitnexus:start -->';
 const GITNEXUS_END_MARKER = '<!-- gitnexus:end -->';
 
 /**
+ * Find the index of a section marker that occupies its own line.
+ * Unlike `indexOf`, this rejects inline prose references like
+ * `` See the `<!-- gitnexus:start -->` block `` that appear
+ * mid-sentence (#1041). A marker counts as section-position only when:
+ *   - preceded by newline or start-of-file, AND
+ *   - followed by newline, `\r` (CRLF files), or end-of-file.
+ * The generator always emits each marker alone on its line, so this
+ * matches every legitimate section and none of the inline mentions.
+ *
+ * `startFrom` lets the end-marker lookup start after the already-found
+ * start marker, avoiding a scan from 0 and guaranteeing we never pick
+ * up an end marker that appears earlier in the file than the start.
+ */
+function findSectionMarkerIndex(content: string, marker: string, startFrom = 0): number {
+  let idx = content.indexOf(marker, startFrom);
+  while (idx !== -1) {
+    const atLineStart = idx === 0 || content[idx - 1] === '\n';
+    const endPos = idx + marker.length;
+    const atLineEnd =
+      endPos === content.length || content[endPos] === '\n' || content[endPos] === '\r';
+    if (atLineStart && atLineEnd) return idx;
+    idx = content.indexOf(marker, idx + 1);
+  }
+  return -1;
+}
+
+/**
  * Generate the full GitNexus context content.
  *
  * Design principles (learned from real agent behavior and industry research):
@@ -163,9 +190,18 @@ async function upsertGitNexusSection(
 
   const existingContent = await fs.readFile(filePath, 'utf-8');
 
-  // Check if GitNexus section already exists
-  const startIdx = existingContent.indexOf(GITNEXUS_START_MARKER);
-  const endIdx = existingContent.indexOf(GITNEXUS_END_MARKER);
+  // Check if GitNexus section already exists. Matching is restricted
+  // to markers that occupy their own line so that inline prose
+  // references (e.g. `` See the `<!-- gitnexus:start -->` block `` in
+  // the shipped CLAUDE.md) are NOT treated as section delimiters
+  // (#1041). The end-marker scan starts after the start-marker so it
+  // can never pick up an earlier end in the file.
+  const startIdx = findSectionMarkerIndex(existingContent, GITNEXUS_START_MARKER);
+  const endIdx = findSectionMarkerIndex(
+    existingContent,
+    GITNEXUS_END_MARKER,
+    startIdx === -1 ? 0 : startIdx,
+  );
 
   if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
     // Replace existing section

--- a/gitnexus/test/unit/ai-context.test.ts
+++ b/gitnexus/test/unit/ai-context.test.ts
@@ -164,4 +164,116 @@ describe('generateAIContextFiles', () => {
     expect(agentsAfter).toBe(agentsContent);
     expect(claudeAfter).toBe(claudeContent);
   });
+
+  it('preserves inline marker references in prose and does not corrupt markdown (#1041)', async () => {
+    // Regression guard for #1041. The shipped CLAUDE.md ships with a
+    // prose paragraph referencing the marker pair inline — wrapped in a
+    // backtick-quoted fragment mid-sentence. `indexOf` (the pre-fix
+    // matcher) would match both of those inline markers and replace the
+    // content between them with the full injected block, destroying the
+    // sentence and leaving the backtick unclosed.
+    //
+    // Per-test tmpdir so we start from a known clean slate — the shared
+    // `tmpDir` from beforeAll may already contain CLAUDE.md from earlier
+    // tests in this describe block.
+    const bugDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-ai-ctx-1041-'));
+    const bugStorage = path.join(bugDir, '.gitnexus');
+    await fs.mkdir(bugStorage, { recursive: true });
+
+    const inlineProseLine =
+      'See the `<!-- gitnexus:start --> … <!-- gitnexus:end -->` block in **[AGENTS.md](AGENTS.md)** for the canonical MCP tools, impact analysis rules, and index instructions.';
+    const originalContent = `# Claude Code Rules\n\nLast reviewed: 2026-04-21\n\n## GitNexus rules\n\n${inlineProseLine}\n`;
+
+    const claudeMd = path.join(bugDir, 'CLAUDE.md');
+    await fs.writeFile(claudeMd, originalContent, 'utf-8');
+
+    try {
+      const stats = { nodes: 50, edges: 100, processes: 5 };
+
+      // First run — no section-position markers exist yet, so the
+      // injector must append a fresh section at end. The inline prose
+      // must be preserved verbatim; if it disappears or gets altered,
+      // the bug has recurred.
+      await generateAIContextFiles(bugDir, bugStorage, 'TestProject', stats);
+      let contentAfter = await fs.readFile(claudeMd, 'utf-8');
+
+      expect(contentAfter, 'inline prose line must survive the first run verbatim').toContain(
+        inlineProseLine,
+      );
+      // Exactly 2 start markers total: 1 inline (in prose) + 1
+      // section-position (appended by the injector). The pre-fix
+      // behaviour would have only 1 — the inline pair having been
+      // consumed as if they were section delimiters.
+      expect((contentAfter.match(/<!-- gitnexus:start -->/g) || []).length).toBe(2);
+      expect((contentAfter.match(/<!-- gitnexus:end -->/g) || []).length).toBe(2);
+
+      // Second run — the section from run 1 is now at section position,
+      // so the injector must UPDATE in place (not re-append). Inline
+      // prose stays preserved; marker counts unchanged.
+      await generateAIContextFiles(bugDir, bugStorage, 'TestProject', stats);
+      contentAfter = await fs.readFile(claudeMd, 'utf-8');
+
+      expect(contentAfter, 'inline prose line must survive the second run verbatim').toContain(
+        inlineProseLine,
+      );
+      expect((contentAfter.match(/<!-- gitnexus:start -->/g) || []).length).toBe(2);
+      expect((contentAfter.match(/<!-- gitnexus:end -->/g) || []).length).toBe(2);
+    } finally {
+      await fs.rm(bugDir, { recursive: true, force: true });
+    }
+  });
+
+  it('matches section markers on files with CRLF line endings (#1041 cross-platform)', async () => {
+    // Locks in the CRLF leg of the section-position matcher. Git on
+    // Windows may store files with `\r\n` line endings depending on
+    // `core.autocrlf`; when a section line ends `<!-- gitnexus:start
+    // -->\r\n`, the byte at `endPos` is `\r` (not `\n`). A `\n`-only
+    // line-end check would reject the real section, fall through to
+    // "append", and duplicate the block every run.
+    const crlfDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-ai-ctx-crlf-'));
+    const crlfStorage = path.join(crlfDir, '.gitnexus');
+    await fs.mkdir(crlfStorage, { recursive: true });
+
+    // Inline reference carries BOTH markers in a backtick-quoted
+    // fragment — matches the shape of the shipped CLAUDE.md line
+    // that triggered #1041 so the regression guard is meaningful.
+    const inlineProseLine =
+      'See the `<!-- gitnexus:start --> … <!-- gitnexus:end -->` block in **[AGENTS.md](AGENTS.md)** for more.';
+    const seeded = [
+      '# Claude Code Rules',
+      '',
+      '## GitNexus rules',
+      '',
+      inlineProseLine,
+      '',
+      '<!-- gitnexus:start -->',
+      '# GitNexus — Code Intelligence (stale stub)',
+      '<!-- gitnexus:end -->',
+      '',
+    ].join('\r\n');
+
+    const claudeMd = path.join(crlfDir, 'CLAUDE.md');
+    await fs.writeFile(claudeMd, seeded, 'utf-8');
+
+    try {
+      const stats = { nodes: 50, edges: 100, processes: 5 };
+      await generateAIContextFiles(crlfDir, crlfStorage, 'TestProject', stats);
+      const content = await fs.readFile(claudeMd, 'utf-8');
+
+      // Inline prose survives verbatim — no corruption of CRLF bytes.
+      expect(content).toContain(inlineProseLine);
+      // Exactly 2 start markers total (1 inline + 1 section-position).
+      // If CRLF handling broke, the inline marker would be (incorrectly)
+      // matched as a section start, OR the real section would be
+      // appended duplicated — either way we'd see !== 2.
+      expect((content.match(/<!-- gitnexus:start -->/g) || []).length).toBe(2);
+      expect((content.match(/<!-- gitnexus:end -->/g) || []).length).toBe(2);
+      // Stale stub content must be gone — proves the section was
+      // REPLACED (not appended as a duplicate), which requires the
+      // CRLF-ending markers to have been matched.
+      expect(content).not.toContain('# GitNexus — Code Intelligence (stale stub)');
+    } finally {
+      await fs.rm(crlfDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Problem (#1041)

`upsertGitNexusSection` in `gitnexus/src/cli/ai-context.ts` uses \`existingContent.indexOf(GITNEXUS_START_MARKER)\` / \`indexOf(GITNEXUS_END_MARKER)\` to locate the bounds of the GitNexus section in CLAUDE.md / AGENTS.md before replacement. \`indexOf\` matches the **first occurrence of the marker anywhere** in the file, including inline prose references in backtick-quoted fragments mid-sentence.

The repo's shipped `CLAUDE.md` contains exactly such a reference on line 54:

```markdown
See the \`<!-- gitnexus:start --> … <!-- gitnexus:end -->\` block in **[AGENTS.md](AGENTS.md)** for the canonical MCP tools, impact analysis rules, and index instructions.
```

When a user runs `npx gitnexus analyze` on a fresh install, the injector finds these inline markers, treats them as section delimiters, and **replaces the prose between them with the full ~100-line generated block** — breaking the backtick and corrupting markdown. From the reporter's repro:

```
See the \`<!-- gitnexus:start -->
# GitNexus — Code Intelligence
... (100+ injected lines) ...
<!-- gitnexus:end -->\` block in [AGENTS.md](AGENTS.md) for ...
```

The opening backtick never closes. Every user starting from the shipped CLAUDE.md hits this.

## Fix

New private \`findSectionMarkerIndex\` helper that only matches markers occupying their own line:

- Preceded by \`\n\` or start-of-file
- Followed by \`\n\` / \`\r\` (CRLF files on Windows) / end-of-file

\`\r\` is explicit so CRLF-terminated sections still match under \`core.autocrlf = true\` — without it, the matcher would reject real sections on Windows files and fall through to \"append\", duplicating the block on every run.

The generator always emits markers alone on their own line (see \`ai-context.ts:89\` and \`:132\`), so every legitimate section continues to update in place identically. Only inline prose references now fall through to the \"append\" branch, which leaves existing content untouched.

## Tests

Two new unit tests in \`gitnexus/test/unit/ai-context.test.ts\`:

1. **#1041 regression** — seed CLAUDE.md with the shipped inline prose line (exact shape), run \`generateAIContextFiles\` twice. Assert:
   - Inline prose line preserved verbatim after each run
   - Exactly 2 start markers total (1 inline + 1 section-position)
   - Exactly 2 end markers total
   - No duplication across runs
2. **CRLF handling** — seed a CRLF-terminated file with inline prose + legitimate section. Assert section replaced in place, stale stub removed, inline prose preserved. Locks in the \`\r\` leg of \`atLineEnd\` — would fail a \`\n\`-only check.

Tests use per-test \`mkdtemp\` for clean slate and structural assertions (marker counts + verbatim substring match) rather than brittle regex / whitespace checks.

## Safety / scope

- **No destructive surface** — zero \`fs.rm\`, zero registry writes, zero new file deletion paths
- **No bypass flags** — fix is strictly narrowing matching; no new CLI flags or env vars
- **No new dependencies**
- **No MCP contract changes** — \`tools.ts\` / \`resources.ts\` / \`server.ts\` untouched
- **Backward compatible** — previously-correct files continue to update identically; only false-match corruption path narrows to the safer \"append\" branch
- **Rollback safety** — pure code revert, nothing on disk to unwind

## Verification (local)

- \`tsc --noEmit\` clean
- \`ai-context.test.ts\` 11/11 (9 existing + 2 new)
- \`npm run test:unit\` full suite 4333 pass; 4 pre-existing failures all verified on pristine upstream main @ 6618120f (2 git-utils env failures, 2 Swift parser failures — unrelated to this fix)

## Out of scope

- Marker inside fenced code blocks — such a marker IS at section position, matching is arguably correct behaviour. Full markdown-parser context detection is out of scope for a targeted fix.
- Trailing whitespace on marker lines (e.g. \`<!-- gitnexus:start --> \`) — not emitted by the generator; falling through to \"append\" is the safer failure mode than pre-emptive leniency.

Closes #1041.