### PR TITLE
fix(scope-resolution): avoid variadic reference site aggregation

### DIFF
--- a/gitnexus/src/core/ingestion/finalize-orchestrator.ts
+++ b/gitnexus/src/core/ingestion/finalize-orchestrator.ts
@@ -106,15 +106,13 @@ export function finalizeScopeModel(
   const allScopes: Scope[] = [];
   const allDefs: SymbolDefinition[] = [];
   const moduleEntries: { filePath: string; moduleScopeId: ScopeId }[] = [];
-  const allReferenceSites = [] as ReturnType<typeof collectReferenceSites>;
+  const allReferenceSites = collectReferenceSites(parsedFiles);
 
   for (const file of parsedFiles) {
     for (const s of file.scopes) allScopes.push(s);
     for (const d of file.localDefs) allDefs.push(d);
     moduleEntries.push({ filePath: file.filePath, moduleScopeId: file.moduleScope });
   }
-  // References kept out of the loop above to centralize list-init.
-  allReferenceSites.push(...collectReferenceSites(parsedFiles));
 
   const scopeTree = buildScopeTree(allScopes);
   const defs = buildDefIndex(allDefs);

--- a/gitnexus/test/unit/scope-resolution/finalize-orchestrator.test.ts
+++ b/gitnexus/test/unit/scope-resolution/finalize-orchestrator.test.ts
@@ -108,6 +108,28 @@ describe('finalizeScopeModel: single file', () => {
     expect(out.referenceSites).toHaveLength(1);
     expect(out.referenceSites[0]!.name).toBe('save');
   });
+
+  it('aggregates large referenceSites without variadic push stack overflow', () => {
+    const referenceSites: ParsedFile['referenceSites'] = Array.from(
+      { length: 200_000 },
+      (_, i) => ({
+        name: `ref${i}`,
+        atRange: { startLine: i + 1, startCol: 0, endLine: i + 1, endCol: 1 },
+        inScope: 'scope:large.ts#module',
+        kind: 'call' as const,
+      }),
+    );
+
+    const file = mkFile('large.ts', { referenceSites });
+    const out = finalizeScopeModel([file]);
+
+    expect(out.referenceSites).toHaveLength(referenceSites.length);
+    expect(out.referenceSites[0]).toBe(referenceSites[0]);
+    expect(out.referenceSites[referenceSites.length - 1]).toBe(
+      referenceSites[referenceSites.length - 1],
+    );
+    expect(Object.isFrozen(out.referenceSites)).toBe(true);
+  });
 });
 
 // ─── Multi-file with cross-file imports ────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replaces the variadic `push(...collectReferenceSites(...))` aggregation in `finalizeScopeModel` with direct use of the flattened reference-site array.
- Preserves reference-site order and the frozen output contract while avoiding V8 argument-stack overflow on large repositories.
- Adds a synthetic 200,000-reference regression test that exercises the real finalizer path without parser overhead.

Fixes #1111

## Test plan
- `npm run build` in `gitnexus-shared/`
- `npx vitest run test/unit/scope-resolution/finalize-orchestrator.test.ts --pool=threads`
- `npx tsc --noEmit`
- `npx prettier --check src/core/ingestion/finalize-orchestrator.ts test/unit/scope-resolution/finalize-orchestrator.test.ts`
- `npx tsx src/cli/index.ts detect-changes --repo GitNexus`
- `npm test -- --pool=threads` (not green: unrelated resolver integration suites fail in Python, Swift, and TypeScript large-file coverage; finalizer unit tests pass)