### PR TITLE
test(ignore-service): skip EACCES test under uid=0 (root bypasses chmod)

### DIFF
--- a/gitnexus/test/unit/ignore-service.test.ts
+++ b/gitnexus/test/unit/ignore-service.test.ts
@@ -561,21 +561,30 @@ describe('loadIgnoreRules — error handling', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it.skipIf(process.platform === 'win32')('warns on EACCES but does not throw', async () => {
-    const gitignorePath = path.join(tmpDir, '.gitignore');
-    await fs.writeFile(gitignorePath, 'data/\n');
-    await fs.chmod(gitignorePath, 0o000);
+  // Also skip under uid=0: root bypasses POSIX read-permission checks, so
+  // chmod 000 does NOT trigger EACCES — fs.readFile reads the file anyway
+  // and loadIgnoreRules returns parsed rules instead of null. This makes
+  // the test fail in any privileged environment (rootful Docker, CI runners
+  // configured with root). The non-root branch still exercises the real
+  // EACCES path; root just can't reproduce the failure mode.
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'warns on EACCES but does not throw',
+    async () => {
+      const gitignorePath = path.join(tmpDir, '.gitignore');
+      await fs.writeFile(gitignorePath, 'data/\n');
+      await fs.chmod(gitignorePath, 0o000);
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const result = await loadIgnoreRules(tmpDir);
-    // Should still return (null or partial), not throw
-    expect(result).toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('.gitignore'));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await loadIgnoreRules(tmpDir);
+      // Should still return (null or partial), not throw
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('.gitignore'));
 
-    warnSpy.mockRestore();
-    await fs.chmod(gitignorePath, 0o644);
-    await fs.unlink(gitignorePath);
-  });
+      warnSpy.mockRestore();
+      await fs.chmod(gitignorePath, 0o644);
+      await fs.unlink(gitignorePath);
+    },
+  );
 });
 
 describe('loadIgnoreRules — GITNEXUS_NO_GITIGNORE env var', () => {


### PR DESCRIPTION
## Summary

The `loadIgnoreRules — error handling > warns on EACCES but does not throw` test in `test/unit/ignore-service.test.ts` (line 564 pre-fix) writes a temporary `.gitignore`, runs `chmod 000` on it, and asserts that `loadIgnoreRules` returns `null` because the read fails with `EACCES`. This works on a typical developer laptop, but fails when the test runs under `uid=0`: root bypasses POSIX read-permission checks on Linux, so `chmod 000` does NOT trigger `EACCES` — `fs.readFile` reads the file anyway and `loadIgnoreRules` returns the parsed rules object instead of `null`.

Repro under `node:22-trixie-slim` running as root:

```
✗ warns on EACCES but does not throw  10ms
  AssertionError: expected Ignore{ _rules: [IgnoreRule { pattern: "data/" }] } to be null

  expect(result).toBeNull();
                 ^
```

This breaks any privileged test environment — rootful Docker, certain CI runners, etc. — without saying anything useful about the code under test.

## Fix

Extend the existing `skipIf(process.platform === 'win32')` guard with `process.getuid?.() === 0` so the test is skipped under root. The non-root code path is unchanged and still exercises the real EACCES branch. Root simply cannot reproduce the failure mode the test asserts on, so skipping is the correct posture there — matches the win32 skip's reasoning (the OS-level mechanism the test depends on isn't available).

Optional chaining (`getuid?.()`) keeps Windows compatibility — Node on Windows doesn't expose `process.getuid` at all, so the call must short-circuit cleanly.

## Test plan

- [x] `npx vitest run test/unit/ignore-service.test.ts` under `uid=0` (rootful container): **132 passed / 1 skipped**, was **132 passed / 1 failed** pre-fix.
- [x] Behaviour under non-root unchanged — `it.skipIf(false)` still runs the body, which already passes in upstream CI.
- [x] `npx tsc --noEmit` clean.
- [x] No production code touched.

Spotted while validating PR #1087 (the `canParentScope` refactor) where the dockerized test environment runs as root. Sending as a separate PR because it has nothing to do with scope-resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)