### PR TITLE
fix: ensure FTS indexes during analyze and handle read-only connections in query

### DIFF
--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -20,6 +20,7 @@ import {
   executeWithReusedStatement,
   closeLbug,
   loadCachedEmbeddings,
+  ensureFTSIndex,
 } from './lbug/lbug-adapter.js';
 import {
   getStoragePaths,
@@ -34,6 +35,7 @@ import type { CachedEmbedding } from './embeddings/types.js';
 import { generateAIContextFiles } from '../cli/ai-context.js';
 import { EMBEDDING_TABLE_NAME } from './lbug/schema.js';
 import { STALE_HASH_SENTINEL } from './lbug/schema.js';
+import { FTS_INDEXES } from './search/bm25-index.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -280,12 +282,16 @@ export async function runFullAnalysis(
     });
 
     // ── Phase 3: FTS (85–90%) ─────────────────────────────────────────
-    // FTS indexes are created lazily on first `query`/`context` call instead
-    // of eagerly here. On small repos / CI runners the LadybugDB
-    // CREATE_FTS_INDEX cost is ~440 ms × 5 (≈2 s) regardless of table size,
-    // which dominated `analyze` runtime and pushed Windows CI past its
-    // 30 s test budget. Lazy creation is implemented in
-    // `core/search/bm25-index.ts` via `ensureFTSIndex`.
+    // FTS indexes were previously created lazily on first query to save time
+    // on small repos. However, read-only consumers (MCP, CLI tools) cannot
+    // perform write operations, so lazy creation fails there. We now ensure
+    // they exist during analyze so all consumers find them ready.
+    progress('fts', 85, 'Creating search indexes...');
+    for (const { table, indexName, properties } of FTS_INDEXES) {
+      await ensureFTSIndex(table, indexName, [...properties]).catch((err) => {
+        log(`Warning: FTS index creation failed for ${table}: ${err.message}`);
+      });
+    }
 
     // ── Phase 3.5: Re-insert cached embeddings ────────────────────────
     if (cachedEmbeddings.length > 0) {

--- a/gitnexus/src/core/search/bm25-index.ts
+++ b/gitnexus/src/core/search/bm25-index.ts
@@ -25,7 +25,7 @@ export interface BM25SearchResult {
  * CLI/pipeline path and the MCP pool path use identical (table, index,
  * properties) tuples and the lazy-create logic stays in one place.
  */
-const FTS_INDEXES: ReadonlyArray<{
+export const FTS_INDEXES: ReadonlyArray<{
   table: string;
   indexName: string;
   properties: readonly string[];
@@ -92,6 +92,28 @@ async function ensureFTSIndexViaExecutor(
 ): Promise<void> {
   const key = `${repoId}:${table}:${indexName}`;
   if (ensuredPoolFTS.has(key)) return;
+
+  // Check if index exists by running a dummy query. If it fails with
+  // "does not exist", then it truly doesn't exist. If it succeeds (or
+  // fails with a different error like "empty query"), then it exists.
+  // This allows read-only consumers to use indexes created by analyze
+  // without triggering a write-blocked CALL CREATE_FTS_INDEX.
+  try {
+    await executor(`CALL QUERY_FTS_INDEX('${table}', '${indexName}', '___check_exists___')`);
+    ensuredPoolFTS.add(key);
+    return;
+  } catch (e: any) {
+    const msg = String(e?.message ?? '');
+    if (!msg.includes('does not exist')) {
+      // Index exists (but query failed for other reasons) or some other error.
+      // If it doesn't say "does not exist", we assume it exists or creation would fail anyway.
+      ensuredPoolFTS.add(key);
+      return;
+    }
+  }
+
+  // Index does not exist — try to create it. This will fail on read-only
+  // connections (MCP pool), which is expected if analyze hasn't run.
   const propList = properties.map((p) => `'${p}'`).join(', ');
   try {
     await executor(
@@ -100,15 +122,13 @@ async function ensureFTSIndexViaExecutor(
     // Index was created successfully — safe to cache.
     ensuredPoolFTS.add(key);
   } catch (e: any) {
-    // 'already exists' is the happy path (index persists on disk between
-    // process invocations) — cache it. Anything else is treated as a
-    // transient failure: surface a one-time warning and leave the key
-    // unset so the NEXT query retries rather than silently using a
-    // cached failure (which previously disabled BM25 for the whole
-    // process for that repo).
     const msg = String(e?.message ?? '');
     if (msg.includes('already exists')) {
       ensuredPoolFTS.add(key);
+    } else if (msg.includes('read-only') || msg.includes('Write operations are not allowed')) {
+      // Silently skip if read-only. The subsequent query will also fail,
+      // but we avoid the scary "Cannot execute write operations" warning
+      // on every single query for repos that haven't been re-indexed yet.
     } else {
       console.warn(
         `[gitnexus] FTS index ensure failed for repo "${repoId}" table "${table}" ` +

--- a/gitnexus/test/unit/bm25-search.test.ts
+++ b/gitnexus/test/unit/bm25-search.test.ts
@@ -202,8 +202,11 @@ describe('BM25 search', () => {
     });
 
     it('does NOT cache a transient CREATE_FTS_INDEX failure — second call retries', async () => {
-      // First call: every CREATE_FTS_INDEX fails transiently; QUERY_FTS_INDEX returns nothing.
+      // First call: every CREATE_FTS_INDEX fails transiently; QUERY_FTS_INDEX fails with "does not exist"
       mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
         if (cypher.includes('CREATE_FTS_INDEX')) {
           throw new Error('transient lock error: Could not set lock');
         }
@@ -222,7 +225,12 @@ describe('BM25 search', () => {
       // Second call: CREATE succeeds this time. The bug being fixed: if the
       // first failure was cached, we'd see ZERO additional CREATE calls.
       mockExecuteQuery.mockReset();
-      mockExecuteQuery.mockResolvedValue([]);
+      mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
+        return [];
+      });
 
       await searchFTSFromLbug('anything', 5, REPO);
 
@@ -234,6 +242,9 @@ describe('BM25 search', () => {
 
     it("treats 'already exists' as success and caches it (no retry on second call)", async () => {
       mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
         if (cypher.includes('CREATE_FTS_INDEX')) {
           throw new Error("Catalog exception: index 'file_fts' already exists");
         }
@@ -254,11 +265,21 @@ describe('BM25 search', () => {
 
     it('invalidateEnsuredFTSForRepo drops cached entries so next call re-issues CREATE', async () => {
       // Prime the cache with successful creates.
-      mockExecuteQuery.mockResolvedValue([]);
+      mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
+        return [];
+      });
       await searchFTSFromLbug('anything', 5, REPO);
 
       mockExecuteQuery.mockReset();
-      mockExecuteQuery.mockResolvedValue([]);
+      mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
+        return [];
+      });
 
       // Without invalidation: no re-CREATE.
       await searchFTSFromLbug('anything', 5, REPO);
@@ -269,7 +290,12 @@ describe('BM25 search', () => {
       // After invalidation: next call re-issues CREATE for all 5 tables.
       invalidateEnsuredFTSForRepo(REPO);
       mockExecuteQuery.mockReset();
-      mockExecuteQuery.mockResolvedValue([]);
+      mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
+        return [];
+      });
       await searchFTSFromLbug('anything', 5, REPO);
       expect(
         mockExecuteQuery.mock.calls.filter((c) => String(c[1]).includes('CREATE_FTS_INDEX')).length,
@@ -279,7 +305,12 @@ describe('BM25 search', () => {
     it('a pool-close listener fired by the pool adapter invalidates this repo only', async () => {
       const OTHER = 'other-repo';
 
-      mockExecuteQuery.mockResolvedValue([]);
+      mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
+        return [];
+      });
       // Prime both repos.
       await searchFTSFromLbug('anything', 5, REPO);
       await searchFTSFromLbug('anything', 5, OTHER);
@@ -291,7 +322,12 @@ describe('BM25 search', () => {
       for (const l of poolCloseListeners) l(REPO);
 
       mockExecuteQuery.mockReset();
-      mockExecuteQuery.mockResolvedValue([]);
+      mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
+        return [];
+      });
 
       await searchFTSFromLbug('anything', 5, REPO);
       const createForRepo = mockExecuteQuery.mock.calls.filter(
@@ -301,7 +337,12 @@ describe('BM25 search', () => {
 
       // OTHER repo's cache must remain intact — no re-CREATE for it.
       mockExecuteQuery.mockReset();
-      mockExecuteQuery.mockResolvedValue([]);
+      mockExecuteQuery.mockImplementation(async (_repo: string, cypher: string) => {
+        if (cypher.includes('QUERY_FTS_INDEX')) {
+          throw new Error("Catalog exception: index '...' does not exist");
+        }
+        return [];
+      });
       await searchFTSFromLbug('anything', 5, OTHER);
       const createForOther = mockExecuteQuery.mock.calls.filter(
         (c) => c[0] === OTHER && String(c[1]).includes('CREATE_FTS_INDEX'),


### PR DESCRIPTION
Fixes #1105

### Description
This PR addresses the `Cannot execute write operations in a read-only database!` error encountered during `gitnexus query`.

### Changes
1. **Eager FTS Creation**: Moved FTS index creation from lazy query-time to eager analyze-time in `run-analyze.ts`.
2. **Read-only Safety**: Updated `ensureFTSIndexViaExecutor` in `bm25-index.ts` to perform a read-only existence check before attempting creation.
3. **Graceful Handling**: Silently skip index creation if the connection is read-only, avoiding misleading error logs.
4. **Test Updates**: Adjusted `bm25-search.test.ts` to align with the new existence check logic.

Verified with unit and integration tests.