### PR TITLE
fix: use 'skills' (plural) directory for OpenCode skill installation

### DIFF
--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -581,18 +581,18 @@ async function installCursorSkills(result: SetupResult): Promise<void> {
 }
 
 /**
- * Install global OpenCode skills to ~/.config/opencode/skill/gitnexus/
+ * Install global OpenCode skills to ~/.config/opencode/skills/gitnexus/
  */
 async function installOpenCodeSkills(result: SetupResult): Promise<void> {
   const opencodeDir = path.join(os.homedir(), '.config', 'opencode');
   if (!(await dirExists(opencodeDir))) return;
 
-  const skillsDir = path.join(opencodeDir, 'skill');
+  const skillsDir = path.join(opencodeDir, 'skills');
   try {
     const installed = await installSkillsTo(skillsDir);
     if (installed.length > 0) {
       result.configured.push(
-        `OpenCode skills (${installed.length} skills → ~/.config/opencode/skill/)`,
+        `OpenCode skills (${installed.length} skills → ~/.config/opencode/skills/)`,
       );
     }
   } catch (err: any) {


### PR DESCRIPTION
## Summary

Fixes #1098

`gitnexus setup` was installing OpenCode skills to `~/.config/opencode/skill/` (singular), but OpenCode only discovers skills from `~/.config/opencode/skills/` (plural). All installed skills were invisible to OpenCode.

## Changes

- Corrected directory path from `skill` to `skills` in `installOpenCodeSkills()`
- Updated JSDoc comment to reflect the correct path
- Updated log message to reflect the correct path

## Verification

- [x] `skills` is the documented OpenCode discovery path per https://opencode.ai/docs/skills/
- [x] No other references to the singular `skill` path in the file
