### PR TITLE
fix: issue 986 go does not generate "calls" relationship on reciver functions

### DIFF
--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -568,32 +568,48 @@ const findEnclosingFunctionId = (
           filePath,
           provider.resolveEnclosingOwner,
         );
-        const qualifiedName = classInfo ? `${classInfo.className}.${funcName}` : funcName;
+        const encLang = getLanguageFromFilename(filePath);
+        const standaloneMethodInfo =
+          (finalLabel === 'Method' || finalLabel === 'Constructor') &&
+          encLang === SupportedLanguages.Go &&
+          provider.methodExtractor?.extractFromNode
+            ? provider.methodExtractor.extractFromNode(current, {
+                filePath,
+                language: encLang,
+              })
+            : null;
+        const ownerName = classInfo?.className ?? standaloneMethodInfo?.receiverType ?? undefined;
+        const qualifiedName = ownerName ? `${ownerName}.${funcName}` : funcName;
         // Include #<arity> suffix to match definition-phase Method/Constructor IDs.
         // Use the same MethodExtractor (getMethodInfo) as the definition phase.
         // When same-arity collisions exist, also append ~type1,type2.
         let arity: number | undefined;
         let encTypeTag = '';
         if (finalLabel === 'Method' || finalLabel === 'Constructor') {
-          const encLang = getLanguageFromFilename(filePath);
-          const classNode =
-            findEnclosingClassNode(current) ?? findClassNodeByQualifiedName(current);
-          if (classNode && encLang) {
-            const methodMap = getMethodInfo(classNode, provider, {
-              filePath,
-              language: encLang,
-            });
-            const defLine = current.startPosition.row + 1;
-            const info = methodMap?.get(`${funcName}:${defLine}`);
-            if (info) {
-              arity = info.parameters.some((p) => p.isVariadic)
-                ? undefined
-                : info.parameters.length;
-              if (methodMap && arity !== undefined) {
-                const g = buildCollisionGroups(methodMap);
-                encTypeTag =
-                  typeTagForId(methodMap, funcName, arity, info, encLang, g) +
-                  constTagForId(methodMap, funcName, arity, info, g);
+          if (standaloneMethodInfo) {
+            arity = standaloneMethodInfo.parameters.some((p) => p.isVariadic)
+              ? undefined
+              : standaloneMethodInfo.parameters.length;
+          } else {
+            const classNode =
+              findEnclosingClassNode(current) ?? findClassNodeByQualifiedName(current);
+            if (classNode && encLang) {
+              const methodMap = getMethodInfo(classNode, provider, {
+                filePath,
+                language: encLang,
+              });
+              const defLine = current.startPosition.row + 1;
+              const info = methodMap?.get(`${funcName}:${defLine}`);
+              if (info) {
+                arity = info.parameters.some((p) => p.isVariadic)
+                  ? undefined
+                  : info.parameters.length;
+                if (methodMap && arity !== undefined) {
+                  const g = buildCollisionGroups(methodMap);
+                  encTypeTag =
+                    typeTagForId(methodMap, funcName, arity, info, encLang, g) +
+                    constTagForId(methodMap, funcName, arity, info, g);
+                }
               }
             }
           }

--- a/gitnexus/test/fixtures/lang-resolution/go-receiver-method-free-call/example.go
+++ b/gitnexus/test/fixtures/lang-resolution/go-receiver-method-free-call/example.go
@@ -1,0 +1,7 @@
+package example
+
+type Example struct{}
+
+func (e *Example) Caller() {
+	callee()
+}

--- a/gitnexus/test/fixtures/lang-resolution/go-receiver-method-free-call/go.mod
+++ b/gitnexus/test/fixtures/lang-resolution/go-receiver-method-free-call/go.mod
@@ -1,0 +1,3 @@
+module example.com/go-receiver-method-free-call
+
+go 1.22

--- a/gitnexus/test/fixtures/lang-resolution/go-receiver-method-free-call/util.go
+++ b/gitnexus/test/fixtures/lang-resolution/go-receiver-method-free-call/util.go
@@ -1,0 +1,3 @@
+package example
+
+func callee() {}

--- a/gitnexus/test/integration/resolvers/go.test.ts
+++ b/gitnexus/test/integration/resolvers/go.test.ts
@@ -172,6 +172,26 @@ describe('Go member-call resolution', () => {
   });
 });
 
+describe('Go receiver method free-call resolution', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'go-receiver-method-free-call'),
+      () => {},
+      { workerThresholdsForTest: { minFiles: 1, minBytes: 0 } },
+    );
+  }, 60000);
+
+  it('resolves Caller -> callee when a receiver method calls a package-level function', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const calleeCall = calls.find((c) => c.source === 'Caller' && c.target === 'callee');
+    expect(calleeCall).toBeDefined();
+    expect(calleeCall!.targetLabel).toBe('Function');
+    expect(calleeCall!.targetFilePath).toBe('util.go');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Struct literal resolution: User{...} resolves to Struct node
 // ---------------------------------------------------------------------------


### PR DESCRIPTION

  ## Summary

  Fixes issue #986 for the Go worker/analyze path by aligning `CALLS` edge source IDs for receiver methods with definition-phase method node IDs.

  ## Motivation / context

  Issue #986 reported that running `analyze` on Go code failed to produce a `CALLS` relationship when a receiver method invoked a same-package package-level
  function.

  The root cause was not target resolution failure. The worker path resolved the callee correctly, but emitted an incorrect `sourceId` for Go receiver
  methods, so the edge pointed at a non-existent method node ID.

  ## Areas touched

  - [x] `gitnexus/` (CLI / core / MCP server)
  - [ ] `gitnexus-web/` (Vite / React UI)
  - [ ] `.github/` (workflows, actions)
  - [ ] `eval/` or other tooling
  - [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

  ## Scope & constraints

  **In scope**

  - Align Go worker-path method source IDs with definition-phase method IDs
  - Fix receiver-method `CALLS` edges for same-package package-level function calls
  - Add a minimal Go regression fixture
  - Add a worker-path regression test for issue #986

  **Explicitly out of scope / not done here**

  - No changes to general call target resolution
  - No changes to non-Go languages
  - No changes to web UI, docs, CI, or release flow
  - No attempt to fix unrelated full-suite failures in `test/unit/wiki-flags.test.ts`

  ## Implementation notes

  The fix is intentionally narrow and Go-only.

  In `parse-worker.ts`, `findEnclosingFunctionId()` now uses `extractFromNode()` for Go `Method` / `Constructor` source IDs so the worker path can recover
  receiver type and arity for receiver methods. That allows worker-emitted call source IDs to match the definition-phase method node IDs.

  Example mismatch before this change:

  - emitted by worker: `Method:example.go:Caller`
  - actual method node: `Method:example.go:Example.Caller#0`

  That mismatch made the `CALLS` edge appear missing even though the callee target was already resolved correctly.

  ## Testing & verification

  - [x] `cd gitnexus && npm test`
  - [x] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
  - [x] `cd gitnexus && npx tsc --noEmit`
  - [ ] `cd gitnexus-web && npm test` *(if web changed)*
  - [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
  - [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

  ## Risk & rollout

  Risk is low and localized.

  - The behavior change is restricted to Go
  - The change only affects worker-path source ID generation for method/constructor call ownership
  - No schema or migration changes
  - No web changes
  - No release coordination required

  If validating this fix against a real repository, re-run `npx gitnexus analyze` to regenerate the index with the corrected worker-path method source IDs.

  ## Checklist

  - [x] PR body meets repo minimum length (workflow may label short descriptions)
  - [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
  - [x] No secrets, tokens, or machine-specific paths committed