### PR TITLE
docs: clarify PostToolUse hook is notification-only, not auto-reindex

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -23,7 +23,7 @@ Run from the project root. This parses all source files, builds the knowledge gr
 | `--embeddings`      | Enable embedding generation for semantic search (off by default)                                        |
 | `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them.    |
 
-**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
 
 ### status — Check index freshness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ npx gitnexus analyze --drop-embeddings  # explicit opt-in to wipe existing embed
 
 Check `.gitnexus/meta.json` `stats.embeddings` (0 = none). A plain `analyze` no longer drops existing vectors — pass `--drop-embeddings` to wipe.
 
-> Claude Code: PostToolUse hook handles this after `git commit` and `git merge`.
+> Claude Code: PostToolUse hook detects a stale index after `git commit` and `git merge` and prompts the agent to run `analyze`. The hook does not invoke `analyze` itself.
 
 ## CLI Skills
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To configure MCP for your editor, run `npx gitnexus setup` once — or set it up
 | **Windsurf**    | Yes | —     | —                   | MCP            |
 | **OpenCode**    | Yes | Yes    | —                   | MCP + Skills   |
 
-> **Claude Code** gets the deepest integration: MCP tools + agent skills + PreToolUse hooks that enrich searches with graph context + PostToolUse hooks that auto-reindex after commits.
+> **Claude Code** gets the deepest integration: MCP tools + agent skills + PreToolUse hooks that enrich searches with graph context + PostToolUse hooks that detect a stale index after commits and prompt the agent to reindex.
 
 ## Community Integrations
 

--- a/gitnexus/skills/gitnexus-cli.md
+++ b/gitnexus/skills/gitnexus-cli.md
@@ -23,7 +23,7 @@ Run from the project root. This parses all source files, builds the knowledge gr
 | `--embeddings` | Enable embedding generation for semantic search (off by default) |
 | `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
 
-**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
 
 ### status — Check index freshness
 


### PR DESCRIPTION
## Summary

The README, AGENTS.md, and `gitnexus-cli` skill all claim the PostToolUse hook runs `analyze` **automatically** after `git commit` and `git merge`. The hook source itself ([`gitnexus/hooks/claude/gitnexus-hook.cjs`](gitnexus/hooks/claude/gitnexus-hook.cjs)) explicitly chose notification-only:

> Instead of spawning a full `gitnexus analyze` synchronously (which blocks the agent for up to 120s and risks KuzuDB corruption on timeout), we do a lightweight staleness check: compare `git rev-parse HEAD` against the lastCommit stored in `.gitnexus/meta.json`. If they differ, notify the agent so it can decide when to reindex.

So users (and any AI agent reading the docs) form an incorrect mental model: they expect zero-touch reindex but actually get repeated stale-index notifications until they run `npx gitnexus analyze` themselves.

## What this PR changes

Four user-facing doc lines updated to match real behavior. No code changes — the hook already behaves correctly; only the docs were lying.

| File | Change |
| ---- | ------ |
| `README.md` (Editor Support callout) | "auto-reindex after commits" → "detect a stale index after commits and prompt the agent to reindex" |
| `AGENTS.md` (Keeping the Index Fresh) | "PostToolUse hook handles this" → "detects a stale index … and prompts the agent to run `analyze`. The hook does not invoke `analyze` itself." |
| `gitnexus/skills/gitnexus-cli.md` (analyze → When to run) | "runs `analyze` automatically" → "detects staleness … notifies the agent to run `analyze`" + adds the "why not auto-run" reasoning the hook author already wrote |
| `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` (analyze → When to run) | Same wording as above |

The Enterprise "Auto-reindexing" line at `README.md:71` is left intact — that describes a real Enterprise feature, distinct from the OSS hook.

## How I noticed this

I ran several `git commit` / `git merge` operations on a project that had GitNexus indexed, and each one fired the `[GitNexus] index is stale` notification. The CLAUDE.md generated by `gitnexus analyze` told me a hook would auto-reindex, so I assumed the hook was broken. After reading the hook source I realised the docs were the bug — the design choice is sound, just under-described.

## Test plan

- [x] No code changes — only Markdown text
- [x] Verified `gitnexus/hooks/claude/gitnexus-hook.cjs` does not call `gitnexus analyze` in any code path on PostToolUse (only `sendHookResponse` with the staleness message)
- [x] Skill markdown is included in published npm package output → end-user CLAUDE.md will reflect the corrected wording on next `gitnexus analyze`