### PR TITLE
fix(deps): silence Node 22 DEP0151 warning from tree-sitter-c-sharp import (#1013)

### DIFF
--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -6,7 +6,8 @@ import Python from 'tree-sitter-python';
 import Java from 'tree-sitter-java';
 import C from 'tree-sitter-c';
 import CPP from 'tree-sitter-cpp';
-import CSharp from 'tree-sitter-c-sharp';
+// Explicit subpath import — see parser-loader.ts for rationale (#1013).
+import CSharp from 'tree-sitter-c-sharp/bindings/node/index.js';
 import Go from 'tree-sitter-go';
 import Rust from 'tree-sitter-rust';
 import PHP from 'tree-sitter-php';

--- a/gitnexus/src/core/tree-sitter/parser-loader.ts
+++ b/gitnexus/src/core/tree-sitter/parser-loader.ts
@@ -5,7 +5,12 @@ import Python from 'tree-sitter-python';
 import Java from 'tree-sitter-java';
 import C from 'tree-sitter-c';
 import CPP from 'tree-sitter-cpp';
-import CSharp from 'tree-sitter-c-sharp';
+// Explicit subpath import: tree-sitter-c-sharp declares `type: "module"` with
+// `main: "bindings/node"` (no extension) and no `exports` field, which triggers
+// Node 22's DEP0151 deprecation warning on the bare-package import. Importing
+// the built entrypoint directly bypasses the deprecated ESM main-field
+// resolution. (#1013)
+import CSharp from 'tree-sitter-c-sharp/bindings/node/index.js';
 import Go from 'tree-sitter-go';
 import Rust from 'tree-sitter-rust';
 import PHP from 'tree-sitter-php';


### PR DESCRIPTION
## Summary

Fix the `[DEP0151] DeprecationWarning` that Node 22 emits on every `gitnexus analyze` run, reported in #1013.

## Root cause

`tree-sitter-c-sharp` declares:

```json
{ "type": "module", "main": "bindings/node" }
```

No file extension on `main`, no `"exports"` field. On Node 22, an ESM consumer (our compiled CLI is `type: module`) that imports `from 'tree-sitter-c-sharp'` falls back to the **deprecated** main-field auto-extension resolution and Node prints:

```
[DEP0151] DeprecationWarning: Package .../tree-sitter-c-sharp/ has a "main" field set to "bindings/node"
Automatic extension resolution of the "main" field is deprecated for ES modules.
```

The other 10 tree-sitter grammars GitNexus imports (`tree-sitter-javascript`, `-typescript`, `-python`, `-java`, `-go`, `-rust`, `-ruby`, `-php`, `-c`, `-cpp`) all declare `"main": "bindings/node"` too, but they're CommonJS (no `"type": "module"`), so their main field is resolved via legacy CJS rules which aren't deprecated. Only `tree-sitter-c-sharp` trips DEP0151.

## Fix

Switch both callsites to the explicit subpath:

```diff
- import CSharp from 'tree-sitter-c-sharp';
+ import CSharp from 'tree-sitter-c-sharp/bindings/node/index.js';
```

- `gitnexus/src/core/tree-sitter/parser-loader.ts:8`
- `gitnexus/src/core/ingestion/workers/parse-worker.ts:9`

The explicit path bypasses the deprecated main-field resolution entirely. Types continue to resolve from the colocated `bindings/node/index.d.ts` that ships in the tarball.

Left the 10 CJS tree-sitter grammars alone — keeps the diff narrow and respects the reporter's proven scope.

An inline comment on the loader explains the deprecation rationale + back-links #1013, so no future contributor "simplifies" it back to the bare-package form.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | ✅ clean |
| `npm run test:unit` | ✅ 4466 passed / 4 failed / 2 skipped — the 4 failures are pre-existing env issues (2 git-utils on Windows temp-dir detection, 2 Swift method-extraction from the optional `tree-sitter-swift` native binding), identical to the failure set I saw pre-fix on clean upstream/main |

**Local DEP0151 repro**: could not reproduce the warning on my Node `v22.17.1` (both the bare import and the explicit-subpath import load without any deprecation output). The reporter confirmed the warning on Node `v22.22.2`, and their pre-tested fix is exactly what this PR applies. I treated this as a Node-minor-version sensitivity in the deprecation emission rather than evidence the fix is wrong, since:

1. The root cause (deprecated main-field ESM resolution) is documented behaviour.
2. The explicit subpath unambiguously avoids that resolution step for all Node versions.
3. Types and runtime loading both verified working locally.

If a reviewer can reproduce on their machine, happy to include the before/after output in a follow-up comment.

## Why only 2 files

Both `parser-loader.ts` and `parse-worker.ts` hold independent import copies of the tree-sitter grammar set (one for the main-thread registry, one for the worker-thread pool). The fix has to be applied to both.

Closes #1013.