### PR TITLE
fix(ingestion): classify Python class methods as Method

### DIFF
--- a/gitnexus/src/core/ingestion/languages/python.ts
+++ b/gitnexus/src/core/ingestion/languages/python.ts
@@ -31,6 +31,7 @@ import { pythonCallConfig } from '../call-extractors/configs/python.js';
 import { createHeritageExtractor } from '../heritage-extractors/generic.js';
 import {
   emitPythonScopeCaptures,
+  pythonFunctionDefinitionLabel,
   interpretPythonImport,
   interpretPythonTypeBinding,
   pythonArityCompatibility,
@@ -88,6 +89,7 @@ export const pythonProvider = defineLanguage({
   classExtractor: createClassExtractor(pythonClassConfig),
   heritageExtractor: createHeritageExtractor(SupportedLanguages.Python),
   builtInNames: BUILT_INS,
+  labelOverride: pythonFunctionDefinitionLabel,
 
   // ── RFC #909 Ring 3: scope-based resolution hooks (RFC §5) ──────────
   // Python is the first migration. See ./python/index.ts for the

--- a/gitnexus/src/core/ingestion/languages/python/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/python/captures.ts
@@ -24,6 +24,7 @@ import { synthesizeReceiverTypeBinding } from './receiver-binding.js';
 import { computePythonArityMetadata } from './arity-metadata.js';
 import { recordCacheHit, recordCacheMiss } from './cache-stats.js';
 import { getTreeSitterBufferSize } from '../../constants.js';
+import { pythonFunctionDefinitionLabel } from './simple-hooks.js';
 
 export function emitPythonScopeCaptures(
   sourceText: string,
@@ -98,6 +99,10 @@ export function emitPythonScopeCaptures(
       const anchorCap = grouped['@declaration.function']!;
       const fnNode = findNodeAtRange(tree.rootNode, anchorCap.range, 'function_definition');
       if (fnNode !== null) {
+        if (pythonFunctionDefinitionLabel(fnNode, 'Function') === 'Method') {
+          delete grouped['@declaration.function'];
+          grouped['@declaration.method'] = { ...anchorCap, name: '@declaration.method' };
+        }
         const arity = computePythonArityMetadata(fnNode);
         if (arity.parameterCount !== undefined) {
           grouped['@declaration.parameter-count'] = syntheticCapture(

--- a/gitnexus/src/core/ingestion/languages/python/index.ts
+++ b/gitnexus/src/core/ingestion/languages/python/index.ts
@@ -80,6 +80,7 @@ export { pythonArityCompatibility } from './arity.js';
 export { resolvePythonImportTarget, type PythonResolveContext } from './import-target.js';
 export {
   pythonBindingScopeFor,
+  pythonFunctionDefinitionLabel,
   pythonImportOwningScope,
   pythonReceiverBinding,
 } from './simple-hooks.js';

--- a/gitnexus/src/core/ingestion/languages/python/simple-hooks.ts
+++ b/gitnexus/src/core/ingestion/languages/python/simple-hooks.ts
@@ -8,12 +8,30 @@
 
 import type {
   CaptureMatch,
+  NodeLabel,
   ParsedImport,
   Scope,
   ScopeId,
   ScopeTree,
   TypeRef,
 } from 'gitnexus-shared';
+import type { SyntaxNode } from 'tree-sitter';
+import { findAncestorBeforeBoundary, FUNCTION_NODE_TYPES } from '../../utils/ast-helpers.js';
+
+const PYTHON_METHOD_CONTAINER_TYPES: ReadonlySet<string> = new Set(['class_definition']);
+
+export function pythonFunctionDefinitionLabel(
+  functionNode: SyntaxNode,
+  defaultLabel: NodeLabel,
+): NodeLabel {
+  if (defaultLabel !== 'Function') return defaultLabel;
+  const ancestor = findAncestorBeforeBoundary(
+    functionNode,
+    PYTHON_METHOD_CONTAINER_TYPES,
+    FUNCTION_NODE_TYPES,
+  );
+  return ancestor === null ? 'Function' : 'Method';
+}
 
 // ─── bindingScopeFor ──────────────────────────────────────────────────────
 

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -166,6 +166,21 @@ export const CONTAINER_TYPE_TO_LABEL: Record<string, string> = {
   companion_object: 'Class',
 };
 
+/** Return the first matching ancestor unless a boundary ancestor is reached first. */
+export function findAncestorBeforeBoundary(
+  node: SyntaxNode,
+  targetTypes: ReadonlySet<string>,
+  boundaryTypes: ReadonlySet<string>,
+): SyntaxNode | null {
+  let current = node.parent;
+  while (current !== null) {
+    if (boundaryTypes.has(current.type)) return null;
+    if (targetTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
 /**
  * Determine the graph node label from a tree-sitter capture map.
  * Handles language-specific reclassification via the provider's labelOverride hook

--- a/gitnexus/test/fixtures/lang-resolution/python-member-calls/user.py
+++ b/gitnexus/test/fixtures/lang-resolution/python-member-calls/user.py
@@ -1,3 +1,6 @@
 class User:
     def save(self):
         return True
+
+    def __getitem__(self, key):
+        return None

--- a/gitnexus/test/integration/cross-file-binding.test.ts
+++ b/gitnexus/test/integration/cross-file-binding.test.ts
@@ -338,9 +338,7 @@ describe('Phase 9 — Cross-File Call-Result Binding: Python', () => {
 
   it('detects User class with save and get_name methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
-    // Python tree-sitter captures all function_definitions as Function, including methods
-    expect(getNodesByLabel(result, 'Function')).toContain('save');
-    expect(getNodesByLabel(result, 'Function')).toContain('get_name');
+    expect(getNodesByLabel(result, 'Method')).toEqual(expect.arrayContaining(['save', 'get_name']));
   });
 
   it('detects get_user function and run function', () => {
@@ -702,10 +700,9 @@ describe('Consumer-Before-Provider: Python', () => {
     );
   }, 60000);
 
-  it('detects User class and save function', () => {
+  it('detects User class and save method', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
-    // Python tree-sitter captures all function_definitions as Function, including methods
-    expect(getNodesByLabel(result, 'Function')).toContain('save');
+    expect(getNodesByLabel(result, 'Method')).toContain('save');
   });
 
   it('resolves u.save() in main() to User#save', () => {

--- a/gitnexus/test/integration/resolvers/python.test.ts
+++ b/gitnexus/test/integration/resolvers/python.test.ts
@@ -35,12 +35,12 @@ describe('Python relative import & heritage resolution', () => {
     result = await runPipelineFromRepo(path.join(FIXTURES, 'python-pkg'), () => {});
   }, 60000);
 
-  it('detects exactly 3 classes and 5 functions', () => {
+  it('classifies top-level functions separately from class methods', () => {
     expect(getNodesByLabel(result, 'Class')).toEqual(['AuthService', 'BaseModel', 'User']);
-    expect(getNodesByLabel(result, 'Function')).toEqual([
+    expect(getNodesByLabel(result, 'Function')).toEqual(['process_model']);
+    expect(getNodesByLabel(result, 'Method')).toEqual([
       'authenticate',
       'get_name',
-      'process_model',
       'save',
       'validate',
     ]);
@@ -158,10 +158,13 @@ describe('Python member-call resolution', () => {
     expect(saveCall!.targetFilePath).toBe('user.py');
   });
 
-  it('detects User class and save function (Python methods are Function nodes)', () => {
+  it('classifies regular and dunder class-body functions as Method nodes', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
-    // Python tree-sitter captures all function_definitions as Function, including methods
-    expect(getNodesByLabel(result, 'Function')).toContain('save');
+    expect(getNodesByLabel(result, 'Method')).toEqual(
+      expect.arrayContaining(['save', '__getitem__']),
+    );
+    expect(getNodesByLabel(result, 'Function')).not.toContain('save');
+    expect(getNodesByLabel(result, 'Function')).not.toContain('__getitem__');
   });
 });
 
@@ -176,11 +179,10 @@ describe('Python receiver-constrained resolution', () => {
     result = await runPipelineFromRepo(path.join(FIXTURES, 'python-receiver-resolution'), () => {});
   }, 60000);
 
-  it('detects User and Repo classes, both with save functions', () => {
+  it('detects User and Repo classes, both with save methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    // Python tree-sitter captures all function_definitions as Function
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -516,7 +518,7 @@ describe('Python constructor-inferred type resolution', () => {
   it('detects User and Repo classes, both with save methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -558,8 +560,7 @@ describe('Python constructor-call resolution', () => {
 
   it('detects User class with __init__ and save methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
-    expect(getNodesByLabel(result, 'Function')).toContain('__init__');
-    expect(getNodesByLabel(result, 'Function')).toContain('save');
+    expect(getNodesByLabel(result, 'Method')).toEqual(expect.arrayContaining(['__init__', 'save']));
     expect(getNodesByLabel(result, 'Function')).toContain('process');
   });
 
@@ -600,9 +601,9 @@ describe('Python self resolution', () => {
     );
   }, 60000);
 
-  it('detects User and Repo classes, each with a save function', () => {
+  it('detects User and Repo classes, each with a save method', () => {
     expect(getNodesByLabel(result, 'Class')).toEqual(['Repo', 'User']);
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -726,8 +727,7 @@ describe('Python walrus operator type inference', () => {
 
   it('detects User class with save and greet methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
-    expect(getNodesByLabel(result, 'Function')).toContain('save');
-    expect(getNodesByLabel(result, 'Function')).toContain('greet');
+    expect(getNodesByLabel(result, 'Method')).toEqual(expect.arrayContaining(['save', 'greet']));
   });
 
   it('resolves user.save() via walrus operator constructor inference', () => {
@@ -752,7 +752,7 @@ describe('Python class-level annotation resolution', () => {
   it('detects User and Repo classes, both with save methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -899,10 +899,10 @@ describe('Python nullable receiver resolution', () => {
     result = await runPipelineFromRepo(path.join(FIXTURES, 'python-nullable-receiver'), () => {});
   }, 60000);
 
-  it('detects User and Repo classes, both with save functions', () => {
+  it('detects User and Repo classes, both with save methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -952,7 +952,7 @@ describe('Python assignment chain propagation', () => {
   it('detects User and Repo classes each with a save method', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -1014,7 +1014,7 @@ describe('Python nullable (User | None) + assignment chain combined', () => {
   it('detects User and Repo classes each with a save method', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -1076,10 +1076,10 @@ describe('Python walrus operator (:=) assignment chain', () => {
     result = await runPipelineFromRepo(path.join(FIXTURES, 'python-walrus-chain'), () => {});
   }, 60000);
 
-  it('detects User and Repo classes each with a save function', () => {
+  it('detects User and Repo classes each with a save method', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -1143,7 +1143,7 @@ describe('Python match/case as-pattern type binding', () => {
   it('detects User and Repo classes each with a save method', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    const saveFns = getNodesByLabel(result, 'Function').filter((m) => m === 'save');
+    const saveFns = getNodesByLabel(result, 'Method').filter((m) => m === 'save');
     expect(saveFns.length).toBe(2);
   });
 
@@ -1261,8 +1261,7 @@ describe('Python member access iterable for-loop', () => {
   it('detects User and Repo classes with save methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
     expect(getNodesByLabel(result, 'Class')).toContain('Repo');
-    // Python tree-sitter captures all function_definitions as Function, including methods
-    expect(getNodesByLabel(result, 'Function')).toContain('save');
+    expect(getNodesByLabel(result, 'Method')).toContain('save');
   });
 
   it('resolves user.save() via self.users to User#save', () => {
@@ -1486,7 +1485,7 @@ describe('Field type disambiguation (Python)', () => {
   }, 60000);
 
   it('detects both User#save and Address#save', () => {
-    const methods = getNodesByLabel(result, 'Function');
+    const methods = getNodesByLabel(result, 'Method');
     const saveMethods = methods.filter((m) => m === 'save');
     expect(saveMethods.length).toBe(2);
   });
@@ -1651,8 +1650,7 @@ describe('Python cross-file binding propagation', () => {
 
   it('detects User class with save and get_name methods', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('User');
-    expect(getNodesByLabel(result, 'Function')).toContain('save');
-    expect(getNodesByLabel(result, 'Function')).toContain('get_name');
+    expect(getNodesByLabel(result, 'Method')).toEqual(expect.arrayContaining(['save', 'get_name']));
   });
 
   it('detects get_user and run functions', () => {
@@ -1717,12 +1715,12 @@ describe('Python module import CALLS resolution (Issue #337)', () => {
     expect(classes.filter((c) => c === 'Admin').length).toBe(1);
   });
 
-  it('detects exactly 3 Function nodes: save, verify, login', () => {
-    const fns = getNodesByLabel(result, 'Function');
-    expect(fns.length).toBe(3);
-    expect(fns).toContain('save');
-    expect(fns).toContain('verify');
-    expect(fns).toContain('login');
+  it('detects exactly 3 Method nodes: save, verify, login', () => {
+    const methods = getNodesByLabel(result, 'Method');
+    expect(methods.length).toBe(3);
+    expect(methods).toContain('save');
+    expect(methods).toContain('verify');
+    expect(methods).toContain('login');
   });
 
   // ── IMPORTS edges ───────────────────────────────────────────────────
@@ -2024,13 +2022,14 @@ describe('Python overload dispatch', () => {
     expect(getNodesByLabel(result, 'Class')).toContain('Formatter');
   });
 
-  it('detects all functions including methods', () => {
+  it('classifies overload methods separately from free functions', () => {
     const fns = getNodesByLabel(result, 'Function');
-    expect(fns).toContain('format');
-    expect(fns).toContain('format_with_prefix');
     expect(fns).toContain('format_text');
     expect(fns).toContain('format_text_with_width');
     expect(fns).toContain('run');
+    expect(getNodesByLabel(result, 'Method')).toEqual(
+      expect.arrayContaining(['format', 'format_with_prefix']),
+    );
   });
 
   it('emits HAS_METHOD for Formatter.format and Formatter.format_with_prefix', () => {

--- a/gitnexus/test/integration/resolvers/python.test.ts
+++ b/gitnexus/test/integration/resolvers/python.test.ts
@@ -2539,7 +2539,7 @@ def create_utf8_user():
 
   it('extracts trailing functions after large ASCII and UTF-8 padding', () => {
     expect(getNodesByLabel(result, 'Function')).toEqual(
-      expect.arrayContaining(['create_ascii_user', 'create_utf8_user', 'save']),
+      expect.arrayContaining(['create_ascii_user', 'create_utf8_user']),
     );
   });
 

--- a/gitnexus/test/unit/scope-resolution/python/python-fixtures.test.ts
+++ b/gitnexus/test/unit/scope-resolution/python/python-fixtures.test.ts
@@ -116,15 +116,18 @@ describe('Python scopes — module / class / function', () => {
     const fn = scopesByKind(f, 'Function')[0]!;
     expect(cls.parent).toBe(mod.id);
     expect(fn.parent).toBe(cls.id);
+    expect(findDef(f, 'm')?.type).toBe('Method');
   });
 
-  it('case 06: nested function nests Function under Function', () => {
-    const f = parse('def outer():\n    def inner():\n        pass\n');
+  it('case 06: nested function remains Function when declared inside a method body', () => {
+    const f = parse('class A:\n    def m(self):\n        def inner():\n            pass\n');
     const fns = scopesByKind(f, 'Function');
     expect(fns).toHaveLength(2);
-    const outer = fns.find((s) => s.range.startLine === 1)!;
-    const inner = fns.find((s) => s.range.startLine === 2)!;
+    const outer = fns.find((s) => s.range.startLine === 2)!;
+    const inner = fns.find((s) => s.range.startLine === 3)!;
     expect(inner.parent).toBe(outer.id);
+    expect(findDef(f, 'm')?.type).toBe('Method');
+    expect(findDef(f, 'inner')?.type).toBe('Function');
   });
 });
 

--- a/gitnexus/test/unit/scope-resolution/workspace-index.test.ts
+++ b/gitnexus/test/unit/scope-resolution/workspace-index.test.ts
@@ -194,7 +194,7 @@ class User:
     expect(classDef).toBeDefined();
 
     const found = findOwnedMember(classDef!.nodeId, 'save', model);
-    expect(found?.type).toBe('Function');
+    expect(found?.type).toBe('Method');
     expect(found?.qualifiedName).toBe('User.save');
   });
 });


### PR DESCRIPTION
## Summary
- Classify Python class-body `def` declarations as `Method` nodes in both parse-time graph labels and scope-resolution captures.
- Add a generic bounded ancestor helper so function-like classification can stop at nested function boundaries without Python-only traversal duplication.
- Update Python resolver, cross-file, and scope-resolution tests to assert the corrected `Method` contract.

Closes #1091

## Test plan
- `cd gitnexus && npx tsc --noEmit`
- `cd gitnexus && npx prettier --check src/core/ingestion/utils/ast-helpers.ts src/core/ingestion/languages/python.ts src/core/ingestion/languages/python/captures.ts src/core/ingestion/languages/python/simple-hooks.ts src/core/ingestion/languages/python/index.ts`
- `cd gitnexus && npx vitest run test/integration/resolvers/python.test.ts --pool=threads`
- `cd gitnexus && npx vitest run test/unit/scope-resolution/python/python-fixtures.test.ts`
- `cd gitnexus && npx vitest run test/integration/cross-file-binding.test.ts test/unit/scope-resolution/workspace-index.test.ts`
- `cd gitnexus && npm test` (known remaining Swift baseline failures: 6 Swift tests in `method-extraction`, `type-env`, and `resolvers/swift`)