### PR TITLE
test(gitnexus): stabilize rel-csv-split stream teardown on Windows (expect.poll)

### DIFF
--- a/gitnexus/test/unit/rel-csv-split.test.ts
+++ b/gitnexus/test/unit/rel-csv-split.test.ts
@@ -247,14 +247,14 @@ describe('splitRelCsvByLabelPair', () => {
       mockFactory(streams, { blocked: true }),
     );
 
-    // The first pair stream is created immediately and blocks on its header
-    // write. Unblock it once so the loop advances and creates the second
-    // pair stream (also blocked). Now both streams exist — trigger the error.
-    await new Promise((r) => setTimeout(r, 20));
-    expect(streams.length).toBe(1);
+    // The first pair stream is created once readline has delivered a data row;
+    // fixed sleeps race on slow Windows CI (streams.length still 0 → ENOTEMPTY
+    // in afterEach). Poll until the harness reaches the intended state.
+    await expect.poll(() => streams.length, { interval: 10, timeout: 10_000 }).toBe(1);
     streams[0].unblock();
-    await new Promise((r) => setTimeout(r, 20));
-    expect(streams.length).toBeGreaterThanOrEqual(2);
+    await expect
+      .poll(() => streams.length, { interval: 10, timeout: 10_000 })
+      .toBeGreaterThanOrEqual(2);
     streams[0].triggerError(new Error('EMFILE'));
 
     await expect(promise).rejects.toThrow('EMFILE');

--- a/gitnexus/test/unit/rel-csv-split.test.ts
+++ b/gitnexus/test/unit/rel-csv-split.test.ts
@@ -106,6 +106,8 @@ function writeCsv(lines: string[]): string {
 // ---------------------------------------------------------------------------
 describe('splitRelCsvByLabelPair', () => {
   const validTables = new Set(['Function', 'Class', 'File', 'Method']);
+  /** Bounded poll for readline + split loop to reach an observable milestone (DoD §2.7). */
+  const pollOpts = { interval: 10, timeout: 10_000 } as const;
 
   it('splits lines into per-pair files with correct row counts', async () => {
     const csvPath = writeCsv([
@@ -197,8 +199,8 @@ describe('splitRelCsvByLabelPair', () => {
       mockFactory(streams, { blocked: true }),
     );
 
-    // Give readline time to buffer and fire lines
-    await new Promise((r) => setTimeout(r, 50));
+    // All rows share Function|Class — one stream, blocked on header or row drain
+    await expect.poll(() => streams.length, pollOpts).toBe(1);
 
     // Unblock all streams so the Promise can resolve
     for (const ws of streams) ws.unblock();
@@ -222,9 +224,7 @@ describe('splitRelCsvByLabelPair', () => {
       mockFactory(streams, { blocked: true }),
     );
 
-    // Wait for readline to process, then error while paused on drain
-    await new Promise((r) => setTimeout(r, 50));
-    expect(streams.length).toBe(1);
+    await expect.poll(() => streams.length, pollOpts).toBe(1);
     streams[0].triggerError(new Error('disk full'));
 
     await expect(promise).rejects.toThrow('disk full');
@@ -247,14 +247,12 @@ describe('splitRelCsvByLabelPair', () => {
       mockFactory(streams, { blocked: true }),
     );
 
-    // The first pair stream is created once readline has delivered a data row;
-    // fixed sleeps race on slow Windows CI (streams.length still 0 → ENOTEMPTY
-    // in afterEach). Poll until the harness reaches the intended state.
-    await expect.poll(() => streams.length, { interval: 10, timeout: 10_000 }).toBe(1);
+    // First pair stream once readline delivered a row; poll avoids Windows CI races.
+    await expect.poll(() => streams.length, pollOpts).toBe(1);
     streams[0].unblock();
     // Exactly two pair keys before the third CSV row: Function|Class then
     // File|Method; the loop is blocked on the second stream's header drain.
-    await expect.poll(() => streams.length, { interval: 10, timeout: 10_000 }).toBe(2);
+    await expect.poll(() => streams.length, pollOpts).toBe(2);
     streams[0].triggerError(new Error('EMFILE'));
 
     await expect(promise).rejects.toThrow('EMFILE');

--- a/gitnexus/test/unit/rel-csv-split.test.ts
+++ b/gitnexus/test/unit/rel-csv-split.test.ts
@@ -224,7 +224,7 @@ describe('splitRelCsvByLabelPair', () => {
 
     // Wait for readline to process, then error while paused on drain
     await new Promise((r) => setTimeout(r, 50));
-    expect(streams.length).toBeGreaterThan(0);
+    expect(streams.length).toBe(1);
     streams[0].triggerError(new Error('disk full'));
 
     await expect(promise).rejects.toThrow('disk full');
@@ -252,9 +252,9 @@ describe('splitRelCsvByLabelPair', () => {
     // in afterEach). Poll until the harness reaches the intended state.
     await expect.poll(() => streams.length, { interval: 10, timeout: 10_000 }).toBe(1);
     streams[0].unblock();
-    await expect
-      .poll(() => streams.length, { interval: 10, timeout: 10_000 })
-      .toBeGreaterThanOrEqual(2);
+    // Exactly two pair keys before the third CSV row: Function|Class then
+    // File|Method; the loop is blocked on the second stream's header drain.
+    await expect.poll(() => streams.length, { interval: 10, timeout: 10_000 }).toBe(2);
     streams[0].triggerError(new Error('EMFILE'));
 
     await expect(promise).rejects.toThrow('EMFILE');


### PR DESCRIPTION
## Summary

Windows CI (run [24850653533](https://github.com/abhigyanpatwari/GitNexus/actions/runs/24850653533/job/72749889772)) flaked in `destroys all streams when one errors (no lingering FDs)` because a fixed 20ms `setTimeout` raced async readline / stream setup. The test now uses Vitest 4 `await expect.poll(() => streams.length, { interval: 10, timeout: 10_000 })` so assertions wait for the harness to reach the intended state instead of wall-clock guessing. Investigation: issue #1051.

---

## Definition of Done for this implementation

_(From `DoD.md` §7, tailored to this change.)_

- [x] **Runtime wiring is complete for the affected path.** — N/a for production: only `gitnexus/test/unit/rel-csv-split.test.ts` changed; no CLI/MCP/graph wiring.
- [x] **Requested behavior is correct and relevant contracts are preserved or explicitly updated.** — No public contracts, types, or persisted shapes touched.
- [x] **The design stays scoped, readable, and proportionate to the task.** — Replaces fixed delay + brittle length checks with bounded polling; same test intent (no lingering streams after error).
- [x] **Tests prove the changed behavior and catch broken wiring.** — Same scenario (error path + stream lifecycle); failure modes still surface if streams are not destroyed; polling removes host timing variance.
- [x] **Required validation for touched packages has been run, or any gap is explicitly noted.** — See **Validation** below; full `npm test` runs in CI.
- [x] **Repo boundaries, security, performance, and operational safety are respected.** — No new trust boundaries, I/O surfaces, or hot-path code; poll timeout capped at 10s.
- [x] **The diff contains only the intended change — no unrelated churn.** — Single targeted test adjustment for #1051.

---

## Validation

Per `DoD.md` §4.2 (`gitnexus/` touched):

| Command | Result |
|---------|--------|
| `cd gitnexus && npx tsc --noEmit` | Pass |
| `cd gitnexus && npx vitest run test/unit/rel-csv-split.test.ts` | Pass (8 tests) |
| `cd gitnexus && npx prettier --check test/unit/rel-csv-split.test.ts` | Pass |

**CI:** full `npm test` as in existing workflows (not re-run locally for this PR due to suite size).

**Build ordering:** `gitnexus-shared/` unchanged.

---

## Risks / N/A

| Area | Status |
|------|--------|
| **Contracts / compatibility** | N/A — no `gitnexus-shared`, MCP, HTTP, or CLI surface changes. |
| **Security** | N/A — test-only; no new injection or secret paths. |
| **Performance (prod)** | N/A — no runtime path change. |
| **Observability / operability** | N/A — no user-facing errors or logging. |
| **Residual risk** | Low: worst-case wait bounded by poll timeout if teardown regressed; failure remains explicit. |

---

## Review gates (`DoD.md` §5)

All six axes satisfied at trivial or N/A scope for a single deterministic test fix.

Fixes #1051
