### PR TITLE
docs(ingestion): document configurable large-file skip threshold (#991)

### DIFF
--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable large-file skip threshold** — the walker's 512 KB default is now overridable via `GITNEXUS_MAX_FILE_SIZE` (KB) or `gitnexus analyze --max-file-size <kb>`. Values are clamped to the 32 MB tree-sitter ceiling, invalid inputs fall back to the default with a one-time warning, and the CLI banner reports the effective post-clamp threshold when an override is active (#991, #1044).
+
 ### Performance
 
 - **`analyze` ~33% faster** — moved FTS index creation from the analyze pipeline to first-use lazy initialisation. The 5 `CREATE_FTS_INDEX` calls cost ~440 ms each in LadybugDB regardless of table size (≈2 s fixed overhead) and dominated runtime on small repos and slow CI runners. The cost now amortises across the first `query`/`context` call in a session via a new `ensureFTSIndex` helper. Mini-repo `analyze` measured locally on Windows: 6.4 s → 4.0 s warm; on CI Windows runners (≈3× slower) restores comfortable headroom against the 30 s e2e test budget.

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -155,6 +155,7 @@ gitnexus analyze --force         # Force full re-index
 gitnexus analyze --embeddings    # Enable embedding generation (slower, better search)
 gitnexus analyze --skip-agents-md  # Preserve custom AGENTS.md/CLAUDE.md gitnexus section edits
 gitnexus analyze --verbose       # Log skipped files when parsers are unavailable
+gitnexus analyze --max-file-size 1024  # Skip files larger than N KB (default: 512, cap: 32768)
 gitnexus mcp                     # Start MCP server (stdio) — serves all indexed repos
 gitnexus serve                   # Start local HTTP server (multi-repo) for web UI
 gitnexus index                   # Register an existing .gitnexus/ folder into the global registry
@@ -306,6 +307,21 @@ NODE_OPTIONS="--max-old-space-size=16384" npx gitnexus analyze
 echo "vendor/" >> .gitnexusignore
 echo "dist/" >> .gitnexusignore
 ```
+
+### Large files are being skipped
+
+By default the walker skips files larger than **512 KB** (see log line `Skipped N large files (>512KB)`). Raise the threshold via either the CLI flag or the environment variable — both accept a value in **KB**:
+
+```bash
+# CLI flag (takes precedence over the env var)
+npx gitnexus analyze --max-file-size 2048     # skip only files > 2 MB
+
+# Environment variable (persists across commands)
+export GITNEXUS_MAX_FILE_SIZE=2048
+npx gitnexus analyze
+```
+
+Values above **32768 KB (32 MB)** are clamped to the tree-sitter parser ceiling; invalid values fall back to the 512 KB default with a one-time warning. When an override is active, `analyze` prints the effective threshold in its startup banner (e.g. `GITNEXUS_MAX_FILE_SIZE: effective threshold 2048KB (default 512KB)`).
 
 ## Privacy
 


### PR DESCRIPTION
## Summary

Follow-up to #1044, as requested: documentation-only PR for the configurable large-file skip threshold feature that shipped in that PR.

> _"Can you please submit a new pr to document this? 🙏 I accidentally merged your changes before this."_

No code changes — only `gitnexus/README.md` and `gitnexus/CHANGELOG.md` updates.

## Changes

### `gitnexus/README.md`

1. **CLI Commands block** — added one example line alongside the other `gitnexus analyze` flags:
   ```
   gitnexus analyze --max-file-size 1024  # Skip files larger than N KB (default: 512, cap: 32768)
   ```

2. **Troubleshooting** — new subsection **"Large files are being skipped"** placed right after _"Analysis runs out of memory"_ (its natural neighbour), covering:
   - The 512 KB default and the `Skipped N large files (>512KB)` log line that leads users here
   - Both configuration surfaces: `--max-file-size <kb>` (takes precedence) and `GITNEXUS_MAX_FILE_SIZE` (persistent)
   - The 32 MB tree-sitter ceiling (values above are clamped)
   - Fallback behaviour for invalid values (one-time warning, reverts to 512 KB)
   - The effective-threshold startup banner (e.g. `GITNEXUS_MAX_FILE_SIZE: effective threshold 2048KB (default 512KB)`) — so operators know they're getting the post-clamp value in telemetry

### `gitnexus/CHANGELOG.md`

- New `### Added` entry under `[Unreleased]` with cross-references to issue #991 and implementation PR #1044.

## Diff size

```
gitnexus/CHANGELOG.md |  4 ++++
gitnexus/README.md    | 16 ++++++++++++++++
2 files changed, 20 insertions(+)
```

All additions. No existing text was modified or reformatted.

## Validation

- `*.md` is in `.prettierignore`, so no prettier run on markdown (verified against `.prettierignore` and `ci-quality.yml`).
- Pre-commit hook (typecheck + lint-staged) passed locally; no staged files matched any formatter task (expected for ignored markdown).
- No code touched → no test impact.

## References

- Issue: #991
- Implementation PR: #1044 (merged)

---

Closes the docs follow-up requested on #1044.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author