### PR TITLE
test(csharp): companion fixture for #1066 frozen-bucket regression

### DIFF
--- a/gitnexus/test/fixtures/lang-resolution/csharp-frozen-binding-collision/App/Program.cs
+++ b/gitnexus/test/fixtures/lang-resolution/csharp-frozen-binding-collision/App/Program.cs
@@ -1,0 +1,18 @@
+using Collision.Models;
+
+namespace Collision.App
+{
+    public class User
+    {
+        public string GetName() { return "app"; }
+    }
+
+    public class Program
+    {
+        public void Run()
+        {
+            var u = new User();
+            u.GetName();
+        }
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/csharp-frozen-binding-collision/CsharpFrozenBindingCollision.csproj
+++ b/gitnexus/test/fixtures/lang-resolution/csharp-frozen-binding-collision/CsharpFrozenBindingCollision.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Collision</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/gitnexus/test/fixtures/lang-resolution/csharp-frozen-binding-collision/Models/User.cs
+++ b/gitnexus/test/fixtures/lang-resolution/csharp-frozen-binding-collision/Models/User.cs
@@ -1,0 +1,7 @@
+namespace Collision.Models
+{
+    public class User
+    {
+        public string GetName() { return "models"; }
+    }
+}

--- a/gitnexus/test/integration/resolvers/csharp.test.ts
+++ b/gitnexus/test/integration/resolvers/csharp.test.ts
@@ -2485,3 +2485,50 @@ describe('C# large-file + frozen-bucket regression (issue #1066)', () => {
     expect(['import-resolved', 'global']).toContain(save!.rel.reason);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #1066 companion regression: small-file trigger for the same
+// frozen-bucket failure. Where csharp-large-cache-miss-resolution exercises
+// the path through tree-sitter cache-miss reparse on >32 KB files, this
+// fixture trips the same `Object.freeze` contract on the populator's
+// namespace-import loop in a single small file pair: the importer locally
+// declares a class with the same simple name as a sibling reachable through
+// `using`, so the extractor pre-populates (and freezes) `User` in the
+// importer's Module bindings before populateNamespaceSiblings tries to
+// append the cross-file `Collision.Models.User`. Pre-#1082 the populator
+// pushed onto the frozen array → "Cannot add property N, object is not
+// extensible" → whole scopeResolution phase aborted. Post-#1082 the
+// augmentation channel keeps both bindings visible to readers, with the
+// local `Collision.App.User` taking precedence per origin ordering.
+// ---------------------------------------------------------------------------
+
+describe('C# frozen-binding collision via using-import (issue #1066 companion)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'csharp-frozen-binding-collision'),
+      () => {},
+    );
+  }, 60000);
+
+  it('completes scopeResolution without throwing on the colliding bucket', () => {
+    expect(getNodesByLabel(result, 'Class')).toEqual(expect.arrayContaining(['User', 'Program']));
+  });
+
+  it('detects both User declarations across the two namespaces', () => {
+    const users = getNodesByLabelFull(result, 'Class').filter((n) => n.name === 'User');
+    expect(users.length).toBe(2);
+    const paths = users.map((u) => u.properties.filePath).sort();
+    expect(paths).toEqual(['App/Program.cs', 'Models/User.cs']);
+  });
+
+  it('resolves Program.Run -> local Collision.App.User constructor (origin:local shadows namespace)', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const ctor = calls.find(
+      (c) => c.source === 'Run' && c.target === 'User' && c.targetLabel === 'Class',
+    );
+    expect(ctor).toBeDefined();
+    expect(ctor!.targetFilePath).toBe('App/Program.cs');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a small-file companion fixture for the freeze-contract regression fixed in #1082. The merged `csharp-large-cache-miss-resolution` fixture reproduces the failure via the >32 KB tree-sitter cache-miss reparse path; this fixture trips the same `Object.freeze` contract in `populateCsharpNamespaceSiblings` through a different trigger that doesn't depend on file size:

> An importer locally declares a class with the same simple name as a sibling reachable through `using`, so scope-extractor pre-populates (and freezes) `User` in the importer's Module bindings before the populator's namespace-import loop tries to append the cross-file `Collision.Models.User`.

Pre-#1082 the populator pushed onto the frozen array → `TypeError: Cannot add property N, object is not extensible` → the whole `scopeResolution` phase aborted for the repo. Post-#1082 the augmentation channel keeps both bindings visible to readers; the local `Collision.App.User` shadows the namespace-imported one per origin precedence.

This is the trigger we originally hit on the [PersistentWindows](https://github.com/kangyu-california/PersistentWindows) real-world WinForms repo and used to reproduce the bug in the (now-closed) #1083 — adding it here as resolver coverage so the freeze contract is locked-in on both reproduction paths.

## Fixture

`test/fixtures/lang-resolution/csharp-frozen-binding-collision/`:
- `Models/User.cs` — `namespace Collision.Models { public class User { ... } }`
- `App/Program.cs` — `using Collision.Models;` + `namespace Collision.App { public class User { ... } public class Program { ... } }`

Tiny by design — the bug is shape-driven, not size-driven, so the fixture stays small and fast (567 ms for the new describe vs ~25 s for the cache-miss fixture in the same suite).

## Tests

New describe block in `test/integration/resolvers/csharp.test.ts`, sibling to the merged `'C# large-file + frozen-bucket regression (issue #1066)'` block:

- `completes scopeResolution without throwing on the colliding bucket` — the freeze regression itself.
- `detects both User declarations across the two namespaces` — pins augmentation visibility.
- `resolves Program.Run -> local Collision.App.User constructor (origin:local shadows namespace)` — pins the precedence contract that makes the augmentation channel architecturally correct (not just non-throwing).

Crossreference: `test/integration/resolvers/csharp.test.ts:2454` (cache-miss-reparse trigger) ↔ new block (collision-via-using-import trigger). Both anchor on the same `bindingAugmentations` machinery added in #1082; either one reverting reproduces #1066.

## Validation

- `npx vitest run test/integration/resolvers/csharp.test.ts` → **207 passed / 0 failed** (was 204; +3 new).
- `npx tsc --noEmit` → clean.
- Pre-commit hook (typecheck) green.
- Verified end-to-end on PersistentWindows after rebuilding from `upstream/main` (#1082 merged): 0 freeze errors, **1113 nodes / 2987 edges / 39 clusters / 97 flows** vs **1025 / 1715 / 28 / 25** with the closed #1083 workaround. The augmentation channel reaches ~74 % more cross-file edges than copy-on-read could.

## Test plan

- [x] `npx vitest run test/integration/resolvers/csharp.test.ts` (full file)
- [x] `npx tsc --noEmit` in `gitnexus/`
- [x] New describe runs in <1 s isolated; doesn't slow the resolver suite materially
- [x] Each new test fails on a hypothetical revert of #1082's Step 4 (write target back to `indexes.bindings`) — same shape as the merged #1066 fixture's bidirectional revert verification