### PR TITLE
fix: recover worker parse stalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ gitnexus analyze --skip-agents-md  # Preserve custom AGENTS.md/CLAUDE.md gitnexu
 gitnexus analyze --skip-git        # Index folders that are not Git repositories
 gitnexus analyze --embeddings    # Enable embedding generation (slower, better search)
 gitnexus analyze --verbose       # Log skipped files when parsers are unavailable
+gitnexus analyze --worker-timeout 60  # Increase worker idle timeout for slow parses
 gitnexus mcp                     # Start MCP server (stdio) — serves all indexed repos
 gitnexus serve                   # Start local HTTP server (multi-repo) for web UI connection
 gitnexus list                    # List all indexed repositories
@@ -217,6 +218,8 @@ gitnexus group contracts <name>  # Inspect extracted contracts and cross-links
 gitnexus group query <name> <q>  # Search execution flows across all repos in a group
 gitnexus group status <name>     # Check staleness of repos in a group
 ```
+
+If `analyze` reports a worker parse timeout on a large or unusual repository, it keeps running and falls back safely. To give slow worker jobs more time, use `gitnexus analyze --worker-timeout 60` or set `GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS=60000`. For very large files, `GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES` controls the worker job byte budget.
 
 ### What Your AI Agent Gets
 

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -156,6 +156,7 @@ gitnexus analyze --embeddings    # Enable embedding generation (slower, better s
 gitnexus analyze --skip-agents-md  # Preserve custom AGENTS.md/CLAUDE.md gitnexus section edits
 gitnexus analyze --verbose       # Log skipped files when parsers are unavailable
 gitnexus analyze --max-file-size 1024  # Skip files larger than N KB (default: 512, cap: 32768)
+gitnexus analyze --worker-timeout 60  # Increase worker idle timeout for slow parses
 gitnexus mcp                     # Start MCP server (stdio) — serves all indexed repos
 gitnexus serve                   # Start local HTTP server (multi-repo) for web UI
 gitnexus index                   # Register an existing .gitnexus/ folder into the global registry
@@ -322,6 +323,21 @@ npx gitnexus analyze
 ```
 
 Values above **32768 KB (32 MB)** are clamped to the tree-sitter parser ceiling; invalid values fall back to the 512 KB default with a one-time warning. When an override is active, `analyze` prints the effective threshold in its startup banner (e.g. `GITNEXUS_MAX_FILE_SIZE: effective threshold 2048KB (default 512KB)`).
+
+### Analyze reports a worker timeout
+
+Worker parse timeouts are recoverable. GitNexus retries stalled worker jobs with backoff, splits large jobs to isolate slow files, and falls back to the sequential parser when needed. If a large repository needs more time per worker job, use either:
+
+```bash
+# CLI flag, in seconds
+npx gitnexus analyze --worker-timeout 60
+
+# Environment variable, in milliseconds
+export GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS=60000
+npx gitnexus analyze
+```
+
+For repositories with very large source files, `GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES` controls the worker job byte budget. The default is **8388608 bytes (8 MB)**.
 
 ## Privacy
 

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -91,6 +91,8 @@ export interface AnalyzeOptions {
    * `GITNEXUS_MAX_FILE_SIZE` for the rest of the pipeline.
    */
   maxFileSize?: string;
+  /** Override worker sub-batch idle timeout in seconds. */
+  workerTimeout?: string;
 }
 
 export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOptions) => {
@@ -102,6 +104,18 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
 
   if (options?.maxFileSize) {
     process.env.GITNEXUS_MAX_FILE_SIZE = options.maxFileSize;
+  }
+
+  if (options?.workerTimeout) {
+    const workerTimeoutSeconds = Number(options.workerTimeout);
+    if (!Number.isFinite(workerTimeoutSeconds) || workerTimeoutSeconds < 1) {
+      console.log('  --worker-timeout must be at least 1 second.\n');
+      process.exitCode = 1;
+      return;
+    }
+    process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS = String(
+      Math.round(workerTimeoutSeconds * 1000),
+    );
   }
 
   console.log('\n  GitNexus Analyzer\n');

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -109,7 +109,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
   if (options?.workerTimeout) {
     const workerTimeoutSeconds = Number(options.workerTimeout);
     if (!Number.isFinite(workerTimeoutSeconds) || workerTimeoutSeconds < 1) {
-      console.log('  --worker-timeout must be at least 1 second.\n');
+      console.error('  --worker-timeout must be at least 1 second.\n');
       process.exitCode = 1;
       return;
     }

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -48,11 +48,17 @@ program
     '--max-file-size <kb>',
     'Skip files larger than this (KB). Default: 512. Hard cap: 32768 (tree-sitter limit).',
   )
+  .option(
+    '--worker-timeout <seconds>',
+    'Worker sub-batch idle timeout before retry/fallback. Default: 30.',
+  )
   .addHelpText(
     'after',
     '\nEnvironment variables:\n' +
       '  GITNEXUS_NO_GITIGNORE=1   Skip .gitignore parsing (still reads .gitnexusignore)\n' +
       '  GITNEXUS_MAX_FILE_SIZE=N  Override large-file skip threshold (KB). Default 512, max 32768.\n' +
+      '  GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS=N  Worker idle timeout in milliseconds. Default 30000.\n' +
+      '  GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES=N  Worker job byte budget. Default 8388608.\n' +
       '\nTip: `.gitnexusignore` supports `.gitignore`-style negation. Add e.g.\n' +
       '     `!__tests__/` to index a directory that is auto-filtered by default (#771).',
   )

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -725,6 +725,14 @@ export const processParsing = async (
   onFileProgress?: FileProgressCallback,
   workerPool?: WorkerPool,
 ): Promise<WorkerExtractedData | null> => {
+  let lastProgress = 0;
+  const reportProgress: FileProgressCallback | undefined = onFileProgress
+    ? (current, total, detail) => {
+        lastProgress = Math.max(lastProgress, current);
+        onFileProgress(lastProgress, total, detail);
+      }
+    : undefined;
+
   if (workerPool) {
     if (scopeTreeCache !== undefined && process.env.PROF_SCOPE_RESOLUTION === '1') {
       // Trees can't cross MessageChannels, so worker-parsed files land
@@ -742,12 +750,15 @@ export const processParsing = async (
         symbolTable,
         astCache,
         workerPool,
-        onFileProgress,
+        reportProgress,
       );
     } catch (err) {
-      console.warn(
-        'Worker pool parsing failed, falling back to sequential:',
-        err instanceof Error ? err.message : err,
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn('Worker pool parsing stopped; continuing with sequential parser:', message);
+      reportProgress?.(
+        lastProgress,
+        files.length,
+        `Sequential fallback after worker issue: ${message}`,
       );
     }
   }
@@ -759,7 +770,7 @@ export const processParsing = async (
     symbolTable,
     astCache,
     scopeTreeCache,
-    onFileProgress,
+    reportProgress,
   );
   return null;
 };

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -763,7 +763,7 @@ const processBatch = (
 
   let totalProcessed = 0;
   let lastReported = 0;
-  const PROGRESS_INTERVAL = 100; // report every 100 files
+  const PROGRESS_INTERVAL = Math.max(1, Math.min(100, Math.ceil(files.length / 10)));
 
   const onFileProcessed = onProgress
     ? () => {
@@ -827,6 +827,10 @@ const processBatch = (
           (result.skippedLanguages[language] || 0) + tsxFiles.length;
       }
     }
+  }
+
+  if (onProgress && totalProcessed !== lastReported) {
+    onProgress(totalProcessed);
   }
 
   return result;

--- a/gitnexus/src/core/ingestion/workers/worker-pool.ts
+++ b/gitnexus/src/core/ingestion/workers/worker-pool.ts
@@ -5,9 +5,8 @@ import { fileURLToPath } from 'node:url';
 
 export interface WorkerPool {
   /**
-   * Dispatch items across workers. Items are split into chunks (one per worker),
-   * each worker processes its chunk via sub-batches to limit peak memory,
-   * and results are concatenated back in order.
+   * Dispatch items across workers. Items are split into bounded jobs, each job
+   * is committed independently, and stalled jobs are split/retried locally.
    */
   dispatch<TInput, TResult>(
     items: TInput[],
@@ -21,6 +20,14 @@ export interface WorkerPool {
   readonly size: number;
 }
 
+export interface WorkerPoolOptions {
+  subBatchSize?: number;
+  subBatchMaxBytes?: number;
+  subBatchIdleTimeoutMs?: number;
+  maxTimeoutRetries?: number;
+  timeoutBackoffFactor?: number;
+}
+
 /** Message shapes sent back by worker threads. */
 type WorkerOutgoingMessage =
   | { type: 'progress'; filesProcessed: number }
@@ -29,20 +36,112 @@ type WorkerOutgoingMessage =
   | { type: 'error'; error: string }
   | { type: 'result'; data: unknown };
 
+interface WorkerJob<TInput> {
+  startIndex: number;
+  items: TInput[];
+  estimatedBytes: number;
+  attempt: number;
+  timeoutMs: number;
+}
+
+interface WorkerJobResult<TResult> {
+  startIndex: number;
+  data: TResult;
+}
+
 /**
  * Max files to send to a worker in a single postMessage.
  * Keeps structured-clone memory bounded per sub-batch.
  */
 const SUB_BATCH_SIZE = 1500;
+const SUB_BATCH_MAX_BYTES = 8 * 1024 * 1024;
 
-/** Per sub-batch timeout. If a single sub-batch takes longer than this,
- *  likely a pathological file (e.g. minified 50MB JS). Fail fast. */
-const SUB_BATCH_TIMEOUT_MS = 30_000;
+const DEFAULT_SUB_BATCH_IDLE_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_RETRIES = 1;
+const DEFAULT_TIMEOUT_BACKOFF_FACTOR = 2;
+
+function positiveInteger(value: unknown): number | undefined {
+  const parsed = typeof value === 'string' ? Number(value) : value;
+  return typeof parsed === 'number' && Number.isFinite(parsed) && parsed > 0
+    ? Math.floor(parsed)
+    : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+  const parsed = typeof value === 'string' ? Number(value) : value;
+  return typeof parsed === 'number' && Number.isFinite(parsed) && parsed >= 0
+    ? Math.floor(parsed)
+    : undefined;
+}
+
+function resolveWorkerPoolOptions(options: WorkerPoolOptions = {}): Required<WorkerPoolOptions> {
+  return {
+    subBatchSize: positiveInteger(options.subBatchSize) ?? SUB_BATCH_SIZE,
+    subBatchMaxBytes:
+      positiveInteger(options.subBatchMaxBytes) ??
+      positiveInteger(process.env.GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES) ??
+      SUB_BATCH_MAX_BYTES,
+    subBatchIdleTimeoutMs:
+      positiveInteger(options.subBatchIdleTimeoutMs) ??
+      positiveInteger(process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS) ??
+      DEFAULT_SUB_BATCH_IDLE_TIMEOUT_MS,
+    maxTimeoutRetries: nonNegativeInteger(options.maxTimeoutRetries) ?? DEFAULT_TIMEOUT_RETRIES,
+    timeoutBackoffFactor:
+      positiveInteger(options.timeoutBackoffFactor) ?? DEFAULT_TIMEOUT_BACKOFF_FACTOR,
+  };
+}
+
+function estimateItemBytes(item: unknown): number {
+  if (typeof item !== 'object' || item === null) return 0;
+  const content = (item as { content?: unknown }).content;
+  return typeof content === 'string' ? Buffer.byteLength(content, 'utf8') : 0;
+}
+
+function itemPath(item: unknown): string | undefined {
+  if (typeof item !== 'object' || item === null) return undefined;
+  const path = (item as { path?: unknown }).path;
+  return typeof path === 'string' ? path : undefined;
+}
+
+function createJobs<TInput>(
+  items: TInput[],
+  maxItems: number,
+  maxBytes: number,
+  timeoutMs: number,
+): WorkerJob<TInput>[] {
+  const jobs: WorkerJob<TInput>[] = [];
+  let startIndex = 0;
+  let batch: TInput[] = [];
+  let batchBytes = 0;
+
+  const flush = () => {
+    if (batch.length === 0) return;
+    jobs.push({ startIndex, items: batch, estimatedBytes: batchBytes, attempt: 0, timeoutMs });
+    startIndex += batch.length;
+    batch = [];
+    batchBytes = 0;
+  };
+
+  for (const item of items) {
+    const itemBytes = estimateItemBytes(item);
+    const wouldExceedItems = batch.length >= maxItems;
+    const wouldExceedBytes = batch.length > 0 && batchBytes + itemBytes > maxBytes;
+    if (wouldExceedItems || wouldExceedBytes) flush();
+    batch.push(item);
+    batchBytes += itemBytes;
+  }
+  flush();
+  return jobs;
+}
 
 /**
  * Create a pool of worker threads.
  */
-export const createWorkerPool = (workerUrl: URL, poolSize?: number): WorkerPool => {
+export const createWorkerPool = (
+  workerUrl: URL,
+  poolSize?: number,
+  options?: WorkerPoolOptions,
+): WorkerPool => {
   // Validate worker script exists before spawning to prevent uncaught
   // MODULE_NOT_FOUND crashes in worker threads (e.g. when running from src/ via vitest)
   const workerPath = fileURLToPath(workerUrl);
@@ -51,6 +150,7 @@ export const createWorkerPool = (workerUrl: URL, poolSize?: number): WorkerPool 
   }
 
   const size = poolSize ?? Math.min(8, Math.max(1, os.cpus().length - 1));
+  const poolOptions = resolveWorkerPoolOptions(options);
   const workers: Worker[] = [];
 
   for (let i = 0; i < size; i++) {
@@ -62,77 +162,197 @@ export const createWorkerPool = (workerUrl: URL, poolSize?: number): WorkerPool 
     onProgress?: (filesProcessed: number) => void,
   ): Promise<TResult[]> => {
     if (items.length === 0) return Promise.resolve([]);
+    if (workers.length === 0) return Promise.reject(new Error('Worker pool has no active workers'));
 
-    const chunkSize = Math.ceil(items.length / size);
-    const chunks: TInput[][] = [];
-    for (let i = 0; i < items.length; i += chunkSize) {
-      chunks.push(items.slice(i, i + chunkSize));
-    }
+    const jobs = createJobs(
+      items,
+      poolOptions.subBatchSize,
+      poolOptions.subBatchMaxBytes,
+      poolOptions.subBatchIdleTimeoutMs,
+    );
 
-    const workerProgress = new Array(chunks.length).fill(0);
+    return new Promise<TResult[]>((resolve, reject) => {
+      const results: WorkerJobResult<TResult>[] = [];
+      const inFlightProgress = new Array(workers.length).fill(0);
+      let completedFiles = 0;
+      let activeWorkers = 0;
+      let stopped = false;
+      let maxReported = 0;
 
-    const promises = chunks.map((chunk, i) => {
-      const worker = workers[i];
-      return new Promise<TResult>((resolve, reject) => {
+      const reportProgress = () => {
+        if (!onProgress) return;
+        const inFlight = inFlightProgress.reduce((sum, value) => sum + value, 0);
+        const next = Math.min(items.length, Math.max(maxReported, completedFiles + inFlight));
+        if (next === maxReported) return;
+        maxReported = next;
+        onProgress(next);
+      };
+
+      const replaceWorker = async (workerIndex: number) => {
+        const worker = workers[workerIndex];
+        await worker?.terminate().catch(() => undefined);
+        if (!stopped) workers[workerIndex] = new Worker(workerUrl);
+      };
+
+      const fail = async (err: Error) => {
+        if (stopped) return;
+        stopped = true;
+        await Promise.all(workers.map((worker) => worker.terminate().catch(() => undefined)));
+        reject(err);
+      };
+
+      const maybeDone = () => {
+        if (stopped) return;
+        if (jobs.length === 0 && activeWorkers === 0) {
+          stopped = true;
+          results.sort((a, b) => a.startIndex - b.startIndex);
+          if (onProgress && maxReported < items.length) onProgress(items.length);
+          resolve(results.map((result) => result.data));
+        }
+      };
+
+      const requeueAfterTimeout = (
+        workerIndex: number,
+        job: WorkerJob<TInput>,
+        lastProgress: number,
+      ): boolean => {
+        const nextTimeout = Math.ceil(job.timeoutMs * poolOptions.timeoutBackoffFactor);
+
+        if (job.items.length > 1) {
+          const midpoint = Math.ceil(job.items.length / 2);
+          const firstItems = job.items.slice(0, midpoint);
+          const secondItems = job.items.slice(midpoint);
+          const first: WorkerJob<TInput> = {
+            startIndex: job.startIndex,
+            items: firstItems,
+            estimatedBytes: firstItems.reduce((sum, item) => sum + estimateItemBytes(item), 0),
+            attempt: job.attempt + 1,
+            timeoutMs: nextTimeout,
+          };
+          const second: WorkerJob<TInput> = {
+            startIndex: job.startIndex + midpoint,
+            items: secondItems,
+            estimatedBytes: secondItems.reduce((sum, item) => sum + estimateItemBytes(item), 0),
+            attempt: job.attempt + 1,
+            timeoutMs: nextTimeout,
+          };
+          console.warn(
+            `Worker ${workerIndex} parse job idle timeout after ${job.timeoutMs / 1000}s ` +
+              `(${job.items.length} items, ${job.estimatedBytes} bytes, last progress: ${lastProgress}). ` +
+              `Splitting into ${first.items.length}/${second.items.length} item jobs with ` +
+              `${nextTimeout / 1000}s timeout.`,
+          );
+          jobs.unshift(second, first);
+          return true;
+        }
+
+        const nextAttempt = job.attempt + 1;
+        if (nextAttempt <= poolOptions.maxTimeoutRetries) {
+          console.warn(
+            `Worker ${workerIndex} parse job idle timeout after ${job.timeoutMs / 1000}s ` +
+              `(single item, attempt ${nextAttempt}/${poolOptions.maxTimeoutRetries + 1}). ` +
+              `Retrying with ${nextTimeout / 1000}s timeout.`,
+          );
+          jobs.unshift({
+            ...job,
+            attempt: nextAttempt,
+            timeoutMs: nextTimeout,
+          });
+          return true;
+        }
+
+        void fail(
+          new Error(
+            `Worker ${workerIndex} parse job idle timeout after ${job.timeoutMs / 1000}s ` +
+              `(single item${itemPath(job.items[0]) ? `: ${itemPath(job.items[0])}` : ''}, ` +
+              `${job.estimatedBytes} bytes, last progress: ${lastProgress}). ` +
+              `Analyze will retry through sequential fallback. Increase with ` +
+              `--worker-timeout or GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS.`,
+          ),
+        );
+        return false;
+      };
+
+      const runWorker = (workerIndex: number) => {
+        if (stopped) return;
+        const job = jobs.shift();
+        if (!job) {
+          maybeDone();
+          return;
+        }
+
+        activeWorkers++;
+        inFlightProgress[workerIndex] = 0;
+        const worker = workers[workerIndex];
         let settled = false;
-        let subBatchTimer: ReturnType<typeof setTimeout> | null = null;
+        let waitingForFlush = false;
+        let idleTimer: ReturnType<typeof setTimeout> | null = null;
+        let lastProgress = 0;
 
         const cleanup = () => {
-          if (subBatchTimer) clearTimeout(subBatchTimer);
+          if (idleTimer) clearTimeout(idleTimer);
           worker.removeListener('message', handler);
           worker.removeListener('error', errorHandler);
           worker.removeListener('exit', exitHandler);
         };
 
-        const resetSubBatchTimer = () => {
-          if (subBatchTimer) clearTimeout(subBatchTimer);
-          subBatchTimer = setTimeout(() => {
+        const finishJob = () => {
+          activeWorkers--;
+          inFlightProgress[workerIndex] = 0;
+          runWorker(workerIndex);
+          maybeDone();
+        };
+
+        const resetIdleTimer = () => {
+          if (idleTimer) clearTimeout(idleTimer);
+          idleTimer = setTimeout(async () => {
             if (!settled) {
               settled = true;
               cleanup();
-              reject(
-                new Error(
-                  `Worker ${i} sub-batch timed out after ${SUB_BATCH_TIMEOUT_MS / 1000}s (chunk: ${chunk.length} items).`,
-                ),
-              );
+              activeWorkers--;
+              inFlightProgress[workerIndex] = 0;
+              const shouldContinue = requeueAfterTimeout(workerIndex, job, lastProgress);
+              if (!shouldContinue) return;
+              await replaceWorker(workerIndex);
+              reportProgress();
+              runWorker(workerIndex);
+              maybeDone();
             }
-          }, SUB_BATCH_TIMEOUT_MS);
-        };
-
-        let subBatchIdx = 0;
-
-        const sendNextSubBatch = () => {
-          const start = subBatchIdx * SUB_BATCH_SIZE;
-          if (start >= chunk.length) {
-            worker.postMessage({ type: 'flush' });
-            return;
-          }
-          const subBatch = chunk.slice(start, start + SUB_BATCH_SIZE);
-          subBatchIdx++;
-          resetSubBatchTimer();
-          worker.postMessage({ type: 'sub-batch', files: subBatch });
+          }, job.timeoutMs);
         };
 
         const handler = (msg: WorkerOutgoingMessage) => {
-          if (settled) return;
+          if (settled || stopped) return;
           if (msg.type === 'progress') {
-            workerProgress[i] = msg.filesProcessed;
-            if (onProgress) {
-              const total = workerProgress.reduce((a, b) => a + b, 0);
-              onProgress(total);
-            }
+            const bounded = Math.min(job.items.length, Math.max(0, msg.filesProcessed));
+            inFlightProgress[workerIndex] = bounded;
+            lastProgress = bounded;
+            resetIdleTimer();
+            reportProgress();
           } else if (msg.type === 'warning') {
+            resetIdleTimer();
             console.warn(msg.message);
           } else if (msg.type === 'sub-batch-done') {
-            sendNextSubBatch();
+            waitingForFlush = true;
+            resetIdleTimer();
+            worker.postMessage({ type: 'flush' });
           } else if (msg.type === 'error') {
             settled = true;
             cleanup();
-            reject(new Error(`Worker ${i} error: ${msg.error}`));
+            void fail(new Error(`Worker ${workerIndex} error: ${msg.error}`));
           } else if (msg.type === 'result') {
+            if (!waitingForFlush) {
+              settled = true;
+              cleanup();
+              void fail(new Error(`Worker ${workerIndex} protocol error: result before flush`));
+              return;
+            }
             settled = true;
             cleanup();
-            resolve(msg.data as TResult);
+            results.push({ startIndex: job.startIndex, data: msg.data as TResult });
+            completedFiles += job.items.length;
+            reportProgress();
+            finishJob();
           }
         };
 
@@ -140,7 +360,7 @@ export const createWorkerPool = (workerUrl: URL, poolSize?: number): WorkerPool 
           if (!settled) {
             settled = true;
             cleanup();
-            reject(err);
+            void fail(err);
           }
         };
 
@@ -148,9 +368,9 @@ export const createWorkerPool = (workerUrl: URL, poolSize?: number): WorkerPool 
           if (!settled) {
             settled = true;
             cleanup();
-            reject(
+            void fail(
               new Error(
-                `Worker ${i} exited with code ${code}. Likely OOM or native addon failure.`,
+                `Worker ${workerIndex} exited with code ${code}. Likely OOM or native addon failure.`,
               ),
             );
           }
@@ -159,11 +379,16 @@ export const createWorkerPool = (workerUrl: URL, poolSize?: number): WorkerPool 
         worker.on('message', handler);
         worker.once('error', errorHandler);
         worker.once('exit', exitHandler);
-        sendNextSubBatch();
-      });
-    });
+        resetIdleTimer();
+        if (stopped) {
+          cleanup();
+          return;
+        }
+        worker.postMessage({ type: 'sub-batch', files: job.items });
+      };
 
-    return Promise.all(promises);
+      for (let i = 0; i < workers.length; i++) runWorker(i);
+    });
   };
 
   const terminate = async (): Promise<void> => {

--- a/gitnexus/src/core/ingestion/workers/worker-pool.ts
+++ b/gitnexus/src/core/ingestion/workers/worker-pool.ts
@@ -41,6 +41,7 @@ interface WorkerJob<TInput> {
   items: TInput[];
   estimatedBytes: number;
   attempt: number;
+  splitDepth: number;
   timeoutMs: number;
 }
 
@@ -74,7 +75,9 @@ function nonNegativeInteger(value: unknown): number | undefined {
     : undefined;
 }
 
-function resolveWorkerPoolOptions(options: WorkerPoolOptions = {}): Required<WorkerPoolOptions> {
+export function resolveWorkerPoolOptions(
+  options: WorkerPoolOptions = {},
+): Required<WorkerPoolOptions> {
   return {
     subBatchSize: positiveInteger(options.subBatchSize) ?? SUB_BATCH_SIZE,
     subBatchMaxBytes:
@@ -116,7 +119,14 @@ function createJobs<TInput>(
 
   const flush = () => {
     if (batch.length === 0) return;
-    jobs.push({ startIndex, items: batch, estimatedBytes: batchBytes, attempt: 0, timeoutMs });
+    jobs.push({
+      startIndex,
+      items: batch,
+      estimatedBytes: batchBytes,
+      attempt: 0,
+      splitDepth: 0,
+      timeoutMs,
+    });
     startIndex += batch.length;
     batch = [];
     batchBytes = 0;
@@ -226,14 +236,16 @@ export const createWorkerPool = (
             startIndex: job.startIndex,
             items: firstItems,
             estimatedBytes: firstItems.reduce((sum, item) => sum + estimateItemBytes(item), 0),
-            attempt: job.attempt + 1,
+            attempt: job.attempt,
+            splitDepth: job.splitDepth + 1,
             timeoutMs: nextTimeout,
           };
           const second: WorkerJob<TInput> = {
             startIndex: job.startIndex + midpoint,
             items: secondItems,
             estimatedBytes: secondItems.reduce((sum, item) => sum + estimateItemBytes(item), 0),
-            attempt: job.attempt + 1,
+            attempt: job.attempt,
+            splitDepth: job.splitDepth + 1,
             timeoutMs: nextTimeout,
           };
           console.warn(

--- a/gitnexus/src/core/ingestion/workers/worker-pool.ts
+++ b/gitnexus/src/core/ingestion/workers/worker-pool.ts
@@ -264,7 +264,8 @@ export const createWorkerPool = (
               `Splitting into ${first.items.length}/${second.items.length} item jobs with ` +
               `${nextTimeout / 1000}s timeout.`,
           );
-          jobs.unshift(second, first);
+          // Preserve intuitive retry order; final result order is still enforced by startIndex sort.
+          jobs.unshift(first, second);
           return true;
         }
 

--- a/gitnexus/src/core/ingestion/workers/worker-pool.ts
+++ b/gitnexus/src/core/ingestion/workers/worker-pool.ts
@@ -162,6 +162,8 @@ export const createWorkerPool = (
   const size = poolSize ?? Math.min(8, Math.max(1, os.cpus().length - 1));
   const poolOptions = resolveWorkerPoolOptions(options);
   const workers: Worker[] = [];
+  let poolBroken = false;
+  let poolFailure: Error | undefined;
 
   for (let i = 0; i < size; i++) {
     workers.push(new Worker(workerUrl));
@@ -171,6 +173,12 @@ export const createWorkerPool = (
     items: TInput[],
     onProgress?: (filesProcessed: number) => void,
   ): Promise<TResult[]> => {
+    if (poolBroken) {
+      const reason = poolFailure ? `: ${poolFailure.message}` : '';
+      return Promise.reject(
+        new Error(`Worker pool is unavailable after a previous failure${reason}`),
+      );
+    }
     if (items.length === 0) return Promise.resolve([]);
     if (workers.length === 0) return Promise.reject(new Error('Worker pool has no active workers'));
 
@@ -205,6 +213,8 @@ export const createWorkerPool = (
       };
 
       const fail = async (err: Error) => {
+        poolBroken = true;
+        poolFailure = err;
         if (stopped) return;
         stopped = true;
         await Promise.all(workers.map((worker) => worker.terminate().catch(() => undefined)));

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -251,7 +251,8 @@ export async function runFullAnalysis(
   const pipelineResult = await runPipelineFromRepo(repoPath, (p) => {
     const phaseLabel = PHASE_LABELS[p.phase] || p.phase;
     const scaled = Math.round(p.percent * 0.6);
-    progress(p.phase, scaled, phaseLabel);
+    const message = p.detail ? `${p.message || phaseLabel} (${p.detail})` : p.message || phaseLabel;
+    progress(p.phase, scaled, message);
   });
 
   // ── Phase 2: LadybugDB (60–85%) ──────────────────────────────────

--- a/gitnexus/test/integration/worker-pool.test.ts
+++ b/gitnexus/test/integration/worker-pool.test.ts
@@ -494,6 +494,9 @@ describe('worker pool integration', () => {
       await expect(pool.dispatch<any, any>([{ path: 'bad.ts', content: '' }])).rejects.toThrow(
         /protocol error/,
       );
+      await expect(pool.dispatch<any, any>([{ path: 'after.ts', content: '' }])).rejects.toThrow(
+        /previous failure.*protocol error/,
+      );
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/gitnexus/test/integration/worker-pool.test.ts
+++ b/gitnexus/test/integration/worker-pool.test.ts
@@ -244,7 +244,7 @@ describe('worker pool integration', () => {
               clearInterval(timer);
               parentPort.postMessage({ type: 'sub-batch-done' });
             }
-          }, 60);
+          }, 120);
           return;
         }
         if (msg && msg.type === 'flush') {
@@ -255,7 +255,7 @@ describe('worker pool integration', () => {
     );
 
     pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
-      subBatchIdleTimeoutMs: 150,
+      subBatchIdleTimeoutMs: 500,
       maxTimeoutRetries: 0,
     });
 

--- a/gitnexus/test/integration/worker-pool.test.ts
+++ b/gitnexus/test/integration/worker-pool.test.ts
@@ -244,7 +244,7 @@ describe('worker pool integration', () => {
               clearInterval(timer);
               parentPort.postMessage({ type: 'sub-batch-done' });
             }
-          }, 30);
+          }, 60);
           return;
         }
         if (msg && msg.type === 'flush') {
@@ -255,7 +255,7 @@ describe('worker pool integration', () => {
     );
 
     pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
-      subBatchIdleTimeoutMs: 70,
+      subBatchIdleTimeoutMs: 150,
       maxTimeoutRetries: 0,
     });
 
@@ -300,7 +300,7 @@ describe('worker pool integration', () => {
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
-      subBatchIdleTimeoutMs: 50,
+      subBatchIdleTimeoutMs: 150,
       maxTimeoutRetries: 1,
       timeoutBackoffFactor: 4,
     });
@@ -308,7 +308,7 @@ describe('worker pool integration', () => {
     try {
       const results = await pool.dispatch<any, any>([{ path: 'retry.ts', content: '' }]);
       expect(results).toEqual([{ fileCount: 1, recovered: true }]);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Retrying with 0.2s timeout'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Retrying with 0.6s timeout'));
     } finally {
       warnSpy.mockRestore();
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -347,7 +347,7 @@ describe('worker pool integration', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
       subBatchSize: 2,
-      subBatchIdleTimeoutMs: 30,
+      subBatchIdleTimeoutMs: 150,
       maxTimeoutRetries: 0,
       timeoutBackoffFactor: 3,
     });
@@ -391,7 +391,7 @@ describe('worker pool integration', () => {
     );
 
     pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
-      subBatchIdleTimeoutMs: 15,
+      subBatchIdleTimeoutMs: 150,
       maxTimeoutRetries: 0,
     });
 
@@ -427,7 +427,7 @@ describe('worker pool integration', () => {
             return;
           }
           if (current.includes('tail-a.ts')) {
-            setTimeout(finish, 45);
+            setTimeout(finish, 180);
             return;
           }
           finish();
@@ -443,7 +443,7 @@ describe('worker pool integration', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     pool = createWorkerPool(pathToFileURL(workerPath) as URL, 2, {
       subBatchSize: 2,
-      subBatchIdleTimeoutMs: 20,
+      subBatchIdleTimeoutMs: 150,
       maxTimeoutRetries: 0,
       timeoutBackoffFactor: 3,
     });

--- a/gitnexus/test/integration/worker-pool.test.ts
+++ b/gitnexus/test/integration/worker-pool.test.ts
@@ -25,6 +25,13 @@ const DIST_WORKER = path.resolve(
 );
 const hasDistWorker = fs.existsSync(DIST_WORKER);
 
+function writeTempWorker(prefix: string, source: string): { tempDir: string; workerPath: string } {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const workerPath = path.join(tempDir, 'worker.js');
+  fs.writeFileSync(workerPath, source);
+  return { tempDir, workerPath };
+}
+
 describe('worker pool integration', () => {
   let pool: WorkerPool | undefined;
 
@@ -187,10 +194,8 @@ describe('worker pool integration', () => {
   );
 
   it('treats warning messages as non-terminal and still resolves the worker result', async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-worker-warning-'));
-    const workerPath = path.join(tempDir, 'warning-worker.js');
-    fs.writeFileSync(
-      workerPath,
+    const { tempDir, workerPath } = writeTempWorker(
+      'gitnexus-worker-warning-',
       `
       const { parentPort } = require('node:worker_threads');
       parentPort.on('message', (msg) => {
@@ -223,10 +228,331 @@ describe('worker pool integration', () => {
     }
   });
 
+  it('keeps a slow sub-batch alive when the worker reports progress', async () => {
+    const { tempDir, workerPath } = writeTempWorker(
+      'gitnexus-worker-progress-',
+      `
+      const { parentPort } = require('node:worker_threads');
+      parentPort.on('message', (msg) => {
+        if (msg && msg.type === 'sub-batch') {
+          let processed = 1;
+          parentPort.postMessage({ type: 'progress', filesProcessed: processed });
+          const timer = setInterval(() => {
+            processed++;
+            parentPort.postMessage({ type: 'progress', filesProcessed: processed });
+            if (processed === 4) {
+              clearInterval(timer);
+              parentPort.postMessage({ type: 'sub-batch-done' });
+            }
+          }, 30);
+          return;
+        }
+        if (msg && msg.type === 'flush') {
+          parentPort.postMessage({ type: 'result', data: { fileCount: 4 } });
+        }
+      });
+    `,
+    );
+
+    pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
+      subBatchIdleTimeoutMs: 70,
+      maxTimeoutRetries: 0,
+    });
+
+    try {
+      const progressCalls: number[] = [];
+      const results = await pool.dispatch<any, any>(
+        Array.from({ length: 4 }, (_, i) => ({ path: `slow-${i}.ts`, content: '' })),
+        (filesProcessed) => progressCalls.push(filesProcessed),
+      );
+      expect(results).toEqual([{ fileCount: 4 }]);
+      expect(progressCalls).toEqual([1, 2, 3, 4]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('replaces a timed-out worker and retries with a longer timeout', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-worker-retry-'));
+    const markerPath = path.join(tempDir, 'first-attempt.txt');
+    const workerPath = path.join(tempDir, 'worker.js');
+    fs.writeFileSync(
+      workerPath,
+      `
+      const fs = require('node:fs');
+      const { parentPort } = require('node:worker_threads');
+      const markerPath = ${JSON.stringify(markerPath)};
+      parentPort.on('message', (msg) => {
+        if (msg && msg.type === 'sub-batch') {
+          if (!fs.existsSync(markerPath)) {
+            fs.writeFileSync(markerPath, 'timed out once');
+            return;
+          }
+          parentPort.postMessage({ type: 'sub-batch-done' });
+          return;
+        }
+        if (msg && msg.type === 'flush') {
+          parentPort.postMessage({ type: 'result', data: { fileCount: 1, recovered: true } });
+        }
+      });
+    `,
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
+      subBatchIdleTimeoutMs: 50,
+      maxTimeoutRetries: 1,
+      timeoutBackoffFactor: 4,
+    });
+
+    try {
+      const results = await pool.dispatch<any, any>([{ path: 'retry.ts', content: '' }]);
+      expect(results).toEqual([{ fileCount: 1, recovered: true }]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Retrying with 0.2s timeout'));
+    } finally {
+      warnSpy.mockRestore();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves global path order across split-and-retry', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-worker-split-'));
+    const markerPath = path.join(tempDir, 'stalled-once.txt');
+    const workerPath = path.join(tempDir, 'worker.js');
+    fs.writeFileSync(
+      workerPath,
+      `
+      const fs = require('node:fs');
+      const { parentPort } = require('node:worker_threads');
+      const markerPath = ${JSON.stringify(markerPath)};
+      let current = [];
+      parentPort.on('message', (msg) => {
+        if (msg && msg.type === 'sub-batch') {
+          current = msg.files.map((file) => file.path);
+          if (current.includes('stall.ts') && current.length > 1 && !fs.existsSync(markerPath)) {
+            fs.writeFileSync(markerPath, 'split this job');
+            return;
+          }
+          parentPort.postMessage({ type: 'progress', filesProcessed: current.length });
+          parentPort.postMessage({ type: 'sub-batch-done' });
+          return;
+        }
+        if (msg && msg.type === 'flush') {
+          parentPort.postMessage({ type: 'result', data: { fileCount: current.length, paths: current } });
+        }
+      });
+    `,
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
+      subBatchSize: 2,
+      subBatchIdleTimeoutMs: 30,
+      maxTimeoutRetries: 0,
+      timeoutBackoffFactor: 3,
+    });
+
+    try {
+      const progressCalls: number[] = [];
+      const results = await pool.dispatch<any, any>(
+        [
+          { path: 'first.ts', content: '' },
+          { path: 'second.ts', content: '' },
+          { path: 'stall.ts', content: '' },
+          { path: 'after.ts', content: '' },
+        ],
+        (filesProcessed) => progressCalls.push(filesProcessed),
+      );
+
+      expect(results.flatMap((result) => result.paths)).toEqual([
+        'first.ts',
+        'second.ts',
+        'stall.ts',
+        'after.ts',
+      ]);
+      expect(progressCalls).toEqual([...progressCalls].sort((a, b) => a - b));
+      expect(progressCalls.at(-1)).toBe(4);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Splitting into 1/1 item jobs'));
+    } finally {
+      warnSpy.mockRestore();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a persistently stalled singleton so the caller can fall back sequentially', async () => {
+    const { tempDir, workerPath } = writeTempWorker(
+      'gitnexus-worker-stalled-',
+      `
+      const { parentPort } = require('node:worker_threads');
+      parentPort.on('message', (msg) => {
+        if (msg && msg.type === 'sub-batch') return;
+      });
+    `,
+    );
+
+    pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
+      subBatchIdleTimeoutMs: 15,
+      maxTimeoutRetries: 0,
+    });
+
+    try {
+      await expect(pool.dispatch<any, any>([{ path: 'stalled.ts', content: '' }])).rejects.toThrow(
+        /sequential fallback/,
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not resolve early when a stalled peer job is requeued during another worker finish', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-worker-race-'));
+    const markerPath = path.join(tempDir, 'stalled-once.txt');
+    const workerPath = path.join(tempDir, 'worker.js');
+    fs.writeFileSync(
+      workerPath,
+      `
+      const fs = require('node:fs');
+      const { parentPort } = require('node:worker_threads');
+      const markerPath = ${JSON.stringify(markerPath)};
+      let current = [];
+      function finish() {
+        parentPort.postMessage({ type: 'progress', filesProcessed: current.length });
+        parentPort.postMessage({ type: 'sub-batch-done' });
+      }
+      parentPort.on('message', (msg) => {
+        if (msg && msg.type === 'sub-batch') {
+          current = msg.files.map((file) => file.path);
+          if (current.includes('stall-a.ts') && current.length > 1 && !fs.existsSync(markerPath)) {
+            fs.writeFileSync(markerPath, 'stall the second job once');
+            return;
+          }
+          if (current.includes('tail-a.ts')) {
+            setTimeout(finish, 45);
+            return;
+          }
+          finish();
+          return;
+        }
+        if (msg && msg.type === 'flush') {
+          parentPort.postMessage({ type: 'result', data: { fileCount: current.length, paths: current } });
+        }
+      });
+    `,
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    pool = createWorkerPool(pathToFileURL(workerPath) as URL, 2, {
+      subBatchSize: 2,
+      subBatchIdleTimeoutMs: 20,
+      maxTimeoutRetries: 0,
+      timeoutBackoffFactor: 3,
+    });
+
+    try {
+      const results = await pool.dispatch<any, any>([
+        { path: 'first-a.ts', content: '' },
+        { path: 'first-b.ts', content: '' },
+        { path: 'stall-a.ts', content: '' },
+        { path: 'stall-b.ts', content: '' },
+        { path: 'tail-a.ts', content: '' },
+        { path: 'tail-b.ts', content: '' },
+      ]);
+
+      expect(results.flatMap((result) => result.paths)).toEqual([
+        'first-a.ts',
+        'first-b.ts',
+        'stall-a.ts',
+        'stall-b.ts',
+        'tail-a.ts',
+        'tail-b.ts',
+      ]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Splitting into 1/1 item jobs'));
+    } finally {
+      warnSpy.mockRestore();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails fast on a result message that violates the worker protocol', async () => {
+    const { tempDir, workerPath } = writeTempWorker(
+      'gitnexus-worker-protocol-',
+      `
+      const { parentPort } = require('node:worker_threads');
+      parentPort.on('message', (msg) => {
+        if (msg && msg.type === 'sub-batch') {
+          parentPort.postMessage({ type: 'result', data: { fileCount: 1 } });
+        }
+      });
+    `,
+    );
+
+    pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
+      subBatchIdleTimeoutMs: 100,
+    });
+
+    try {
+      await expect(pool.dispatch<any, any>([{ path: 'bad.ts', content: '' }])).rejects.toThrow(
+        /protocol error/,
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('bounds worker jobs by byte budget as well as file count', async () => {
+    const { tempDir, workerPath } = writeTempWorker(
+      'gitnexus-worker-byte-budget-',
+      `
+      const { parentPort } = require('node:worker_threads');
+      let current = [];
+      parentPort.on('message', (msg) => {
+        if (msg && msg.type === 'sub-batch') {
+          current = msg.files.map((file) => file.path);
+          parentPort.postMessage({ type: 'progress', filesProcessed: current.length });
+          parentPort.postMessage({ type: 'sub-batch-done' });
+          return;
+        }
+        if (msg && msg.type === 'flush') {
+          parentPort.postMessage({ type: 'result', data: { paths: current } });
+        }
+      });
+    `,
+    );
+
+    pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
+      subBatchSize: 10,
+      subBatchMaxBytes: 6,
+      subBatchIdleTimeoutMs: 100,
+    });
+
+    try {
+      const results = await pool.dispatch<any, any>([
+        { path: 'a.ts', content: '1234' },
+        { path: 'b.ts', content: '5678' },
+        { path: 'c.ts', content: '90' },
+      ]);
+      expect(results.map((result) => result.paths)).toEqual([['a.ts'], ['b.ts', 'c.ts']]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it.skipIf(!hasDistWorker)('createWorkerPool with size 0 creates pool with zero workers', () => {
     const workerUrl = pathToFileURL(DIST_WORKER) as URL;
     const zeroPool = createWorkerPool(workerUrl, 0);
     expect(zeroPool.size).toBe(0);
     return zeroPool.terminate();
+  });
+
+  it.skipIf(!hasDistWorker)('dispatch with size 0 rejects clearly', async () => {
+    const workerUrl = pathToFileURL(DIST_WORKER) as URL;
+    const zeroPool = createWorkerPool(workerUrl, 0);
+    try {
+      await expect(zeroPool.dispatch([{ path: 'x.ts', content: 'const x = 1;' }])).rejects.toThrow(
+        /no active workers/,
+      );
+    } finally {
+      await zeroPool.terminate();
+    }
   });
 });

--- a/gitnexus/test/unit/analyze-worker-timeout.test.ts
+++ b/gitnexus/test/unit/analyze-worker-timeout.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runFullAnalysisMock = vi.fn();
+
+vi.mock('../../src/core/run-analyze.js', () => ({
+  runFullAnalysis: runFullAnalysisMock,
+}));
+
+vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
+  closeLbug: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../src/storage/repo-manager.js', () => ({
+  getStoragePaths: vi.fn(() => ({ storagePath: '.gitnexus', lbugPath: '.gitnexus/lbug' })),
+  getGlobalRegistryPath: vi.fn(() => 'registry.json'),
+  RegistryNameCollisionError: class RegistryNameCollisionError extends Error {},
+}));
+
+vi.mock('../../src/storage/git.js', () => ({
+  getGitRoot: vi.fn(() => '/repo'),
+  hasGitDir: vi.fn(() => true),
+}));
+
+vi.mock('../../src/core/ingestion/utils/max-file-size.js', () => ({
+  getMaxFileSizeBannerMessage: vi.fn(() => null),
+}));
+
+describe('analyzeCommand worker timeout validation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    runFullAnalysisMock.mockReset();
+    process.exitCode = undefined;
+    process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --max-old-space-size=8192`.trim();
+    delete process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS;
+  });
+
+  it.each(['0', 'abc', '-5', 'Infinity'])(
+    'rejects invalid --worker-timeout value %s before analysis starts',
+    async (workerTimeout) => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const { analyzeCommand } = await import('../../src/cli/analyze.js');
+
+      await analyzeCommand(undefined, { workerTimeout });
+
+      expect(process.exitCode).toBe(1);
+      expect(errorSpy).toHaveBeenCalledWith('  --worker-timeout must be at least 1 second.\n');
+      expect(runFullAnalysisMock).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    },
+  );
+
+  it('sets the worker timeout environment variable for valid values', async () => {
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+    runFullAnalysisMock.mockResolvedValue({
+      repoName: 'repo',
+      repoPath: '/repo',
+      stats: {},
+      alreadyUpToDate: true,
+    });
+
+    await analyzeCommand(undefined, { workerTimeout: '2' });
+
+    expect(process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS).toBe('2000');
+    expect(runFullAnalysisMock).toHaveBeenCalled();
+  });
+});

--- a/gitnexus/test/unit/parsing-worker-fallback.test.ts
+++ b/gitnexus/test/unit/parsing-worker-fallback.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createASTCache } from '../../src/core/ingestion/ast-cache.js';
+import { processParsing } from '../../src/core/ingestion/parsing-processor.js';
+import type { WorkerPool } from '../../src/core/ingestion/workers/worker-pool.js';
+import { createKnowledgeGraph } from '../../src/core/graph/graph.js';
+import { createSymbolTable } from '../../src/core/ingestion/model/symbol-table.js';
+
+describe('processParsing worker fallback', () => {
+  it('continues sequentially with visible progress when the worker pool times out', async () => {
+    const graph = createKnowledgeGraph();
+    const progressCounts: number[] = [];
+    const progressDetails: string[] = [];
+    const workerPool: WorkerPool = {
+      size: 1,
+      dispatch: vi.fn(async (_items, onProgress?: (filesProcessed: number) => void) => {
+        onProgress?.(1);
+        throw new Error('injected worker idle timeout');
+      }),
+      terminate: vi.fn(async () => undefined),
+    };
+
+    const result = await processParsing(
+      graph,
+      [{ path: 'src/a.ts', content: 'export function a() { return 1; }\n' }],
+      createSymbolTable(),
+      createASTCache(),
+      createASTCache(),
+      (current, _total, detail) => {
+        progressCounts.push(current);
+        progressDetails.push(detail);
+      },
+      workerPool,
+    );
+
+    expect(result).toBeNull();
+    expect(progressDetails).toContain(
+      'Sequential fallback after worker issue: injected worker idle timeout',
+    );
+    expect(progressCounts).toEqual([...progressCounts].sort((a, b) => a - b));
+    expect(
+      graph.nodes.some((node) => node.label === 'Function' && node.properties.name === 'a'),
+    ).toBe(true);
+  });
+});

--- a/gitnexus/test/unit/worker-pool-options.test.ts
+++ b/gitnexus/test/unit/worker-pool-options.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveWorkerPoolOptions } from '../../src/core/ingestion/workers/worker-pool.js';
+
+const ORIGINAL_TIMEOUT = process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS;
+const ORIGINAL_MAX_BYTES = process.env.GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES;
+
+describe('resolveWorkerPoolOptions', () => {
+  afterEach(() => {
+    if (ORIGINAL_TIMEOUT === undefined) {
+      delete process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS;
+    } else {
+      process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS = ORIGINAL_TIMEOUT;
+    }
+
+    if (ORIGINAL_MAX_BYTES === undefined) {
+      delete process.env.GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES;
+    } else {
+      process.env.GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES = ORIGINAL_MAX_BYTES;
+    }
+  });
+
+  it('reads worker timeout and byte budget from environment variables', () => {
+    process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS = '5000';
+    process.env.GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES = '4096';
+
+    const options = resolveWorkerPoolOptions();
+
+    expect(options.subBatchIdleTimeoutMs).toBe(5000);
+    expect(options.subBatchMaxBytes).toBe(4096);
+  });
+
+  it('prefers explicit options over environment variables', () => {
+    process.env.GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS = '5000';
+    process.env.GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES = '4096';
+
+    const options = resolveWorkerPoolOptions({
+      subBatchIdleTimeoutMs: 7000,
+      subBatchMaxBytes: 8192,
+    });
+
+    expect(options.subBatchIdleTimeoutMs).toBe(7000);
+    expect(options.subBatchMaxBytes).toBe(8192);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces static worker chunks with bounded parse jobs so completed work is kept and stalled jobs are split/retried locally.
- Adds worker idle timeout controls through `--worker-timeout`, `GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS`, and byte-bounded worker jobs.
- Improves fallback diagnostics and keeps parse progress monotonic when workers fail.

Closes #1116

## Test plan
- `npx vitest run test/integration/worker-pool.test.ts test/unit/parsing-worker-fallback.test.ts --pool=threads`
- `npx vitest run test/unit/parse-impl-fallback.test.ts --pool=threads`
- `npx tsc --noEmit`
- `npx prettier --check src/core/ingestion/workers/worker-pool.ts src/core/ingestion/workers/parse-worker.ts src/core/ingestion/parsing-processor.ts src/core/run-analyze.ts src/cli/analyze.ts src/cli/index.ts test/integration/worker-pool.test.ts test/unit/parsing-worker-fallback.test.ts`
- `npm run build`
- `npx tsx src/cli/index.ts detect-changes --repo GitNexus`

Note: a full `npm test` run on this Windows machine still has unrelated existing failures in LadybugDB locking and Swift resolver coverage.