### PR TITLE
feat(ingestion): GITNEXUS_INDEX_TEST_DIRS opt-in for __tests__ / __mocks__ (#771)

### DIFF
--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -46,8 +46,10 @@ program
   .addHelpText(
     'after',
     '\nEnvironment variables:\n' +
-      '  GITNEXUS_NO_GITIGNORE=1   Skip .gitignore parsing (still reads .gitnexusignore)\n' +
-      '  GITNEXUS_MAX_FILE_SIZE=N  Override large-file skip threshold (KB). Default 512, max 32768.',
+      '  GITNEXUS_NO_GITIGNORE=1    Skip .gitignore parsing (still reads .gitnexusignore)\n' +
+      '  GITNEXUS_MAX_FILE_SIZE=N   Override large-file skip threshold (KB). Default 512, max 32768.\n' +
+      '  GITNEXUS_INDEX_TEST_DIRS=1 Opt-in: index __tests__ and __mocks__ directories\n' +
+      '                             (off by default — useful for QE workflows that trace test coverage).',
   )
   .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -46,10 +46,10 @@ program
   .addHelpText(
     'after',
     '\nEnvironment variables:\n' +
-      '  GITNEXUS_NO_GITIGNORE=1    Skip .gitignore parsing (still reads .gitnexusignore)\n' +
-      '  GITNEXUS_MAX_FILE_SIZE=N   Override large-file skip threshold (KB). Default 512, max 32768.\n' +
-      '  GITNEXUS_INDEX_TEST_DIRS=1 Opt-in: index __tests__ and __mocks__ directories\n' +
-      '                             (off by default — useful for QE workflows that trace test coverage).',
+      '  GITNEXUS_NO_GITIGNORE=1   Skip .gitignore parsing (still reads .gitnexusignore)\n' +
+      '  GITNEXUS_MAX_FILE_SIZE=N  Override large-file skip threshold (KB). Default 512, max 32768.\n' +
+      '\nTip: `.gitnexusignore` supports `.gitignore`-style negation. Add e.g.\n' +
+      '     `!__tests__/` to index a directory that is auto-filtered by default (#771).',
   )
   .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 

--- a/gitnexus/src/config/ignore-service.ts
+++ b/gitnexus/src/config/ignore-service.ts
@@ -274,15 +274,38 @@ const IGNORED_FILES = new Set([
 // entries in DEFAULT_IGNORE_LIST — this is intentional. The hardcoded list protects
 // against indexing directories that are almost never source code (node_modules, .git, etc.).
 // Users who need to include such directories should remove them from the hardcoded list.
+//
+// Narrow escape hatch (#771): the GITNEXUS_INDEX_TEST_DIRS env var lets operators
+// opt into indexing `__tests__` and `__mocks__` specifically, for Quality
+// Engineering use cases where test files are the primary index target (tracing
+// coverage via CALLS edges). All other hardcoded entries remain unaffected — this
+// is deliberately scoped to the two names the issue asks for.
+
+/**
+ * Effective directory-ignore check. Mirrors the `GITNEXUS_NO_GITIGNORE` env-var
+ * pattern: the default (env unset) preserves the hardcoded list exactly.
+ * `isHardcodedIgnoredDirectory` stays a pure membership check — callers that
+ * want the raw list semantic still get it. Callers that want the runtime
+ * effective ignore (walker / shouldIgnorePath) go through this helper.
+ */
+const isEffectivelyIgnoredDirectory = (name: string): boolean => {
+  if (!DEFAULT_IGNORE_LIST.has(name)) return false;
+  if ((name === '__tests__' || name === '__mocks__') && !!process.env.GITNEXUS_INDEX_TEST_DIRS) {
+    return false;
+  }
+  return true;
+};
+
 export const shouldIgnorePath = (filePath: string): boolean => {
   const normalizedPath = filePath.replace(/\\/g, '/');
   const parts = normalizedPath.split('/');
   const fileName = parts[parts.length - 1];
   const fileNameLower = fileName.toLowerCase();
 
-  // Check if any path segment is in ignore list
+  // Check if any path segment is in ignore list (respecting the
+  // GITNEXUS_INDEX_TEST_DIRS opt-in for __tests__ / __mocks__ per #771).
   for (const part of parts) {
-    if (DEFAULT_IGNORE_LIST.has(part)) {
+    if (isEffectivelyIgnoredDirectory(part)) {
       return true;
     }
   }
@@ -392,11 +415,12 @@ export const createIgnoreFilter = async (repoPath: string, options?: IgnoreOptio
       return shouldIgnorePath(rel);
     },
     childrenIgnored(p: Path): boolean {
-      // Fast path: check directory name against hardcoded list.
+      // Fast path: check directory name against hardcoded list, respecting
+      // the GITNEXUS_INDEX_TEST_DIRS opt-in per #771.
       // Note: dot-directories (.git, .vscode, etc.) are primarily excluded by
       // glob's `dot: false` option in filesystem-walker.ts. This check is
       // defense-in-depth — do not remove `dot: false` assuming this covers it.
-      if (DEFAULT_IGNORE_LIST.has(p.name)) return true;
+      if (isEffectivelyIgnoredDirectory(p.name)) return true;
       // Check against .gitignore / .gitnexusignore patterns.
       // Since childrenIgnored is only called for directories, always test with
       // a trailing slash. This ensures directory-only negation patterns (e.g.

--- a/gitnexus/src/config/ignore-service.ts
+++ b/gitnexus/src/config/ignore-service.ts
@@ -420,7 +420,11 @@ const hasExplicitUnignore = (ig: Ignore, rel: string): boolean => {
  * Precedence (#771): user's `.gitnexusignore` negation patterns take
  * priority over the hardcoded list, matching `.gitignore` semantics.
  * An explicit `!pattern` rule unignores descendants even when they
- * would otherwise be blocked by DEFAULT_IGNORE_LIST.
+ * would otherwise be blocked by DEFAULT_IGNORE_LIST — UNLESS a more
+ * specific rule in the same file re-ignores a subset (e.g.
+ * `!__tests__/` paired with `__tests__/generated/` blocks the child
+ * while leaving the parent negated). Last-match-wins is enforced by
+ * consulting `ig.ignores(rel)` after `hasExplicitUnignore`.
  */
 export const createIgnoreFilter = async (repoPath: string, options?: IgnoreOptions) => {
   const ig = await loadIgnoreRules(repoPath, options);
@@ -433,8 +437,12 @@ export const createIgnoreFilter = async (repoPath: string, options?: IgnoreOptio
       if (!rel) return false;
       // User's .gitnexusignore negation takes precedence over hardcoded
       // rules (#771). If any ancestor or the path itself was explicitly
-      // unignored, respect that override.
-      if (ig && hasExplicitUnignore(ig, rel)) return false;
+      // unignored AND no more-specific rule re-ignores this exact path,
+      // allow it through. The `!ig.ignores(rel)` guard matches
+      // .gitignore's last-match-wins semantics: `!__tests__/` followed
+      // by `__tests__/generated/` negates the parent but still blocks
+      // the re-ignored child.
+      if (ig && hasExplicitUnignore(ig, rel) && !ig.ignores(rel)) return false;
       // Check .gitignore / .gitnexusignore patterns
       if (ig && ig.ignores(rel)) return true;
       // Fall back to hardcoded rules
@@ -449,8 +457,10 @@ export const createIgnoreFilter = async (repoPath: string, options?: IgnoreOptio
       // User's .gitnexusignore negation takes precedence (#771) — if the
       // user explicitly unignored this directory or any ancestor via a
       // !pattern rule, allow descent even if the directory name is in
-      // DEFAULT_IGNORE_LIST.
-      if (ig && rel && hasExplicitUnignore(ig, rel)) return false;
+      // DEFAULT_IGNORE_LIST. The `!ig.ignores(rel + '/')` guard keeps
+      // last-match-wins: `!__tests__/` + `__tests__/generated/` still
+      // blocks descent into `__tests__/generated/`.
+      if (ig && rel && hasExplicitUnignore(ig, rel) && !ig.ignores(rel + '/')) return false;
       // Hardcoded list: block descent into well-known noise directories.
       if (DEFAULT_IGNORE_LIST.has(p.name)) return true;
       // Check against .gitignore / .gitnexusignore patterns.

--- a/gitnexus/src/config/ignore-service.ts
+++ b/gitnexus/src/config/ignore-service.ts
@@ -270,42 +270,23 @@ const IGNORED_FILES = new Set([
   '.env.example',
 ]);
 
-// NOTE: Negation patterns in .gitnexusignore (e.g. `!vendor/`) cannot override
-// entries in DEFAULT_IGNORE_LIST — this is intentional. The hardcoded list protects
-// against indexing directories that are almost never source code (node_modules, .git, etc.).
-// Users who need to include such directories should remove them from the hardcoded list.
-//
-// Narrow escape hatch (#771): the GITNEXUS_INDEX_TEST_DIRS env var lets operators
-// opt into indexing `__tests__` and `__mocks__` specifically, for Quality
-// Engineering use cases where test files are the primary index target (tracing
-// coverage via CALLS edges). All other hardcoded entries remain unaffected — this
-// is deliberately scoped to the two names the issue asks for.
-
-/**
- * Effective directory-ignore check. Mirrors the `GITNEXUS_NO_GITIGNORE` env-var
- * pattern: the default (env unset) preserves the hardcoded list exactly.
- * `isHardcodedIgnoredDirectory` stays a pure membership check — callers that
- * want the raw list semantic still get it. Callers that want the runtime
- * effective ignore (walker / shouldIgnorePath) go through this helper.
- */
-const isEffectivelyIgnoredDirectory = (name: string): boolean => {
-  if (!DEFAULT_IGNORE_LIST.has(name)) return false;
-  if ((name === '__tests__' || name === '__mocks__') && !!process.env.GITNEXUS_INDEX_TEST_DIRS) {
-    return false;
-  }
-  return true;
-};
-
+// The hardcoded DEFAULT_IGNORE_LIST is the "safety net" default: directories
+// that are almost never source code (node_modules, .git, dist, __tests__,
+// etc.). Users who legitimately need to index one of these can negate the
+// hardcoded rule via a `!pattern` line in `.gitnexusignore` (#771) — same
+// semantics as `.gitignore` negation. That override is applied in
+// `createIgnoreFilter` below; `shouldIgnorePath` itself stays a pure
+// hardcoded-list check so its callers (wiki generator, tests) get
+// deterministic results independent of per-repo config.
 export const shouldIgnorePath = (filePath: string): boolean => {
   const normalizedPath = filePath.replace(/\\/g, '/');
   const parts = normalizedPath.split('/');
   const fileName = parts[parts.length - 1];
   const fileNameLower = fileName.toLowerCase();
 
-  // Check if any path segment is in ignore list (respecting the
-  // GITNEXUS_INDEX_TEST_DIRS opt-in for __tests__ / __mocks__ per #771).
+  // Check if any path segment is in the hardcoded ignore list.
   for (const part of parts) {
-    if (isEffectivelyIgnoredDirectory(part)) {
+    if (DEFAULT_IGNORE_LIST.has(part)) {
       return true;
     }
   }
@@ -393,12 +374,53 @@ export const loadIgnoreRules = async (
 };
 
 /**
+ * Walk ancestor segments of `rel` and check whether `.gitnexusignore`
+ * (or `.gitignore`) contains an explicit `!pattern` negation that
+ * applies. Returns true as soon as any segment — or the path itself —
+ * is matched by a negation rule.
+ *
+ * Why this exists (#771): the hardcoded DEFAULT_IGNORE_LIST would
+ * otherwise block indexing of directories like `__tests__/` even when
+ * the user has an explicit `!__tests__/` line in `.gitnexusignore`.
+ * Mirroring `.gitignore` negation semantics: a user's explicit
+ * unignore of a parent directory implicitly unignores everything
+ * underneath, so we walk the ancestor chain rather than only testing
+ * the leaf.
+ *
+ * The `ignore` package's `test(path)` returns `{ignored, unignored}`;
+ * `unignored: true` is the "a negation rule matched this path"
+ * signal. Children of a negated directory return
+ * `{ignored: false, unignored: false}` on a direct test, which is why
+ * we also walk the ancestors here.
+ */
+const hasExplicitUnignore = (ig: Ignore, rel: string): boolean => {
+  // Direct match on the path (as a file).
+  if (ig.test(rel).unignored) return true;
+  // Direct match on the path treated as a directory — `!dir/` matches
+  // here when rel is the directory itself.
+  if (ig.test(rel + '/').unignored) return true;
+  // Walk ancestor segments. `!parent/` should propagate to every
+  // descendant the same way `.gitignore` negation propagates.
+  const parts = rel.split('/');
+  for (let i = parts.length - 1; i > 0; i--) {
+    const ancestor = parts.slice(0, i).join('/') + '/';
+    if (ig.test(ancestor).unignored) return true;
+  }
+  return false;
+};
+
+/**
  * Create a glob-compatible ignore filter combining:
  * - .gitignore / .gitnexusignore patterns (via `ignore` package)
  * - Hardcoded DEFAULT_IGNORE_LIST, IGNORED_EXTENSIONS, IGNORED_FILES
  *
  * Returns an IgnoreLike object for glob's `ignore` option,
  * enabling directory-level pruning during traversal.
+ *
+ * Precedence (#771): user's `.gitnexusignore` negation patterns take
+ * priority over the hardcoded list, matching `.gitignore` semantics.
+ * An explicit `!pattern` rule unignores descendants even when they
+ * would otherwise be blocked by DEFAULT_IGNORE_LIST.
  */
 export const createIgnoreFilter = async (repoPath: string, options?: IgnoreOptions) => {
   const ig = await loadIgnoreRules(repoPath, options);
@@ -409,18 +431,28 @@ export const createIgnoreFilter = async (repoPath: string, options?: IgnoreOptio
       // which is what the `ignore` package expects. No explicit normalization needed.
       const rel = p.relative();
       if (!rel) return false;
+      // User's .gitnexusignore negation takes precedence over hardcoded
+      // rules (#771). If any ancestor or the path itself was explicitly
+      // unignored, respect that override.
+      if (ig && hasExplicitUnignore(ig, rel)) return false;
       // Check .gitignore / .gitnexusignore patterns
       if (ig && ig.ignores(rel)) return true;
       // Fall back to hardcoded rules
       return shouldIgnorePath(rel);
     },
     childrenIgnored(p: Path): boolean {
-      // Fast path: check directory name against hardcoded list, respecting
-      // the GITNEXUS_INDEX_TEST_DIRS opt-in per #771.
       // Note: dot-directories (.git, .vscode, etc.) are primarily excluded by
-      // glob's `dot: false` option in filesystem-walker.ts. This check is
-      // defense-in-depth — do not remove `dot: false` assuming this covers it.
-      if (isEffectivelyIgnoredDirectory(p.name)) return true;
+      // glob's `dot: false` option in filesystem-walker.ts. The hardcoded
+      // list check below is defense-in-depth — do not remove `dot: false`
+      // assuming this covers it.
+      const rel = p.relative();
+      // User's .gitnexusignore negation takes precedence (#771) — if the
+      // user explicitly unignored this directory or any ancestor via a
+      // !pattern rule, allow descent even if the directory name is in
+      // DEFAULT_IGNORE_LIST.
+      if (ig && rel && hasExplicitUnignore(ig, rel)) return false;
+      // Hardcoded list: block descent into well-known noise directories.
+      if (DEFAULT_IGNORE_LIST.has(p.name)) return true;
       // Check against .gitignore / .gitnexusignore patterns.
       // Since childrenIgnored is only called for directories, always test with
       // a trailing slash. This ensures directory-only negation patterns (e.g.
@@ -429,10 +461,7 @@ export const createIgnoreFilter = async (repoPath: string, options?: IgnoreOptio
       // Bare-name patterns (e.g. `local`) still match `local/` per gitignore spec:
       // the `ignore` package normalizes `dir` and `dir/` to match directories.
       // See: https://github.com/kaelzhang/node-ignore#2-filenames-and-dirnames
-      if (ig) {
-        const rel = p.relative();
-        if (rel && ig.ignores(rel + '/')) return true;
-      }
+      if (ig && rel && ig.ignores(rel + '/')) return true;
       return false;
     },
   };

--- a/gitnexus/test/unit/ignore-service.test.ts
+++ b/gitnexus/test/unit/ignore-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
@@ -216,6 +216,98 @@ describe('isHardcodedIgnoredDirectory', () => {
     expect(isHardcodedIgnoredDirectory('lib')).toBe(false);
     expect(isHardcodedIgnoredDirectory('app')).toBe(false);
     expect(isHardcodedIgnoredDirectory('local')).toBe(false);
+  });
+});
+
+// ─── GITNEXUS_INDEX_TEST_DIRS opt-in (#771) ─────────────────────────
+//
+// The env var lets Quality Engineering users opt into indexing
+// __tests__ and __mocks__ so they can trace test coverage via CALLS
+// edges. These tests lock in:
+//   - default behaviour (env unset) is byte-identical to pre-#771
+//   - env set removes EXACTLY __tests__ and __mocks__ from the
+//     effective ignore set — other hardcoded entries stay ignored
+//   - test-adjacent dirs the issue did NOT ask for (__snapshots__,
+//     snapshots, fixtures, .jest) remain ignored regardless — this
+//     is a scope-discipline lock; a future expansion would fail here
+//   - `isHardcodedIgnoredDirectory` export semantic is unchanged
+//     (it's a raw-membership query, not an effective-runtime query)
+describe('GITNEXUS_INDEX_TEST_DIRS opt-in (#771)', () => {
+  const savedEnv = process.env.GITNEXUS_INDEX_TEST_DIRS;
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.GITNEXUS_INDEX_TEST_DIRS;
+    } else {
+      process.env.GITNEXUS_INDEX_TEST_DIRS = savedEnv;
+    }
+  });
+
+  describe('default behaviour — env unset', () => {
+    beforeEach(() => {
+      delete process.env.GITNEXUS_INDEX_TEST_DIRS;
+    });
+
+    it('ignores __tests__ directory paths', () => {
+      expect(shouldIgnorePath('src/__tests__/foo.test.ts')).toBe(true);
+      expect(shouldIgnorePath('__tests__/index.test.js')).toBe(true);
+    });
+
+    it('ignores __mocks__ directory paths', () => {
+      expect(shouldIgnorePath('src/__mocks__/api.ts')).toBe(true);
+      expect(shouldIgnorePath('pkg/__mocks__/fs.js')).toBe(true);
+    });
+  });
+
+  describe('opt-in behaviour — env set', () => {
+    beforeEach(() => {
+      process.env.GITNEXUS_INDEX_TEST_DIRS = '1';
+    });
+
+    it('does NOT ignore __tests__ paths', () => {
+      expect(shouldIgnorePath('src/__tests__/foo.test.ts')).toBe(false);
+      expect(shouldIgnorePath('__tests__/index.test.js')).toBe(false);
+    });
+
+    it('does NOT ignore __mocks__ paths', () => {
+      expect(shouldIgnorePath('src/__mocks__/api.ts')).toBe(false);
+      expect(shouldIgnorePath('pkg/__mocks__/fs.js')).toBe(false);
+    });
+
+    it('still ignores other hardcoded entries (node_modules, .git, dist, __pycache__)', () => {
+      // Opt-in is scoped narrowly — every other auto-filter stays active.
+      expect(shouldIgnorePath('node_modules/foo.js')).toBe(true);
+      expect(shouldIgnorePath('.git/HEAD')).toBe(true);
+      expect(shouldIgnorePath('dist/bundle.js')).toBe(true);
+      expect(shouldIgnorePath('src/__pycache__/module.pyc')).toBe(true);
+    });
+
+    it('still ignores test-adjacent dirs the issue did NOT ask to unlock', () => {
+      // Scope-discipline guard — #771 explicitly names __tests__ and
+      // __mocks__. Other test-adjacent entries (__snapshots__, snapshots,
+      // fixtures, .jest) stay ignored. A future PR that widens the
+      // opt-in without filing a new issue would fail here.
+      expect(shouldIgnorePath('src/__snapshots__/foo.snap')).toBe(true);
+      expect(shouldIgnorePath('test/snapshots/foo.snap')).toBe(true);
+      expect(shouldIgnorePath('pkg/fixtures/data.json')).toBe(true);
+      expect(shouldIgnorePath('.jest/cache.js')).toBe(true);
+    });
+  });
+
+  describe('isHardcodedIgnoredDirectory export is unchanged by env var', () => {
+    it('returns true for __tests__ regardless of env', () => {
+      // The raw-membership query has a different contract from the
+      // effective-runtime query. `isHardcodedIgnoredDirectory` is
+      // "is this in the hardcoded list?" — the list itself does not
+      // change. The runtime decision changes via shouldIgnorePath.
+      delete process.env.GITNEXUS_INDEX_TEST_DIRS;
+      expect(isHardcodedIgnoredDirectory('__tests__')).toBe(true);
+      expect(isHardcodedIgnoredDirectory('__mocks__')).toBe(true);
+
+      process.env.GITNEXUS_INDEX_TEST_DIRS = '1';
+      expect(isHardcodedIgnoredDirectory('__tests__')).toBe(true);
+      expect(isHardcodedIgnoredDirectory('__mocks__')).toBe(true);
+    });
   });
 });
 

--- a/gitnexus/test/unit/ignore-service.test.ts
+++ b/gitnexus/test/unit/ignore-service.test.ts
@@ -219,95 +219,124 @@ describe('isHardcodedIgnoredDirectory', () => {
   });
 });
 
-// ─── GITNEXUS_INDEX_TEST_DIRS opt-in (#771) ─────────────────────────
+// ─── .gitnexusignore negation can override hardcoded list (#771) ────
 //
-// The env var lets Quality Engineering users opt into indexing
-// __tests__ and __mocks__ so they can trace test coverage via CALLS
-// edges. These tests lock in:
-//   - default behaviour (env unset) is byte-identical to pre-#771
-//   - env set removes EXACTLY __tests__ and __mocks__ from the
-//     effective ignore set — other hardcoded entries stay ignored
-//   - test-adjacent dirs the issue did NOT ask for (__snapshots__,
-//     snapshots, fixtures, .jest) remain ignored regardless — this
-//     is a scope-discipline lock; a future expansion would fail here
-//   - `isHardcodedIgnoredDirectory` export semantic is unchanged
-//     (it's a raw-membership query, not an effective-runtime query)
-describe('GITNEXUS_INDEX_TEST_DIRS opt-in (#771)', () => {
-  const savedEnv = process.env.GITNEXUS_INDEX_TEST_DIRS;
+// Per @magyargergo's review: `.gitnexusignore` should honour
+// `.gitignore`-style negation against the hardcoded DEFAULT_IGNORE_LIST.
+// A `!__tests__/` line in `.gitnexusignore` must re-enable indexing of
+// `__tests__/` even though the hardcoded list would normally block it.
+// These tests exercise the full `createIgnoreFilter` surface with real
+// temp files (the negation logic lives in `createIgnoreFilter`, not in
+// `shouldIgnorePath` — the latter stays pure-hardcoded for callers like
+// the wiki generator that don't have per-repo config context).
+//
+// Locks in:
+//   1. Default (no .gitnexusignore) — hardcoded list still blocks
+//      __tests__ / __mocks__ / node_modules (byte-identical pre-#771).
+//   2. `!__tests__/` negation — __tests__ and its descendants are
+//      indexed; other hardcoded entries (node_modules, .git) stay
+//      blocked.
+//   3. Broader negation (e.g. `!node_modules/`) also works — design is
+//      general, not special-cased to the 2 test dirs.
+//   4. Negation applies both to the directory itself (`childrenIgnored`
+//      allows descent) AND to descendants (`ignored` allows files).
+//   5. `shouldIgnorePath` pure-hardcoded contract is preserved — the
+//      wiki generator and other callers without per-repo config get
+//      deterministic behavior.
+describe('.gitnexusignore negation overrides hardcoded DEFAULT_IGNORE_LIST (#771)', () => {
+  let tmpDir: string;
 
-  afterEach(() => {
-    if (savedEnv === undefined) {
-      delete process.env.GITNEXUS_INDEX_TEST_DIRS;
-    } else {
-      process.env.GITNEXUS_INDEX_TEST_DIRS = savedEnv;
-    }
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-ignore-negation-'));
   });
 
-  describe('default behaviour — env unset', () => {
-    beforeEach(() => {
-      delete process.env.GITNEXUS_INDEX_TEST_DIRS;
-    });
-
-    it('ignores __tests__ directory paths', () => {
-      expect(shouldIgnorePath('src/__tests__/foo.test.ts')).toBe(true);
-      expect(shouldIgnorePath('__tests__/index.test.js')).toBe(true);
-    });
-
-    it('ignores __mocks__ directory paths', () => {
-      expect(shouldIgnorePath('src/__mocks__/api.ts')).toBe(true);
-      expect(shouldIgnorePath('pkg/__mocks__/fs.js')).toBe(true);
-    });
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  describe('opt-in behaviour — env set', () => {
-    beforeEach(() => {
-      process.env.GITNEXUS_INDEX_TEST_DIRS = '1';
-    });
+  /** Synthetic path-scurry Path helper. `createIgnoreFilter.ignored` /
+   *  `childrenIgnored` only look at `.relative()` and `.name`, so a
+   *  minimal shape with those two is enough to exercise the logic. */
+  const mkPath = (rel: string) =>
+    ({
+      relative: () => rel.replace(/\\/g, '/'),
+      name: rel.split(/[/\\]/).pop() || rel,
+    }) as unknown as Parameters<Awaited<ReturnType<typeof createIgnoreFilter>>['ignored']>[0];
 
-    it('does NOT ignore __tests__ paths', () => {
-      expect(shouldIgnorePath('src/__tests__/foo.test.ts')).toBe(false);
-      expect(shouldIgnorePath('__tests__/index.test.js')).toBe(false);
-    });
-
-    it('does NOT ignore __mocks__ paths', () => {
-      expect(shouldIgnorePath('src/__mocks__/api.ts')).toBe(false);
-      expect(shouldIgnorePath('pkg/__mocks__/fs.js')).toBe(false);
-    });
-
-    it('still ignores other hardcoded entries (node_modules, .git, dist, __pycache__)', () => {
-      // Opt-in is scoped narrowly — every other auto-filter stays active.
-      expect(shouldIgnorePath('node_modules/foo.js')).toBe(true);
-      expect(shouldIgnorePath('.git/HEAD')).toBe(true);
-      expect(shouldIgnorePath('dist/bundle.js')).toBe(true);
-      expect(shouldIgnorePath('src/__pycache__/module.pyc')).toBe(true);
-    });
-
-    it('still ignores test-adjacent dirs the issue did NOT ask to unlock', () => {
-      // Scope-discipline guard — #771 explicitly names __tests__ and
-      // __mocks__. Other test-adjacent entries (__snapshots__, snapshots,
-      // fixtures, .jest) stay ignored. A future PR that widens the
-      // opt-in without filing a new issue would fail here.
-      expect(shouldIgnorePath('src/__snapshots__/foo.snap')).toBe(true);
-      expect(shouldIgnorePath('test/snapshots/foo.snap')).toBe(true);
-      expect(shouldIgnorePath('pkg/fixtures/data.json')).toBe(true);
-      expect(shouldIgnorePath('.jest/cache.js')).toBe(true);
-    });
+  it('default (no .gitnexusignore): __tests__ still blocked by hardcoded list', async () => {
+    const filter = await createIgnoreFilter(tmpDir);
+    expect(filter.ignored(mkPath('__tests__/foo.test.ts'))).toBe(true);
+    expect(filter.childrenIgnored(mkPath('__tests__'))).toBe(true);
   });
 
-  describe('isHardcodedIgnoredDirectory export is unchanged by env var', () => {
-    it('returns true for __tests__ regardless of env', () => {
-      // The raw-membership query has a different contract from the
-      // effective-runtime query. `isHardcodedIgnoredDirectory` is
-      // "is this in the hardcoded list?" — the list itself does not
-      // change. The runtime decision changes via shouldIgnorePath.
-      delete process.env.GITNEXUS_INDEX_TEST_DIRS;
-      expect(isHardcodedIgnoredDirectory('__tests__')).toBe(true);
-      expect(isHardcodedIgnoredDirectory('__mocks__')).toBe(true);
+  it('`!__tests__/` negation unlocks the directory and its descendants', async () => {
+    await fs.writeFile(path.join(tmpDir, '.gitnexusignore'), '!__tests__/\n');
+    const filter = await createIgnoreFilter(tmpDir);
+    expect(filter.childrenIgnored(mkPath('__tests__'))).toBe(false);
+    expect(filter.ignored(mkPath('__tests__/foo.test.ts'))).toBe(false);
+    expect(filter.ignored(mkPath('src/__tests__/nested.test.ts'))).toBe(false);
+  });
 
-      process.env.GITNEXUS_INDEX_TEST_DIRS = '1';
-      expect(isHardcodedIgnoredDirectory('__tests__')).toBe(true);
-      expect(isHardcodedIgnoredDirectory('__mocks__')).toBe(true);
-    });
+  it('`!__mocks__/` negation unlocks __mocks__ but NOT __tests__', async () => {
+    await fs.writeFile(path.join(tmpDir, '.gitnexusignore'), '!__mocks__/\n');
+    const filter = await createIgnoreFilter(tmpDir);
+    expect(filter.ignored(mkPath('__mocks__/api.ts'))).toBe(false);
+    // __tests__ not negated — hardcoded list still blocks it.
+    expect(filter.ignored(mkPath('__tests__/foo.test.ts'))).toBe(true);
+    expect(filter.childrenIgnored(mkPath('__tests__'))).toBe(true);
+  });
+
+  it('negation generalises — `!node_modules/` unlocks a different hardcoded entry', async () => {
+    // The design isn't special-cased to the two names from the issue —
+    // it honours any negation the user writes. Lock this in with a
+    // broader example that proves the mechanism, not the dir name.
+    await fs.writeFile(path.join(tmpDir, '.gitnexusignore'), '!node_modules/\n');
+    const filter = await createIgnoreFilter(tmpDir);
+    expect(filter.childrenIgnored(mkPath('node_modules'))).toBe(false);
+    expect(filter.ignored(mkPath('node_modules/express/index.js'))).toBe(false);
+  });
+
+  it('negation of one hardcoded entry does not leak to others', async () => {
+    await fs.writeFile(path.join(tmpDir, '.gitnexusignore'), '!__tests__/\n');
+    const filter = await createIgnoreFilter(tmpDir);
+    // __tests__ negated → allowed.
+    expect(filter.ignored(mkPath('__tests__/foo.test.ts'))).toBe(false);
+    // But node_modules / .git / dist not negated → still blocked.
+    expect(filter.ignored(mkPath('node_modules/pkg/index.js'))).toBe(true);
+    expect(filter.ignored(mkPath('.git/HEAD'))).toBe(true);
+    expect(filter.ignored(mkPath('dist/bundle.js'))).toBe(true);
+    expect(filter.childrenIgnored(mkPath('node_modules'))).toBe(true);
+    expect(filter.childrenIgnored(mkPath('.git'))).toBe(true);
+  });
+
+  it('standard `.gitignore` rules (no negation) still layer on top of hardcoded', async () => {
+    // Pre-#771 behaviour: if .gitnexusignore says `my-dir/`, that dir
+    // is ignored in addition to the hardcoded list. Non-negation
+    // rules are unaffected by this PR.
+    await fs.writeFile(path.join(tmpDir, '.gitnexusignore'), 'my-dir/\n');
+    const filter = await createIgnoreFilter(tmpDir);
+    expect(filter.ignored(mkPath('my-dir/file.ts'))).toBe(true);
+    expect(filter.childrenIgnored(mkPath('my-dir'))).toBe(true);
+    // Hardcoded still blocks unaffected paths.
+    expect(filter.ignored(mkPath('node_modules/foo.js'))).toBe(true);
+  });
+
+  it('shouldIgnorePath (raw hardcoded check) is unchanged — wiki / external callers unaffected', async () => {
+    // `shouldIgnorePath` is called from `core/wiki/generator.ts` and
+    // doesn't have access to per-repo `.gitnexusignore` config. Its
+    // contract stays "is this path in the hardcoded list?". The #771
+    // negation override lives only inside `createIgnoreFilter`, which
+    // IS called with config context. This asymmetry is deliberate.
+    expect(shouldIgnorePath('__tests__/foo.test.ts')).toBe(true);
+    expect(shouldIgnorePath('__mocks__/api.ts')).toBe(true);
+    expect(shouldIgnorePath('node_modules/pkg/index.js')).toBe(true);
+  });
+
+  it('isHardcodedIgnoredDirectory (raw membership) unchanged by negation', async () => {
+    // Pure membership query — the list itself doesn't mutate.
+    expect(isHardcodedIgnoredDirectory('__tests__')).toBe(true);
+    expect(isHardcodedIgnoredDirectory('__mocks__')).toBe(true);
+    expect(isHardcodedIgnoredDirectory('node_modules')).toBe(true);
   });
 });
 

--- a/gitnexus/test/unit/ignore-service.test.ts
+++ b/gitnexus/test/unit/ignore-service.test.ts
@@ -321,6 +321,25 @@ describe('.gitnexusignore negation overrides hardcoded DEFAULT_IGNORE_LIST (#771
     expect(filter.ignored(mkPath('node_modules/foo.js'))).toBe(true);
   });
 
+  it('`!parent/` + `parent/child/` re-ignore: child still blocked (last-match-wins)', async () => {
+    // .gitignore semantics: a later more-specific rule overrides an
+    // earlier negation. The negation unlocks the hardcoded block on
+    // `__tests__/`, but the subsequent `__tests__/generated/` line
+    // re-ignores that subset. `__tests__/foo.test.ts` stays allowed;
+    // `__tests__/generated/foo.ts` stays blocked. This locks in the
+    // guarantee the design comment makes about "standard rules still
+    // layer on top" for the compound case.
+    await fs.writeFile(path.join(tmpDir, '.gitnexusignore'), '!__tests__/\n__tests__/generated/\n');
+    const filter = await createIgnoreFilter(tmpDir);
+    // Parent negation still in effect: top-level tests allowed.
+    expect(filter.ignored(mkPath('__tests__/foo.test.ts'))).toBe(false);
+    expect(filter.childrenIgnored(mkPath('__tests__'))).toBe(false);
+    // Re-ignored subdirectory: children blocked at file level AND at
+    // the directory-descent level, so ingestion never walks in.
+    expect(filter.ignored(mkPath('__tests__/generated/foo.ts'))).toBe(true);
+    expect(filter.childrenIgnored(mkPath('__tests__/generated'))).toBe(true);
+  });
+
   it('shouldIgnorePath (raw hardcoded check) is unchanged — wiki / external callers unaffected', async () => {
     // `shouldIgnorePath` is called from `core/wiki/generator.ts` and
     // doesn't have access to per-repo `.gitnexusignore` config. Its


### PR DESCRIPTION
## Problem (#771)

\`DEFAULT_IGNORE_LIST\` in \`gitnexus/src/config/ignore-service.ts\` hardcodes \`__tests__\` and \`__mocks__\` as auto-filtered directory names. The source comment at \`ignore-service.ts:273\` explicitly documents this as intentional:

> Negation patterns in \`.gitnexusignore\` (e.g. \`!vendor/\`) cannot override entries in \`DEFAULT_IGNORE_LIST\` — this is intentional.

That default is right for most users, but Quality Engineering workflows — where test files are the primary index target (tracing coverage via CALLS edges, mapping which tests exercise which production symbols) — have no escape hatch. The reporter's workaround is manually patching the installed package, which gets overwritten on every \`npm update\`.

## Fix

Add an opt-in env var mirroring the established \`GITNEXUS_NO_GITIGNORE\` / \`GITNEXUS_MAX_FILE_SIZE\` precedent:

\`\`\`bash
GITNEXUS_INDEX_TEST_DIRS=1 npx gitnexus analyze
\`\`\`

When set, \`__tests__\` and \`__mocks__\` are removed from the **effective** ignore set. The raw \`DEFAULT_IGNORE_LIST\` is never mutated; a new private \`isEffectivelyIgnoredDirectory\` helper wraps membership checks with the env-var opt-out.

## Scope discipline — deliberately narrow

- **Only** \`__tests__\` and \`__mocks__\` are unlocked. Other test-adjacent hardcoded entries (\`__snapshots__\`, \`snapshots\`, \`fixtures\`, \`.jest\`) remain auto-filtered. An explicit test locks this scope in — a future PR widening beyond the two named dirs without filing a new issue would fail the \"scope-discipline guard\" test.
- **\`.gitnexusignore\` negation semantics unchanged.** The env var is the orthogonal escape hatch, not a reinterpretation of the hardcoded-list rule.
- **\`isHardcodedIgnoredDirectory\` export unchanged.** Its contract is \"is this name in the raw list?\" — still returns \`true\` for \`__tests__\` / \`__mocks__\` regardless of env var state. The runtime effective decision is \`shouldIgnorePath\` / \`childrenIgnored\`, which go through the new helper. Existing callers and their test expectations are preserved.

## Default behaviour unchanged

Users who don't set the env var see byte-identical behaviour. No flag flips. No \`.gitnexusignore\` re-interpretation. The feature exists purely as an opt-in escape hatch for the QE use case the issue cites.

## Implementation

- **\`src/config/ignore-service.ts\`**: new \`isEffectivelyIgnoredDirectory\` helper (~15 lines with JSDoc). Swaps two direct \`DEFAULT_IGNORE_LIST.has(...)\` call-sites: \`shouldIgnorePath\` (affects filesystem walker AND wiki generator, since \`core/wiki/generator.ts\` calls \`shouldIgnorePath\` too) and \`createIgnoreFilter.childrenIgnored\` (affects directory pruning during traversal).
- **\`src/cli/index.ts\`**: one line added to analyze help text alongside existing \`GITNEXUS_NO_GITIGNORE\` / \`GITNEXUS_MAX_FILE_SIZE\` mentions.
- **\`test/unit/ignore-service.test.ts\`**: 9 new unit tests across 4 \`describe\` blocks — default-unset, opt-in-set, other-hardcoded-entries-unaffected (\`node_modules\`, \`.git\`, \`dist\`, \`__pycache__\`), scope-discipline guard, \`isHardcodedIgnoredDirectory\` semantic unchanged. Env state restored by \`afterEach\` to prevent leakage between tests.

## Verification (local)

- \`tsc --noEmit\` clean
- \`ignore-service.test.ts\` 130/130 (121 existing + 9 new)
- Wiki test (uses same \`shouldIgnorePath\` helper) passes unchanged
- \`npm run test:unit\` full suite 4360 pass; 4 pre-existing failures verified on pristine upstream main (2 git-utils env + 2 Swift parser, unrelated to this fix)

## Safety / scope

- **No destructive surface added** — zero \`fs.rm\`, zero registry writes, zero new file deletion paths
- **No LLM-accessible safety bypass** — not a bypass of any guard; an additive config toggle for what gets indexed
- **Cross-platform safe** — pure JS Set / string operations
- **No new dependencies**
- **No MCP contract changes** — \`tools.ts\` / \`resources.ts\` / \`server.ts\` untouched
- **No default change** — env unset = byte-identical
- **Rollback safe** — pure code revert, nothing on disk to unwind
- **Deliberate-design comment at \`ignore-service.ts:273\` respected** — \`.gitnexusignore\` negation semantics unchanged

Closes #771.