### PR TITLE
docs(readme): fix misleading Web UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,19 +324,21 @@ flowchart TD
 
 ## Web UI (browser-based)
 
-A fully client-side graph explorer and AI chat. No server, no install — your code never leaves the browser.
+A client-side graph explorer and AI chat — your code never leaves your machine.
 
-**Try it now:** [gitnexus.vercel.app](https://gitnexus.vercel.app) — drag & drop a ZIP and start exploring.
+**Try it now:** [gitnexus.vercel.app](https://gitnexus.vercel.app) — run `npx gitnexus@latest serve` locally and the page auto-connects to your local backend.
 
 <img width="2550" height="1343" alt="gitnexus_img" src="https://github.com/user-attachments/assets/cc5d637d-e0e5-48e6-93ff-5bcfdb929285" />
 
-Or run locally:
+Or run the frontend locally:
 
 ```bash
 git clone https://github.com/abhigyanpatwari/gitnexus.git
 cd gitnexus/gitnexus-shared && npm install && npm run build
 cd ../gitnexus-web && npm install
 npm run dev
+# Then in another terminal, start the backend the frontend connects to:
+npx gitnexus@latest serve
 ```
 
 ## Docker


### PR DESCRIPTION
## Summary

Fixes #1110. The "Web UI (browser-based)" section in `README.md` described an older client-side architecture and pointed users at a drag-and-drop flow that doesn't exist in the current code.

The Vercel deployment is a thin frontend that auto-connects to a locally-running `gitnexus serve` backend; there is no ZIP drop target in the UI (`gitnexus-web/src/components/DropZone.tsx` is a phase orchestrator, not a file dropzone — no `onDrop` / `FileReader` / `DataTransfer` anywhere in the web app).

This PR keeps the "your code never leaves your machine" framing (since `gitnexus serve` runs locally) and corrects three concrete inaccuracies:

- Drops the "No server, no install" claim — users do need to run `npx gitnexus@latest serve`.
- Replaces the "drag & drop a ZIP" tagline with what `gitnexus.vercel.app` actually shows: a copy-this-command card that auto-connects to the local backend.
- Adds the missing `gitnexus serve` step to the "Or run locally" block. Following those steps as written previously left users stuck on the "Listening for server…" screen.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Steps in the "Or run the frontend locally" block reproduce a working UI
- [ ] Vercel preview shows the same flow described in the new copy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits that clarify how the Web UI actually connects to a locally running `gitnexus serve` backend.
> 
> **Overview**
> Updates the `README.md` Web UI section to reflect the current architecture: the hosted UI auto-connects to a **locally running** `npx gitnexus@latest serve` backend, rather than a drag-and-drop ZIP flow.
> 
> Adjusts the local run instructions to explicitly separate frontend startup from the required backend `serve` command, reducing setup confusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff3e64f711f80eeaba3b37879761580f4dc322e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->