### PR TITLE
fix(ci): pass secrets to reusable docker job (RC Docker Hub login)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -379,6 +379,10 @@ jobs:
     needs: [guard, publish]
     if: needs.guard.outputs.should_run == 'true' && needs.publish.outputs.vtag != ''
     uses: ./.github/workflows/docker.yml
+    # Reusable workflows do not receive caller secrets unless inherited; without
+    # this, DOCKERHUB_* / GITHUB_TOKEN are empty in docker.yml → "Username and
+    # password required" on Docker Hub login (see same pattern on `ci:` above).
+    secrets: inherit
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

`release-candidate.yml` calls `docker.yml` as a **reusable workflow** but did not set `secrets: inherit`. Per GitHub Actions, [secrets are not passed to reusable workflows unless inherited](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-secrets-to-nested-workflows).

Symptom in [run 24853900024](https://github.com/abhigyanpatwari/GitNexus/actions/runs/24853900024/job/72767211163): **Log in to Docker Hub** fails with `Username and password required` because the `docker/login-action` step received empty `username` / `password` (only `logout: true` appears in the logged `with:` block). GHCR login still succeeded because `GITHUB_TOKEN` is injected separately.

## Fix

Add `secrets: inherit` to the `docker:` job (same pattern as the existing `ci:` job in this file).

## After merge

Re-run the failed Release Candidate workflow (or push a no-op / dispatch) so the Docker job picks up the fix.
