### PR TITLE
Fix typo: capitalize Goliath in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ https://github.com/user-attachments/assets/172685ba-8e54-4ea7-9ad1-e31a3398da72
 
 > *Like DeepWiki, but deeper.* DeepWiki helps you *understand* code. GitNexus lets you *analyze* it — because a knowledge graph tracks every relationship, not just descriptions.
 
-**TL;DR:** The **Web UI** is a quick way to chat with any repo. The **CLI + MCP** is how you make your AI agent actually reliable — it gives Cursor, Claude Code, Codex, and friends a deep architectural view of your codebase so they stop missing dependencies, breaking call chains, and shipping blind edits. Even smaller models get full architectural clarity, making it compete with goliath models.
+**TL;DR:** The **Web UI** is a quick way to chat with any repo. The **CLI + MCP** is how you make your AI agent actually reliable — it gives Cursor, Claude Code, Codex, and friends a deep architectural view of your codebase so they stop missing dependencies, breaking call chains, and shipping blind edits. Even smaller models get full architectural clarity, making it compete with Goliath models.
 
 ---
 


### PR DESCRIPTION
## What

Capitalize "Goliath" in the README TL;DR paragraph.

## Why

"Goliath" is a proper noun (the Biblical giant, used here as a metaphor for large/powerful models). It should be capitalized, just like "David vs Goliath". The previous text read "making it compete with goliath models" which is a minor typo.

## Change

-  →  (line 39 of README.md)