### PR TITLE
fix(ci): skip docker.yml tag-input validation on direct tag pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,8 +69,14 @@ jobs:
             slug: gitnexus
 
     steps:
+      # Only the workflow_call path requires a non-empty `inputs.tag` — callers
+      # (e.g. release-candidate.yml) must pass the RC tag explicitly. On direct
+      # tag pushes the tag comes from `github.ref`, so `inputs.tag` is always
+      # empty and validating it here would break every real release (#1064).
+      # The downstream "Verify tag matches gitnexus/package.json version" step
+      # handles both event types by falling back to GITHUB_REF.
       - name: Validate tag input
-        if: github.event_name == 'workflow_call' || github.event_name == 'push'
+        if: github.event_name == 'workflow_call'
         shell: bash
         env:
           TAG_INPUT: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary

The Docker Build & Push workflow failed on the v1.6.3 tag push:
https://github.com/abhigyanpatwari/GitNexus/actions/runs/24897853631/job/72907431113

\`\`\`
##[error]No tag provided to docker.yml — refusing to build/push.
\`\`\`

**Root cause:** The \"Validate tag input\" step runs on both \`workflow_call\` and \`push\` events, but on a tag push \`inputs.tag\` is always empty — the tag comes from \`github.ref\`. The guard was added in #983 with the intent of protecting the RC reusable-workflow path, but the \`|| push\` branch causes every real release to fail at that gate.

The downstream \"Verify tag matches gitnexus/package.json version\" step already handles both cases by falling back to \`GITHUB_REF\` when \`INPUT_TAG\` is empty, so the early guard only needs to cover \`workflow_call\`.

## Fix

Restrict the validate step to \`workflow_call\` only and add a comment explaining why \`push\` must not be included.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: re-publish v1.6.3 Docker images (see question in review)