### PR TITLE
fix(query): allow lazy FTS index creation in MCP read path

### DIFF
--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -300,9 +300,13 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
   // This prevents buffer manager exhaustion from multiple mmap regions on the same file.
   let shared = dbCache.get(dbPath);
   if (!shared) {
-    // Open in read-only mode — MCP server never writes to the database.
-    // This allows multiple MCP server instances to read concurrently, and
-    // avoids lock conflicts when `gitnexus analyze` is writing.
+    // The MCP/CLI read path lazily creates FTS indexes on first `query`
+    // (see `bm25-index.ts:ensureFTSIndex` → `CALL CREATE_FTS_INDEX(...)`).
+    // CREATE_FTS_INDEX is a write operation, so the connection cannot be
+    // opened in read-only mode without breaking every `gitnexus query`
+    // invocation with `Cannot execute write operations in a read-only
+    // database!`. The lock-retry block below covers contention with a
+    // concurrent `gitnexus analyze` writer.
     let lastError: Error | null = null;
     for (let attempt = 1; attempt <= LOCK_RETRY_ATTEMPTS; attempt++) {
       silenceStdout();
@@ -311,7 +315,7 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
           dbPath,
           0, // bufferManagerSize (default)
           false, // enableCompression (default)
-          true, // readOnly
+          false, // readOnly — see note above re: lazy CREATE_FTS_INDEX
         );
         restoreStdout();
         shared = { db, refCount: 0, ftsLoaded: false, vectorLoaded: false };


### PR DESCRIPTION
## What changed

`gitnexus/src/core/lbug/pool-adapter.ts` — flip the LadybugDB connection's `readOnly` flag from `true` to `false`, with an updated comment explaining why the read-only invariant can't hold given the lazy FTS index creation in the same path.

## Why

The MCP/CLI pool adapter opens the LadybugDB connection with `readOnly: true`, but `bm25-index.ts:ensureFTSIndex` lazily issues `CALL CREATE_FTS_INDEX(...)` on first `gitnexus query`. `CREATE_FTS_INDEX` is a write operation, so the call fails with:

```
[gitnexus] FTS index ensure failed for repo "X" table "File"
  (index "file_fts"): Connection exception: Cannot execute write
  operations in a read-only database!. Will retry on next query.
```

The retry never recovers because the connection mode is fixed at `new lbug.Database(...)` time. Result: BM25 returns 0 on every `gitnexus query` invocation; only `cypher` / `context` / `impact` work because they run pure-read Cypher.

Reproduced on Linux (Devuan 6.1, Node 22.22.0, gitnexus 1.6.3 from npm) on two separate repos (~590 files and ~1450 files). Both produce the same FTS error chain on first `query` and never recover on subsequent calls.

## How to verify

```bash
# Before: query returns empty processes/definitions
gitnexus analyze --skip-git
gitnexus query "<some text>"   # → {processes: [], definitions: []}, FTS errors in stderr

# After: query returns real results
gitnexus query "<some text>"   # → real processes + definitions; first call ~1.5–2.5s
gitnexus query "<some text>"   # → ~300ms (FTS index now persisted)
```

`cypher` / `context` / `impact` are unaffected (they don't issue write Cypher).

## Risk and rollback

The existing lock-retry block (lines 307-327) covers contention with a concurrent `gitnexus analyze` writer, so the only behavioral change visible to users is that `gitnexus query` now succeeds instead of failing.

Rollback: revert this single line.

## Alternative (happy to switch if preferred)

A deeper fix would be to move FTS index creation into `gitnexus analyze` (eagerly, alongside the rest of the graph build) so the pool adapter can stay read-only. That preserves the original "MCP server never writes" invariant but is a larger refactor. Happy to do that instead if you'd rather keep the read-only contract — just say the word.