### PR TITLE
fix(csharp): copy-on-read frozen binding arrays in namespace-siblings

### DIFF
--- a/gitnexus/src/core/ingestion/languages/csharp/namespace-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/namespace-siblings.ts
@@ -308,7 +308,13 @@ export function populateCsharpNamespaceSiblings(
           scopeBindings = new Map<string, BindingRef[]>();
           finalized.set(moduleScope.id, scopeBindings);
         }
-        const existing = scopeBindings.get(simpleName) ?? [];
+        // Copy on read: scope-extractor.ts freezes per-name binding
+        // arrays via `Object.freeze(refs.slice())` (search:
+        // scope-extractor.ts `frozenBindings.set(name, Object.freeze`).
+        // If the populator hits a name pre-populated by the extractor,
+        // mutating the returned array throws "Cannot add property N,
+        // object is not extensible". Spread to a fresh mutable copy.
+        const existing: BindingRef[] = [...(scopeBindings.get(simpleName) ?? [])];
         if (existing.some((b) => b.def.nodeId === memberDef.nodeId)) continue;
         existing.push({ def: memberDef, origin: 'import' });
         scopeBindings.set(simpleName, existing);
@@ -342,7 +348,8 @@ export function populateCsharpNamespaceSiblings(
           scopeBindings = new Map<string, BindingRef[]>();
           finalized.set(moduleScope.id, scopeBindings);
         }
-        const existing = scopeBindings.get(simpleName) ?? [];
+        // Copy on read — see `import` site above for rationale.
+        const existing: BindingRef[] = [...(scopeBindings.get(simpleName) ?? [])];
         if (existing.some((b) => b.def.nodeId === def.nodeId)) continue;
         existing.push({ def, origin: 'namespace' });
         scopeBindings.set(simpleName, existing);
@@ -378,7 +385,8 @@ export function populateCsharpNamespaceSiblings(
         const local = bucket.scopes.find((s) => s.filePath === filePath)?.scope.bindings.get(name);
         if (local !== undefined && local.some((b) => b.origin === 'local')) continue;
 
-        const existing = scopeBindings.get(name) ?? [];
+        // Copy on read — see import-site comment above for rationale.
+        const existing: BindingRef[] = [...(scopeBindings.get(name) ?? [])];
         for (const def of defs) {
           if (def.filePath === filePath) continue; // don't self-reference
           if (existing.some((b) => b.def.nodeId === def.nodeId)) continue;

--- a/gitnexus/test/fixtures/cross-file-binding/csharp-frozen-binding-collision/App/Program.cs
+++ b/gitnexus/test/fixtures/cross-file-binding/csharp-frozen-binding-collision/App/Program.cs
@@ -1,0 +1,30 @@
+// Regression: scope-extractor froze the bindings array for `User`
+// (because Program.cs locally declares `class User`). Then
+// populateCsharpNamespaceSiblings's `using Collision.Models;` tried
+// to push the cross-file `User` into the SAME frozen array, throwing
+// "Cannot add property N, object is not extensible" and abandoning
+// scope resolution for the whole repo.
+using Collision.Models;
+
+namespace Collision.App
+{
+    // Local class with the same simple name as the cross-file sibling —
+    // forces scope-extractor to pre-populate `User` in the Module scope's
+    // bindings (frozen). The populator then injects another binding for
+    // the same simple name via the `using Collision.Models;` directive.
+    public class User
+    {
+        public string GetName() { return "app"; }
+    }
+
+    public class Program
+    {
+        public void Run()
+        {
+            // Local takes precedence (origin:local shadows origin:namespace);
+            // the test only cares that the analysis doesn't blow up.
+            var u = new User();
+            u.GetName();
+        }
+    }
+}

--- a/gitnexus/test/fixtures/cross-file-binding/csharp-frozen-binding-collision/Collision.csproj
+++ b/gitnexus/test/fixtures/cross-file-binding/csharp-frozen-binding-collision/Collision.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Collision</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/gitnexus/test/fixtures/cross-file-binding/csharp-frozen-binding-collision/Models/User.cs
+++ b/gitnexus/test/fixtures/cross-file-binding/csharp-frozen-binding-collision/Models/User.cs
@@ -1,0 +1,7 @@
+namespace Collision.Models
+{
+    public class User
+    {
+        public string GetName() { return "models"; }
+    }
+}

--- a/gitnexus/test/integration/resolvers/csharp.test.ts
+++ b/gitnexus/test/integration/resolvers/csharp.test.ts
@@ -2420,3 +2420,52 @@ describe('C# class-name receiver write ACCESSES (merged Case 2 kind-aware branch
     expect(stray).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: scope-extractor freezes binding arrays per name (see
+// `scope-extractor.ts: frozenBindings.set(name, Object.freeze(refs.slice()))`).
+// `populateCsharpNamespaceSiblings` then reads `scopeBindings.get(name)`
+// and tries to `existing.push(...)` on the frozen array, throwing
+// `TypeError: Cannot add property N, object is not extensible` at
+// `namespace-siblings.ts` and abandoning scope resolution for the
+// entire repo. Triggered when a file locally declares a class with the
+// same simple name as a class in a `using`-imported sibling namespace.
+// Reproduced live on a real-world WinForms repo (PersistentWindows).
+// Fix: copy-on-read the existing entry before mutating.
+// ---------------------------------------------------------------------------
+
+describe('C# regression: namespace-siblings injection vs frozen bindings', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(CROSS_FILE_FIXTURES, 'csharp-frozen-binding-collision'),
+      () => {},
+    );
+  }, 60000);
+
+  it('finishes scope resolution without throwing on collision', () => {
+    // `result` is non-null only when the full pipeline completed.
+    // Pre-fix this `beforeAll` would reject with the "Cannot add
+    // property N, object is not extensible" error from
+    // `populateCsharpNamespaceSiblings`.
+    expect(result).toBeDefined();
+  });
+
+  it('detects both User declarations (cross-file sibling + local)', () => {
+    const classes = getNodesByLabel(result, 'Class');
+    // Two `User` classes — one in Models, one in App — plus Program.
+    expect(classes.filter((n) => n === 'User').length).toBe(2);
+    expect(classes).toContain('Program');
+  });
+
+  it('still resolves the local User binding (origin:local shadows namespace)', () => {
+    // `new User()` inside Program.Run() must point at the local
+    // `Collision.App.User`, not `Collision.Models.User`.
+    const calls = getRelationships(result, 'CALLS');
+    const newUserCall = calls.find(
+      (c) => c.source === 'Run' && c.target === 'User' && c.targetFilePath.includes('App'),
+    );
+    expect(newUserCall).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`scope-extractor.ts` freezes per-name binding arrays via `frozenBindings.set(name, Object.freeze(refs.slice()))` (line 180). When `populateCsharpNamespaceSiblings` later reads back an existing entry via `scopeBindings.get(name) ?? []` and tries to `existing.push(...)` on it, the frozen reference throws

```
TypeError: Cannot add property N, object is not extensible
    at Array.push (<anonymous>)
    at Object.populateCsharpNamespaceSiblings [as populateNamespaceSiblings]
      (.../csharp/namespace-siblings.js:321:26)
    at runScopeResolution (.../scope-resolution/pipeline/run.js:113:18)
    ...
  Phase 'scopeResolution' failed
```

…which abandons scope resolution for the **entire repo** (the index is never produced). The populator's leading comment says "indexes.bindings is typed ReadonlyMap<...> but is a plain Map at runtime; mutating here is the established pattern" — that's true for the outer `Map`, but the inner per-name arrays are nonetheless frozen by the extractor, so the established pattern is silently broken at three sites.

## Reproduction

Triggered when a file locally declares a class with the same simple name as a class in a sibling namespace imported via `using`. Hit live on the [PersistentWindows](https://github.com/kangyu-california/PersistentWindows) real-world WinForms repo (large mix of `.Designer.cs` + namespaced classes); also hit on smaller mixed-namespace C# codebases.

Minimal fixture added under `test/fixtures/cross-file-binding/csharp-frozen-binding-collision/`:
- `Models/User.cs` declares `Collision.Models.User`
- `App/Program.cs` imports `using Collision.Models;` AND locally declares `class User` in `Collision.App` — the local declaration causes scope-extractor to populate (and freeze) `User` in the Module scope's bindings; the populator's namespace-import path then attempts to push `Collision.Models.User` into the same frozen array.

## Fix

Spread to a fresh mutable copy on read at all three sites in `populateCsharpNamespaceSiblings`:

```diff
- const existing = scopeBindings.get(name) ?? [];
+ const existing: BindingRef[] = [...(scopeBindings.get(name) ?? [])];
```

When the populator hits a name pre-populated by the extractor, it now appends to a fresh array and writes that back, replacing the frozen entry in the per-scope Map. Origin precedence (`local` shadows `namespace`) is preserved by the existing `csharpMergeBindings` ordering (see `csharp-hooks.test.ts`).

Three sites fixed:
- `populateCsharpNamespaceSiblings` using-static loop (`origin: 'import'`)
- `populateCsharpNamespaceSiblings` namespace-import loop (`origin: 'namespace'`)
- `populateCsharpNamespaceSiblings` cross-namespace bucket loop (third namespace-injection site)

## Verification

- **`npx tsc --noEmit`** clean
- **`npx vitest run test/integration/resolvers/csharp.test.ts test/unit/scope-resolution/csharp/ test/unit/named-bindings/csharp.test.ts`** → 5 test files / 282 tests / 0 fail (3 of those are the new regression test + 279 existing).
- **Pre-fix** `beforeAll` of the new test rejects with `Phase 'scopeResolution' failed: Cannot add property N, object is not extensible`. **Post-fix** all three test cases pass: scope resolution completes, both `User` declarations are detected, and `new User()` inside `Program.Run()` resolves to the local `Collision.App.User` (origin:local shadows origin:namespace).

## Risk / rollback

Minimal — purely a copy-on-read tweak in a populator that already documented its intent to mutate the per-name arrays. Behavior is unchanged for callers that don't pre-populate the same name. The `Object.freeze` upstream in `scope-extractor.ts` is left in place; if a future change wants to enforce true immutability throughout, this is the right starting point because it makes the freeze contract honest at the populator boundary instead of silently broken.

Rollback: revert the commit; the upstream behavior degrades back to crashing on collision.

## Test plan

- [x] `npx tsc --noEmit` in `gitnexus/`
- [x] Full C# test suite green (integration + unit + named-bindings)
- [x] New regression test fails before fix, passes after
- [ ] Optional: maintainer to run on a wider corpus