### PR TITLE
fix: use os.homedir() instead of process.env.HOME for HuggingFace cache dir

### DIFF
--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -15,6 +15,7 @@ if (!process.env.ORT_LOG_LEVEL) {
 }
 
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import os from 'os';
 import { existsSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, dirname } from 'path';
@@ -161,7 +162,7 @@ export const initEmbedder = async (
       // ./node_modules/.cache inside its own install dir, which is unwritable
       // when gitnexus is installed globally (e.g. /usr/lib/node_modules/).
       // Respect HF_HOME if set, otherwise fall back to ~/.cache/huggingface.
-      env.cacheDir = process.env.HF_HOME ?? `${process.env.HOME}/.cache/huggingface`;
+      env.cacheDir = process.env.HF_HOME ?? join(os.homedir(), '.cache', 'huggingface');
 
       const isDev = process.env.NODE_ENV === 'development';
       if (isDev) {

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -6,6 +6,8 @@
  */
 
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import os from 'os';
+import { join } from 'path';
 import {
   isHttpMode,
   getHttpDimensions,
@@ -46,7 +48,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
       // ./node_modules/.cache inside its own install dir, which is unwritable
       // when gitnexus is installed globally (e.g. /usr/lib/node_modules/).
       // Respect HF_HOME if set, otherwise fall back to ~/.cache/huggingface.
-      env.cacheDir = process.env.HF_HOME ?? `${process.env.HOME}/.cache/huggingface`;
+      env.cacheDir = process.env.HF_HOME ?? join(os.homedir(), '.cache', 'huggingface');
 
       console.error('GitNexus: Loading embedding model (first search may take a moment)...');
 


### PR DESCRIPTION
## Summary

On Windows, `HOME` environment variable is not set by default. When running `gitnexus analyze --embeddings`, the cache directory resolves to `undefined/.cache/huggingface/` because `process.env.HOME` returns `undefined`, which gets stringified into the path.

This pollutes the working tree with an `undefined/` directory containing ~86 MB of model files, risks accidental commits, and prevents cache sharing between repos.

## Changes

- Replace `process.env.HOME` with `os.homedir()` which correctly resolves the user home directory on Windows, macOS, and Linux
- Use `path.join()` for cross-platform path construction instead of template literals
- Applied to both `gitnexus/src/core/embeddings/embedder.ts` and `gitnexus/src/mcp/core/embedder.ts`

## Test

- Verified on Linux that `os.homedir()` returns the correct home directory
- `HF_HOME` environment variable priority is preserved

Fixes #1068