### PR TITLE
fix(lbug): prevent DuckDB extension install hangs

### DIFF
--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -296,6 +296,25 @@ If `npm install -g gitnexus` fails on native modules:
 npm install -g gitnexus
 ```
 
+### Analyze warns about unavailable FTS or VECTOR extensions
+
+GitNexus uses optional DuckDB extensions for BM25 and vector search. The `gitnexus serve` and MCP read paths only ever try to `LOAD` the extensions — they never block on a network install. The `analyze` command, by default, attempts one bounded out-of-process `INSTALL` if `LOAD` fails and proceeds even when that install times out, so the index is always written to disk; BM25/vector search degrade gracefully until the extensions become available.
+
+Configure the behavior with two environment variables:
+
+| Variable | Values | Default | Effect |
+|----------|--------|---------|--------|
+| `GITNEXUS_LBUG_EXTENSION_INSTALL` | `auto`, `load-only`, `never` | `auto` | `auto` runs one bounded INSTALL if LOAD fails. `load-only` only uses already-installed extensions (recommended for offline / firewalled environments). `never` skips optional extensions entirely. |
+| `GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS` | positive integer | `15000` | Wall-clock budget for the out-of-process `INSTALL` child before it is killed. |
+
+```bash
+# Offline/airgapped: never reach the network for extensions
+GITNEXUS_LBUG_EXTENSION_INSTALL=load-only npx gitnexus analyze
+
+# Slow network: give extension downloads more time
+GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS=30000 npx gitnexus analyze
+```
+
 ### Analysis runs out of memory
 
 For very large repositories:

--- a/gitnexus/scripts/install-duckdb-extension.mjs
+++ b/gitnexus/scripts/install-duckdb-extension.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const EXTENSION_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+async function installDuckDbExtension(extensionName) {
+  if (!extensionName || !EXTENSION_NAME_PATTERN.test(extensionName)) {
+    throw new Error(`Invalid DuckDB extension name: ${extensionName ?? '<missing>'}`);
+  }
+
+  const require = createRequire(import.meta.url);
+  const lbugModule = require('@ladybugdb/core');
+  const lbug = lbugModule.default ?? lbugModule;
+
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-ext-install-'));
+  const dbPath = path.join(tmpDir, 'install.lbug');
+  let db;
+  let conn;
+
+  try {
+    db = new lbug.Database(dbPath);
+    conn = new lbug.Connection(db);
+    await conn.query(`INSTALL ${extensionName}`);
+  } finally {
+    if (conn) await conn.close().catch(() => {});
+    if (db) await db.close().catch(() => {});
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+installDuckDbExtension(process.argv[2] ?? process.env.GITNEXUS_LBUG_EXTENSION_NAME).catch((err) => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exitCode = 1;
+});

--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -193,8 +193,11 @@ export const batchInsertEmbeddings = async (
 const createVectorIndex = async (
   executeQuery: (cypher: string) => Promise<any[]>,
 ): Promise<void> => {
-  // Delegate to the adapter which tracks loaded state and handles DB reconnect resets
-  await loadVectorExtension();
+  // Delegate to the adapter which tracks loaded state and handles DB reconnect resets.
+  // If the optional VECTOR extension cannot be loaded, semantic search degrades gracefully.
+  if (!(await loadVectorExtension())) {
+    return;
+  }
 
   try {
     await executeQuery(CREATE_VECTOR_INDEX_QUERY);

--- a/gitnexus/src/core/lbug/extension-loader.ts
+++ b/gitnexus/src/core/lbug/extension-loader.ts
@@ -1,0 +1,283 @@
+import { spawn } from 'child_process';
+
+const DEFAULT_EXTENSION_INSTALL_TIMEOUT_MS = 15_000;
+const EXTENSION_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+/**
+ * Lifecycle policy for an optional DuckDB extension.
+ *
+ * - `auto`     — try `LOAD`, fall back to one bounded out-of-process `INSTALL`
+ *                attempt per process if `LOAD` fails. Default for analyze.
+ * - `load-only`— try `LOAD` only; never spawn an installer. Used by serve/MCP
+ *                read paths so user queries never block on a network install.
+ * - `never`    — skip the extension entirely. Operators can use this to
+ *                forcibly disable optional search features.
+ */
+export type ExtensionInstallPolicy = 'auto' | 'load-only' | 'never';
+
+export interface ExtensionInstallResult {
+  success: boolean;
+  timedOut: boolean;
+  message: string;
+}
+
+/** Snapshot of one optional extension's resolved capability state. */
+export interface ExtensionCapability {
+  name: string;
+  loaded: boolean;
+  /** Human-readable reason when `loaded` is false. */
+  reason?: string;
+}
+
+/** Per-call overrides applied on top of `ExtensionManager` defaults. */
+export interface ExtensionEnsureOptions {
+  policy?: ExtensionInstallPolicy;
+  installTimeoutMs?: number;
+}
+
+export interface ExtensionManagerOptions {
+  policy?: ExtensionInstallPolicy;
+  installTimeoutMs?: number;
+  installExtension?: (extensionName: string, timeoutMs: number) => Promise<ExtensionInstallResult>;
+  warn?: (message: string) => void;
+}
+
+const alreadyAvailable = (message: string): boolean =>
+  message.includes('already loaded') ||
+  message.includes('already installed') ||
+  message.includes('already exists');
+
+const resolvePolicyFromEnv = (): ExtensionInstallPolicy => {
+  const raw = process.env.GITNEXUS_LBUG_EXTENSION_INSTALL;
+  if (raw === 'load-only' || raw === 'never' || raw === 'auto') return raw;
+  return 'auto';
+};
+
+export const getExtensionInstallTimeoutMs = (): number => {
+  const raw = process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS;
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_EXTENSION_INSTALL_TIMEOUT_MS;
+};
+
+/**
+ * Run `INSTALL <extension>` in a short-lived child Node process so the parent
+ * event loop is never blocked by DuckDB's synchronous network call.
+ *
+ * The child opens its own scratch LadybugDB, executes the install, and exits.
+ * If the child exceeds `timeoutMs` the parent kills it with SIGKILL and
+ * resolves with `timedOut: true`.
+ */
+export const installDuckDbExtensionOutOfProcess = async (
+  extensionName: string,
+  timeoutMs: number = getExtensionInstallTimeoutMs(),
+): Promise<ExtensionInstallResult> => {
+  if (!EXTENSION_NAME_PATTERN.test(extensionName)) {
+    throw new Error(`Invalid DuckDB extension name: ${extensionName}`);
+  }
+
+  const childCode = `
+    import fs from 'node:fs/promises';
+    import os from 'node:os';
+    import path from 'node:path';
+    import { createRequire } from 'node:module';
+
+    const extensionName = process.env.GITNEXUS_LBUG_EXTENSION_NAME;
+    const require = createRequire(process.env.GITNEXUS_LBUG_RESOLVE_FROM);
+    const lbugModule = require('@ladybugdb/core');
+    const lbug = lbugModule.default ?? lbugModule;
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-ext-install-'));
+    const dbPath = path.join(tmpDir, 'install.lbug');
+    let db;
+    let conn;
+    try {
+      db = new lbug.Database(dbPath);
+      conn = new lbug.Connection(db);
+      await conn.query(\`INSTALL \${extensionName}\`);
+    } finally {
+      if (conn) await conn.close().catch(() => {});
+      if (db) await db.close().catch(() => {});
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  `;
+
+  return await new Promise<ExtensionInstallResult>((resolve) => {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', childCode], {
+      env: {
+        ...process.env,
+        GITNEXUS_LBUG_EXTENSION_NAME: extensionName,
+        GITNEXUS_LBUG_RESOLVE_FROM: import.meta.url,
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+      windowsHide: true,
+    });
+
+    let stderr = '';
+    child.stderr?.setEncoding('utf8');
+    child.stderr?.on('data', (chunk) => {
+      stderr = (stderr + chunk).slice(-4000);
+    });
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill('SIGKILL');
+      resolve({
+        success: false,
+        timedOut: true,
+        message: `INSTALL ${extensionName} timed out after ${timeoutMs}ms`,
+      });
+    }, timeoutMs);
+
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ success: false, timedOut: false, message: err.message });
+    });
+
+    child.on('exit', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        success: code === 0,
+        timedOut: false,
+        message:
+          code === 0
+            ? `INSTALL ${extensionName} completed`
+            : `INSTALL ${extensionName} failed with ${signal ?? `exit code ${code}`}${stderr ? `: ${stderr.trim()}` : ''}`,
+      });
+    });
+  });
+};
+
+/**
+ * Centralized lifecycle manager for optional LadybugDB extensions.
+ *
+ * Always tries `LOAD EXTENSION <name>` first — it is per-connection,
+ * idempotent, and never touches the network. If `LOAD` fails and the active
+ * policy permits, the manager runs a single bounded out-of-process `INSTALL`
+ * attempt per process and retries `LOAD`. Capability outcomes are cached so
+ * unavailable extensions degrade search features without ever blocking
+ * subsequent analyze or query calls.
+ *
+ * Policy precedence (most specific wins):
+ *   per-call `opts.policy` → constructor `options.policy` → env → `auto`
+ */
+export class ExtensionManager {
+  private readonly capabilities = new Map<string, ExtensionCapability>();
+  private readonly installAttempted = new Map<string, ExtensionInstallResult>();
+  private readonly warnedKeys = new Set<string>();
+
+  constructor(private readonly options: ExtensionManagerOptions = {}) {}
+
+  /** Reset cached capability and install state. Test-only. */
+  reset(): void {
+    this.capabilities.clear();
+    this.installAttempted.clear();
+    this.warnedKeys.clear();
+  }
+
+  /** Snapshot of currently-known optional extension capabilities. */
+  getCapabilities(): ExtensionCapability[] {
+    return Array.from(this.capabilities.values());
+  }
+
+  /**
+   * Ensure an optional extension is loaded on the supplied connection.
+   *
+   * Returns `true` when the extension is usable on `query`, `false` when it
+   * is unavailable. Never throws on install failure — analyze and query
+   * paths are expected to degrade gracefully.
+   */
+  async ensure(
+    query: (sql: string) => Promise<unknown>,
+    name: string,
+    label: string,
+    opts: ExtensionEnsureOptions = {},
+  ): Promise<boolean> {
+    if (!EXTENSION_NAME_PATTERN.test(name)) {
+      throw new Error(`Invalid DuckDB extension name: ${name}`);
+    }
+
+    const policy = opts.policy ?? this.options.policy ?? resolvePolicyFromEnv();
+    const timeoutMs =
+      opts.installTimeoutMs ?? this.options.installTimeoutMs ?? getExtensionInstallTimeoutMs();
+    const warn = this.options.warn ?? console.warn;
+
+    if (policy === 'never') {
+      this.markUnavailable(name, label, 'extension install policy is "never"', warn);
+      return false;
+    }
+
+    if (await this.tryLoad(query, name)) {
+      this.markLoaded(name);
+      return true;
+    }
+
+    if (policy === 'load-only') {
+      this.markUnavailable(name, label, 'load-only policy: extension not pre-installed', warn);
+      return false;
+    }
+
+    let install = this.installAttempted.get(name);
+    if (!install) {
+      const installFn = this.options.installExtension ?? installDuckDbExtensionOutOfProcess;
+      install = await installFn(name, timeoutMs);
+      this.installAttempted.set(name, install);
+    }
+
+    if (!install.success) {
+      this.markUnavailable(name, label, install.message, warn);
+      return false;
+    }
+
+    if (await this.tryLoad(query, name)) {
+      this.markLoaded(name);
+      return true;
+    }
+
+    this.markUnavailable(name, label, `LOAD ${name} failed after successful INSTALL`, warn);
+    return false;
+  }
+
+  private async tryLoad(query: (sql: string) => Promise<unknown>, name: string): Promise<boolean> {
+    try {
+      await query(`LOAD EXTENSION ${name}`);
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return alreadyAvailable(msg);
+    }
+  }
+
+  private markLoaded(name: string): void {
+    this.capabilities.set(name, { name, loaded: true });
+  }
+
+  private markUnavailable(
+    name: string,
+    label: string,
+    reason: string,
+    warn: (message: string) => void,
+  ): void {
+    this.capabilities.set(name, { name, loaded: false, reason });
+    const key = `${name}:${reason}`;
+    if (this.warnedKeys.has(key)) return;
+    this.warnedKeys.add(key);
+    warn(
+      `GitNexus: ${label} extension unavailable; continuing without ${label} features. ${reason}`,
+    );
+  }
+}
+
+/** Process-wide singleton shared by core and pool adapters. */
+export const extensionManager = new ExtensionManager();
+
+/** Snapshot of which optional DuckDB extensions are loaded in this process. */
+export const getExtensionCapabilities = (): ExtensionCapability[] =>
+  extensionManager.getCapabilities();
+
+/** Test-only: clear the singleton's cached capability and install state. */
+export const resetExtensionState = (): void => extensionManager.reset();

--- a/gitnexus/src/core/lbug/extension-loader.ts
+++ b/gitnexus/src/core/lbug/extension-loader.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { fileURLToPath } from 'node:url';
 
 const DEFAULT_EXTENSION_INSTALL_TIMEOUT_MS = 15_000;
 const EXTENSION_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
@@ -59,6 +60,11 @@ export const getExtensionInstallTimeoutMs = (): number => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_EXTENSION_INSTALL_TIMEOUT_MS;
 };
 
+export const getExtensionInstallChildProcessArgs = (extensionName: string): string[] => {
+  const childScript = new URL('../../../scripts/install-duckdb-extension.mjs', import.meta.url);
+  return [fileURLToPath(childScript), extensionName];
+};
+
 /**
  * Run `INSTALL <extension>` in a short-lived child Node process so the parent
  * event loop is never blocked by DuckDB's synchronous network call.
@@ -75,37 +81,11 @@ export const installDuckDbExtensionOutOfProcess = async (
     throw new Error(`Invalid DuckDB extension name: ${extensionName}`);
   }
 
-  const childCode = `
-    import fs from 'node:fs/promises';
-    import os from 'node:os';
-    import path from 'node:path';
-    import { createRequire } from 'node:module';
-
-    const extensionName = process.env.GITNEXUS_LBUG_EXTENSION_NAME;
-    const require = createRequire(process.env.GITNEXUS_LBUG_RESOLVE_FROM);
-    const lbugModule = require('@ladybugdb/core');
-    const lbug = lbugModule.default ?? lbugModule;
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-ext-install-'));
-    const dbPath = path.join(tmpDir, 'install.lbug');
-    let db;
-    let conn;
-    try {
-      db = new lbug.Database(dbPath);
-      conn = new lbug.Connection(db);
-      await conn.query(\`INSTALL \${extensionName}\`);
-    } finally {
-      if (conn) await conn.close().catch(() => {});
-      if (db) await db.close().catch(() => {});
-      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-    }
-  `;
-
   return await new Promise<ExtensionInstallResult>((resolve) => {
-    const child = spawn(process.execPath, ['--input-type=module', '-e', childCode], {
+    const child = spawn(process.execPath, getExtensionInstallChildProcessArgs(extensionName), {
       env: {
         ...process.env,
         GITNEXUS_LBUG_EXTENSION_NAME: extensionName,
-        GITNEXUS_LBUG_RESOLVE_FROM: import.meta.url,
       },
       stdio: ['ignore', 'ignore', 'pipe'],
       windowsHide: true,

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -16,6 +16,7 @@ import {
 } from './schema.js';
 import { streamAllCSVsToDisk } from './csv-generator.js';
 import type { CachedEmbedding } from '../embeddings/types.js';
+import { extensionManager, type ExtensionEnsureOptions } from './extension-loader.js';
 
 // ---------------------------------------------------------------------------
 // Relationship CSV splitting — extracted for testability (PR #818)
@@ -330,7 +331,8 @@ const doInitLbug = async (dbPath: string) => {
     }
   }
 
-  // Load query extensions once per core adapter session.
+  // Load query extensions once per core adapter session. Missing optional
+  // extensions degrade search features but must not block analyze completion.
   await loadFTSExtension();
   await loadVectorExtension();
 
@@ -1142,18 +1144,21 @@ export const getEmbeddingTableName = (): string => EMBEDDING_TABLE_NAME;
 // ============================================================================
 
 /**
- * Load the FTS extension (required before using FTS functions).
+ * Load the FTS extension on the supplied connection (or the singleton
+ * writable connection when none is given).
  *
- * Safe to call multiple times — when invoked without arguments, tracks loaded
- * state via module-level `ftsLoaded`. When invoked with an explicit
- * connection, loads on that connection and returns whether the load
- * succeeded — letting callers (e.g. the pool adapter) track their own state.
- *
- * Tries `LOAD EXTENSION fts` first so previously-cached installs skip the
- * network entirely; falls back to `INSTALL` + `LOAD` only when the extension
- * hasn't been cached yet.
+ * Delegates to the shared `ExtensionManager` so install policy (auto /
+ * load-only / never), out-of-process bounded INSTALL, and capability
+ * caching are owned in one place. The module-level `ftsLoaded` flag is
+ * kept purely as a per-call short-circuit on the singleton writable
+ * connection so repeated callers (e.g. createFTSIndex) avoid an extra
+ * `LOAD` round-trip per invocation. Pool adapter callers pass
+ * `{ policy: 'load-only' }` so query paths never block on a network install.
  */
-export const loadFTSExtension = async (targetConn?: lbug.Connection): Promise<boolean> => {
+export const loadFTSExtension = async (
+  targetConn?: lbug.Connection,
+  opts: ExtensionEnsureOptions = {},
+): Promise<boolean> => {
   const useModuleState = targetConn === undefined;
   if (useModuleState && ftsLoaded) return true;
 
@@ -1162,60 +1167,31 @@ export const loadFTSExtension = async (targetConn?: lbug.Connection): Promise<bo
     throw new Error('LadybugDB not initialized. Call initLbug first.');
   }
 
-  const markLoaded = (): true => {
-    if (useModuleState) ftsLoaded = true;
-    return true;
-  };
-
-  try {
-    // Try loading locally first (no network required)
-    await c.query('LOAD EXTENSION fts');
-    return markLoaded();
-  } catch {
-    // Fall back to install + load (requires network)
-    try {
-      await c.query('INSTALL fts');
-      await c.query('LOAD EXTENSION fts');
-      return markLoaded();
-    } catch (err: any) {
-      const msg = err?.message || '';
-      if (
-        msg.includes('already loaded') ||
-        msg.includes('already installed') ||
-        msg.includes('already exists')
-      ) {
-        return markLoaded();
-      }
-      console.error('GitNexus: FTS extension load failed:', msg);
-      return false;
-    }
-  }
+  const loaded = await extensionManager.ensure((sql) => c.query(sql), 'fts', 'FTS', opts);
+  if (loaded && useModuleState) ftsLoaded = true;
+  return loaded;
 };
+
 /**
- * Load the VECTOR extension (required before using QUERY_VECTOR_INDEX).
- * Safe to call multiple times -- tracks loaded state via module-level vectorExtensionLoaded.
+ * Load the VECTOR extension on the supplied connection (or the singleton
+ * writable connection when none is given). See `loadFTSExtension` for the
+ * policy / capability contract — the same `ExtensionManager` owns both.
  */
-export const loadVectorExtension = async (): Promise<void> => {
-  if (vectorExtensionLoaded) return;
-  if (!conn) {
+export const loadVectorExtension = async (
+  targetConn?: lbug.Connection,
+  opts: ExtensionEnsureOptions = {},
+): Promise<boolean> => {
+  const useModuleState = targetConn === undefined;
+  if (useModuleState && vectorExtensionLoaded) return true;
+
+  const c: lbug.Connection | null = targetConn ?? conn;
+  if (!c) {
     throw new Error('LadybugDB not initialized. Call initLbug first.');
   }
-  try {
-    await conn.query('INSTALL VECTOR');
-    await conn.query('LOAD EXTENSION VECTOR');
-    vectorExtensionLoaded = true;
-  } catch (err: any) {
-    const msg = err?.message || '';
-    if (
-      msg.includes('already loaded') ||
-      msg.includes('already installed') ||
-      msg.includes('already exists')
-    ) {
-      vectorExtensionLoaded = true;
-    } else {
-      console.error('GitNexus: VECTOR extension load failed:', msg);
-    }
-  }
+
+  const loaded = await extensionManager.ensure((sql) => c.query(sql), 'VECTOR', 'VECTOR', opts);
+  if (loaded && useModuleState) vectorExtensionLoaded = true;
+  return loaded;
 };
 /**
  * Create a full-text search index on a table
@@ -1234,7 +1210,9 @@ export const createFTSIndex = async (
     throw new Error('LadybugDB not initialized. Call initLbug first.');
   }
 
-  await loadFTSExtension();
+  if (!(await loadFTSExtension())) {
+    return;
+  }
 
   const propList = properties.map((p) => `'${p}'`).join(', ');
   const query = `CALL CREATE_FTS_INDEX('${tableName}', '${indexName}', [${propList}], stemmer := '${stemmer}')`;

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -17,7 +17,7 @@
 
 import fs from 'fs/promises';
 import lbug from '@ladybugdb/core';
-import { loadFTSExtension } from './lbug-adapter.js';
+import { loadFTSExtension, loadVectorExtension } from './lbug-adapter.js';
 
 /** Per-repo pool: one Database, many Connections */
 interface PoolEntry {
@@ -354,19 +354,15 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
   // Load FTS extension once per shared Database.
   // Done BEFORE pool registration so no concurrent checkout can grab
   // the connection while the async FTS load is in progress.
+  // policy: 'load-only' — the read pool must never trigger a network
+  // install; analyze owns extension installation. If LOAD fails, search
+  // features degrade gracefully and the user-facing query path proceeds.
   if (!shared.ftsLoaded) {
-    shared.ftsLoaded = await loadFTSExtension(available[0]);
+    shared.ftsLoaded = await loadFTSExtension(available[0], { policy: 'load-only' });
   }
 
-  // Load VECTOR extension once per shared Database for semantic search support.
   if (!shared.vectorLoaded) {
-    try {
-      await available[0].query('INSTALL VECTOR');
-      await available[0].query('LOAD EXTENSION VECTOR');
-      shared.vectorLoaded = true;
-    } catch {
-      // VECTOR extension may not be available
-    }
+    shared.vectorLoaded = await loadVectorExtension(available[0], { policy: 'load-only' });
   }
 
   // Register pool entry only after all connections are pre-warmed and FTS is
@@ -427,20 +423,15 @@ export async function initLbugWithDb(
     preWarmActive = false;
   }
 
-  // Load FTS extension if not already loaded on this Database
+  // Load FTS extension if not already loaded on this Database.
+  // policy: 'load-only' — same contract as initLbug above; the read pool
+  // must not block on a network install during query execution.
   if (!shared.ftsLoaded) {
-    shared.ftsLoaded = await loadFTSExtension(available[0]);
+    shared.ftsLoaded = await loadFTSExtension(available[0], { policy: 'load-only' });
   }
 
-  // Load VECTOR extension for semantic search support
   if (!shared.vectorLoaded) {
-    try {
-      await available[0].query('INSTALL VECTOR');
-      await available[0].query('LOAD EXTENSION VECTOR');
-      shared.vectorLoaded = true;
-    } catch {
-      // VECTOR extension may not be available
-    }
+    shared.vectorLoaded = await loadVectorExtension(available[0], { policy: 'load-only' });
   }
 
   pool.set(repoId, {

--- a/gitnexus/test/integration/lbug-vector-extension.test.ts
+++ b/gitnexus/test/integration/lbug-vector-extension.test.ts
@@ -16,14 +16,14 @@ withTestLbugDB('vector-extension', (handle) => {
       const { loadVectorExtension } = await import('../../src/core/lbug/lbug-adapter.js');
 
       // Should resolve without throwing -- idempotent if already loaded by doInitLbug
-      await expect(loadVectorExtension()).resolves.toBeUndefined();
+      await expect(loadVectorExtension()).resolves.toBe(true);
     });
 
     it('is idempotent -- calling twice does not throw', async () => {
       const { loadVectorExtension } = await import('../../src/core/lbug/lbug-adapter.js');
 
       await loadVectorExtension();
-      await expect(loadVectorExtension()).resolves.toBeUndefined();
+      await expect(loadVectorExtension()).resolves.toBe(true);
     });
   });
 
@@ -43,7 +43,7 @@ withTestLbugDB('vector-extension', (handle) => {
       expect(adapter.isLbugReady()).toBe(true);
 
       // loadVectorExtension should succeed (not skip due to stale flag)
-      await expect(adapter.loadVectorExtension()).resolves.toBeUndefined();
+      await expect(adapter.loadVectorExtension()).resolves.toBe(true);
     });
   });
 
@@ -69,7 +69,7 @@ withTestLbugDB('vector-extension', (handle) => {
 
       // After recovery, vector extension should still be loadable
       // (the flag was reset and re-loaded during re-init)
-      await expect(adapter.loadVectorExtension()).resolves.toBeUndefined();
+      await expect(adapter.loadVectorExtension()).resolves.toBe(true);
     });
   });
 });

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -167,7 +167,7 @@ describe('runEmbeddingPipeline incremental filter', () => {
 
     // Mock loadVectorExtension (avoids needing the native lbug module)
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
-      loadVectorExtension: vi.fn().mockResolvedValue(undefined),
+      loadVectorExtension: vi.fn().mockResolvedValue(true),
     }));
   };
 
@@ -296,7 +296,7 @@ describe('runEmbeddingPipeline incremental filter', () => {
       isEmbedderReady: vi.fn().mockReturnValue(true),
     }));
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
-      loadVectorExtension: vi.fn().mockResolvedValue(undefined),
+      loadVectorExtension: vi.fn().mockResolvedValue(true),
     }));
 
     const executeQuery = vi.fn().mockImplementation(async (cypher: string) => {
@@ -465,7 +465,7 @@ describe('runEmbeddingPipeline incremental filter', () => {
       isEmbedderReady: vi.fn().mockReturnValue(true),
     }));
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
-      loadVectorExtension: vi.fn().mockResolvedValue(undefined),
+      loadVectorExtension: vi.fn().mockResolvedValue(true),
     }));
 
     const node = makeNode({
@@ -519,7 +519,7 @@ describe('runEmbeddingPipeline incremental filter', () => {
       isEmbedderReady: vi.fn().mockReturnValue(true),
     }));
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
-      loadVectorExtension: vi.fn().mockResolvedValue(undefined),
+      loadVectorExtension: vi.fn().mockResolvedValue(true),
     }));
 
     const node = makeNode({

--- a/gitnexus/test/unit/lbug-extension-loader.test.ts
+++ b/gitnexus/test/unit/lbug-extension-loader.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ExtensionManager,
+  getExtensionInstallTimeoutMs,
+  type ExtensionInstallResult,
+} from '../../src/core/lbug/extension-loader.js';
+
+const okInstall: ExtensionInstallResult = {
+  success: true,
+  timedOut: false,
+  message: 'installed',
+};
+const failedInstall: ExtensionInstallResult = {
+  success: false,
+  timedOut: false,
+  message: 'install failed',
+};
+const timedOutInstall: ExtensionInstallResult = {
+  success: false,
+  timedOut: true,
+  message: 'INSTALL vector timed out after 10ms',
+};
+
+const noopWarn = (): void => {};
+
+describe('ExtensionManager — LOAD-first behavior', () => {
+  it('uses LOAD only and never invokes INSTALL when the extension is already available', async () => {
+    const installExtension = vi.fn();
+    const manager = new ExtensionManager({ policy: 'auto', installExtension });
+    const query = vi.fn().mockResolvedValue({});
+
+    await expect(manager.ensure(query, 'fts', 'FTS')).resolves.toBe(true);
+
+    expect(query.mock.calls.map(([sql]) => sql)).toEqual(['LOAD EXTENSION fts']);
+    expect(installExtension).not.toHaveBeenCalled();
+    expect(manager.getCapabilities()).toEqual([{ name: 'fts', loaded: true }]);
+  });
+
+  it('treats "already loaded" load errors as success', async () => {
+    const installExtension = vi.fn();
+    const manager = new ExtensionManager({ policy: 'auto', installExtension });
+    const query = vi.fn().mockRejectedValue(new Error('Extension fts is already loaded'));
+
+    await expect(manager.ensure(query, 'fts', 'FTS')).resolves.toBe(true);
+    expect(installExtension).not.toHaveBeenCalled();
+  });
+});
+
+describe('ExtensionManager — install policies', () => {
+  it('runs bounded out-of-process INSTALL and retries LOAD when policy=auto', async () => {
+    const installExtension = vi.fn().mockResolvedValue(okInstall);
+    const manager = new ExtensionManager({ policy: 'auto', installExtension });
+    const query = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Extension "fts" not found'))
+      .mockResolvedValueOnce({});
+
+    await expect(manager.ensure(query, 'fts', 'FTS', { installTimeoutMs: 1234 })).resolves.toBe(
+      true,
+    );
+
+    expect(installExtension).toHaveBeenCalledWith('fts', 1234);
+    expect(query.mock.calls.map(([sql]) => sql)).toEqual([
+      'LOAD EXTENSION fts',
+      'LOAD EXTENSION fts',
+    ]);
+    expect(query.mock.calls.some(([sql]) => String(sql).startsWith('INSTALL '))).toBe(false);
+  });
+
+  it('skips INSTALL and warns when policy=load-only', async () => {
+    const installExtension = vi.fn();
+    const warn = vi.fn();
+    const manager = new ExtensionManager({ policy: 'load-only', installExtension, warn });
+    const query = vi.fn().mockRejectedValue(new Error('Extension "fts" not found'));
+
+    await expect(manager.ensure(query, 'fts', 'FTS')).resolves.toBe(false);
+
+    expect(installExtension).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('continuing without FTS features'));
+    expect(manager.getCapabilities()).toEqual([
+      { name: 'fts', loaded: false, reason: expect.stringContaining('load-only') },
+    ]);
+  });
+
+  it('short-circuits LOAD and INSTALL when policy=never', async () => {
+    const installExtension = vi.fn();
+    const warn = vi.fn();
+    const manager = new ExtensionManager({ policy: 'never', installExtension, warn });
+    const query = vi.fn();
+
+    await expect(manager.ensure(query, 'vector', 'VECTOR')).resolves.toBe(false);
+
+    expect(query).not.toHaveBeenCalled();
+    expect(installExtension).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('continuing without VECTOR features'),
+    );
+  });
+
+  it('per-call options override manager defaults', async () => {
+    const installExtension = vi.fn().mockResolvedValue(okInstall);
+    const manager = new ExtensionManager({
+      policy: 'auto',
+      installExtension,
+      warn: noopWarn,
+    });
+    const query = vi.fn().mockRejectedValue(new Error('Extension "vector" not found'));
+
+    await expect(manager.ensure(query, 'vector', 'VECTOR', { policy: 'load-only' })).resolves.toBe(
+      false,
+    );
+
+    expect(installExtension).not.toHaveBeenCalled();
+  });
+
+  it('returns false and warns when bounded install times out', async () => {
+    const installExtension = vi.fn().mockResolvedValue(timedOutInstall);
+    const warn = vi.fn();
+    const manager = new ExtensionManager({ policy: 'auto', installExtension, warn });
+    const query = vi.fn().mockRejectedValue(new Error('Extension "vector" not found'));
+
+    await expect(manager.ensure(query, 'vector', 'VECTOR', { installTimeoutMs: 10 })).resolves.toBe(
+      false,
+    );
+
+    expect(query.mock.calls.map(([sql]) => sql)).toEqual(['LOAD EXTENSION vector']);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('continuing without VECTOR features'),
+    );
+  });
+});
+
+describe('ExtensionManager — caching', () => {
+  it('caches install attempt outcome to avoid retrying within the same process', async () => {
+    const installExtension = vi.fn().mockResolvedValue(timedOutInstall);
+    const manager = new ExtensionManager({
+      policy: 'auto',
+      installExtension,
+      warn: noopWarn,
+    });
+    const query = vi.fn().mockRejectedValue(new Error('Extension "vector" not found'));
+
+    await expect(manager.ensure(query, 'vector', 'VECTOR')).resolves.toBe(false);
+    await expect(manager.ensure(query, 'vector', 'VECTOR')).resolves.toBe(false);
+
+    expect(installExtension).toHaveBeenCalledOnce();
+  });
+
+  it('reset() clears capability and install state so install is retried', async () => {
+    const installExtension = vi.fn().mockResolvedValue(failedInstall);
+    const manager = new ExtensionManager({
+      policy: 'auto',
+      installExtension,
+      warn: noopWarn,
+    });
+    const query = vi.fn().mockRejectedValue(new Error('Extension "fts" not found'));
+
+    await manager.ensure(query, 'fts', 'FTS');
+    expect(manager.getCapabilities()).toHaveLength(1);
+
+    manager.reset();
+    expect(manager.getCapabilities()).toEqual([]);
+
+    await manager.ensure(query, 'fts', 'FTS');
+    expect(installExtension).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ExtensionManager — observability', () => {
+  it('exposes per-extension capability snapshot', async () => {
+    const manager = new ExtensionManager({ policy: 'load-only', warn: noopWarn });
+    const okQuery = vi.fn().mockResolvedValue({});
+    const failQuery = vi.fn().mockRejectedValue(new Error('Extension "vector" not found'));
+
+    await manager.ensure(okQuery, 'fts', 'FTS');
+    await manager.ensure(failQuery, 'vector', 'VECTOR');
+
+    expect(manager.getCapabilities()).toEqual([
+      { name: 'fts', loaded: true },
+      { name: 'vector', loaded: false, reason: expect.stringContaining('load-only') },
+    ]);
+  });
+
+  it('warns at most once per (extension, reason) pair', async () => {
+    const installExtension = vi.fn();
+    const warn = vi.fn();
+    const manager = new ExtensionManager({ policy: 'load-only', installExtension, warn });
+    const query = vi.fn().mockRejectedValue(new Error('Extension "fts" not found'));
+
+    await manager.ensure(query, 'fts', 'FTS');
+    await manager.ensure(query, 'fts', 'FTS');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ExtensionManager — input validation', () => {
+  it('rejects extension names that are not bare identifiers', async () => {
+    const manager = new ExtensionManager({ policy: 'auto' });
+    const query = vi.fn();
+
+    await expect(manager.ensure(query, 'fts; DROP TABLE x', 'FTS')).rejects.toThrow(/Invalid/);
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('getExtensionInstallTimeoutMs', () => {
+  it('reads a positive override from the environment', () => {
+    const original = process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS;
+    process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS = '42';
+    try {
+      expect(getExtensionInstallTimeoutMs()).toBe(42);
+    } finally {
+      if (original === undefined) {
+        delete process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS;
+      } else {
+        process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS = original;
+      }
+    }
+  });
+
+  it('falls back to the default when the env var is missing or invalid', () => {
+    const original = process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS;
+    delete process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS;
+    try {
+      expect(getExtensionInstallTimeoutMs()).toBe(15_000);
+      process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS = 'notanumber';
+      expect(getExtensionInstallTimeoutMs()).toBe(15_000);
+      process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS = '0';
+      expect(getExtensionInstallTimeoutMs()).toBe(15_000);
+    } finally {
+      if (original === undefined) {
+        delete process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS;
+      } else {
+        process.env.GITNEXUS_LBUG_EXTENSION_INSTALL_TIMEOUT_MS = original;
+      }
+    }
+  });
+});

--- a/gitnexus/test/unit/lbug-extension-loader.test.ts
+++ b/gitnexus/test/unit/lbug-extension-loader.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   ExtensionManager,
+  getExtensionInstallChildProcessArgs,
   getExtensionInstallTimeoutMs,
   type ExtensionInstallResult,
 } from '../../src/core/lbug/extension-loader.js';
@@ -201,6 +202,18 @@ describe('ExtensionManager — input validation', () => {
 
     await expect(manager.ensure(query, 'fts; DROP TABLE x', 'FTS')).rejects.toThrow(/Invalid/);
     expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('installDuckDbExtensionOutOfProcess child process', () => {
+  it('spawns the stable packaged installer script instead of inline -e code', () => {
+    const args = getExtensionInstallChildProcessArgs('fts');
+
+    expect(args).not.toContain('-e');
+    expect(args).not.toContain('--input-type=module');
+    expect(args[0]).toContain('scripts');
+    expect(args[0]).toContain('install-duckdb-extension.mjs');
+    expect(args.at(-1)).toBe('fts');
   });
 });
 


### PR DESCRIPTION
## Summary
- Prevent `gitnexus analyze` from hanging when DuckDB `fts` / `VECTOR` extension downloads are blocked by moving `INSTALL` into a bounded child process.
- Centralize optional extension lifecycle in `ExtensionManager` with explicit `auto`, `load-only`, and `never` policies so analyze can install while serve/MCP read paths only load preinstalled extensions.
- Add a stable debuggable installer script at `gitnexus/scripts/install-duckdb-extension.mjs`, update vector/FTS callers to degrade gracefully, and document the new environment controls.

Closes #1128.

## Test plan
- `npx tsc --noEmit`
- `npx vitest run test/unit/lbug-extension-loader.test.ts --pool=threads`
- `npx vitest run test/unit/embedding-pipeline.test.ts --pool=threads`
- `node scripts/install-duckdb-extension.mjs "bad;name"` (expected non-zero, verifies debuggable script stack trace)
- `npx vitest run --project=lbug-db test/integration/lbug-core-adapter.test.ts --pool=forks --maxWorkers=1`
- `npx vitest run --project=lbug-db test/integration/lbug-vector-extension.test.ts --pool=forks --maxWorkers=1` (assertions pass; Windows may still emit the known native Vitest worker-exit noise after teardown)
- `npm run build`
- `npx tsx src/cli/index.ts detect-changes -r GitNexus`

## Notes
- Full `npm test` still shows unrelated pre-existing Swift failures in `method-extraction`, `type-env`, and Swift resolver coverage.