### PR TITLE
docs(ci): Docker Hub PAT-only auth and DOCKERHUB_USERNAME variable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -140,14 +140,20 @@ jobs:
       # signatures. GHCR remains authoritative (it is the registry the
       # ClusterImagePolicy globs against by default), but Docker Hub is the
       # registry most users reach for first, so we publish there too.
-      # Requires repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (a scoped
-      # access token, NOT the account password) with write access to the
-      # `akonlabs/gitnexus` and `akonlabs/gitnexus-web` repos.
+      # Docker Hub auth is token-only in practice: create a Personal Access Token
+      # (Hub → Account settings → Security → New access token) with push scope to
+      # `akonlabs/gitnexus` and `akonlabs/gitnexus-web`. Never store the account
+      # password in GitHub — `docker/login-action` still names the token field
+      # `password` (Docker API), but the value must be the PAT.
+      # Prefer repo Variable `DOCKERHUB_USERNAME` (Docker ID or bot user) + Secret
+      # `DOCKERHUB_TOKEN` (the PAT). `secrets.DOCKERHUB_USERNAME` remains supported
+      # for older setups. OIDC-only login to docker.io is not available yet
+      # (docker/roadmap#314).
       - name: Log in to Docker Hub
         if: ${{ github.event_name != 'pull_request' && !inputs.dry_run }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Computes image tags and labels from the verified semver tag:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,18 @@ Two publish workflows ship `gitnexus` to npm:
   # then redispatch the workflow with force: true
   ```
 
+  **Docker Hub credentials (maintainers):** CI logs in with a **Docker Hub
+  Personal Access Token** only — do not add the Docker account password to
+  GitHub. In Docker Hub: *Account settings → Security → New access token*
+  (read/write for the `akonlabs/gitnexus` and `akonlabs/gitnexus-web`
+  repositories). Store the token as repository secret **`DOCKERHUB_TOKEN`**.
+  Store the Docker Hub **username** (Docker ID or bot user that owns the
+  token) as repository variable **`DOCKERHUB_USERNAME`** (preferred, not
+  sensitive) or, for legacy setups, as secret `DOCKERHUB_USERNAME`. The
+  `docker/login-action` step maps the PAT to its `password` input per Docker’s
+  documented GitHub Actions pattern; OIDC-only push to `docker.io` is not
+  supported by Hub yet.
+
   **Docker-only partial failure:** if `publish` succeeds (npm tarball + tags
   are live) but the `docker` job subsequently fails (e.g. GHCR flakiness),
   the npm RC is already published and the `rc/<HEAD_SHA>` marker is in place.


### PR DESCRIPTION
## Summary

Docker Hub already authenticates with a **Personal Access Token** in \docker/login-action\'s \password\ input (Docker's documented pattern — never the account password). This change makes that explicit and aligns with token-first ops:

- **Username:** \ars.DOCKERHUB_USERNAME\ (repository **variable**, preferred) with \secrets.DOCKERHUB_USERNAME\ fallback for existing repos.
- **Token:** \secrets.DOCKERHUB_TOKEN\ — must be a Hub **access token** (PAT), not the account password.

Docker Hub does not yet support OIDC-only \docker login\ from GitHub Actions for \docker.io\; see [docker/roadmap#314](https://github.com/docker/roadmap/issues/314).

## Maintainer action

Add repository variable \DOCKERHUB_USERNAME\ (Docker ID / bot) and keep \DOCKERHUB_TOKEN\ as the PAT. Repos that still use \secrets.DOCKERHUB_USERNAME\ continue to work.

## Files

- \.github/workflows/docker.yml\ — comments + username expression
- \CONTRIBUTING.md\ — Releases section: PAT setup steps