### PR TITLE
fix: correct OpenCode skills directory path (skill → skills)

### DIFF
--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -581,13 +581,13 @@ async function installCursorSkills(result: SetupResult): Promise<void> {
 }
 
 /**
- * Install global OpenCode skills to ~/.config/opencode/skill/gitnexus/
+ * Install global OpenCode skills to ~/.config/opencode/skills/gitnexus/
  */
 async function installOpenCodeSkills(result: SetupResult): Promise<void> {
   const opencodeDir = path.join(os.homedir(), '.config', 'opencode');
   if (!(await dirExists(opencodeDir))) return;
 
-  const skillsDir = path.join(opencodeDir, 'skill');
+  const skillsDir = path.join(opencodeDir, 'skills');
   try {
     const installed = await installSkillsTo(skillsDir);
     if (installed.length > 0) {


### PR DESCRIPTION
## Bug
`gitnexus setup` installs skills to `~/.config/opencode/skill/` (singular),
but OpenCode only discovers skills from `~/.config/opencode/skills/` (plural).
Skills were silently installed to the wrong path and never loaded by OpenCode.

## Root Cause
`setup.ts` line 590: `path.join(opencodeDir, 'skill')` — missing trailing `s`.

## Fix
- Line 590: `'skill'` → `'skills'`
- Line 587 JSDoc: updated path comment to match

## Testing
Run `gitnexus setup` and verify that skills now appear at
`~/.config/opencode/skills/gitnexus/` and are loaded by OpenCode.