### PR TITLE
fix(typescript): capture missed CALLS edges from HOF callbacks and JSX

### DIFF
--- a/gitnexus-shared/src/scope-resolution/finalize-algorithm.ts
+++ b/gitnexus-shared/src/scope-resolution/finalize-algorithm.ts
@@ -740,18 +740,30 @@ function findExportByName(
   defs: readonly SymbolDefinition[],
   name: string,
 ): SymbolDefinition | undefined {
-  // Languages like TypeScript can emit MULTIPLE `SymbolDefinition`s with
-  // the same simple name from a single declaration: `const fn = () =>
-  // {}` produces both a `Function` def (from `@declaration.function` on
-  // the inner arrow) AND a `Variable` def (from the generic
-  // `@declaration.variable` pattern matching the wrapping
-  // `lexical_declaration`). Both end up in `localDefs`. The CALLER who
-  // writes `import { fn }` wants the callable, not the variable
-  // shadow — without a preference rule, capture order silently decides
-  // which def the import binds to, which broke cross-file CALLS edges
-  // for arrow-typed exports (see `typescript-hof-callbacks.test.ts`).
+  // GENERIC RULE (applies to every language using this finalize
+  // algorithm): when MULTIPLE `SymbolDefinition`s share the same simple
+  // name in `localDefs`, prefer callable / type-like defs over plain
+  // value defs (`Variable`, `Property`, …). The CALLER side of an
+  // import almost always wants the callable, not a value shadow that
+  // happens to share the name — and without a deterministic
+  // preference, capture order silently decides which def the import
+  // binds to.
   //
-  // Prefer callable / class-like defs; fall back to first-name-match.
+  // The single-def case is unchanged: when only one def has the name,
+  // it's returned regardless of its type (the `fallback` path below).
+  //
+  // TypeScript is the first known language where this matters in
+  // practice: `const fn = () => {}` emits BOTH a `Function` def (from
+  // `@declaration.function` on the inner arrow) AND a `Variable` def
+  // (from the generic `@declaration.variable` pattern matching the
+  // wrapping `lexical_declaration`), and consumers of `import { fn }`
+  // need to bind to the callable. Other migrated languages don't
+  // currently produce dual emits of this shape, so the rule is a no-op
+  // for them today; future languages get the same correctness
+  // guarantee for free if they ever do.
+  //
+  // See `gitnexus/test/integration/resolvers/typescript-hof-callbacks.test.ts`
+  // for the cross-file regression this rule prevents.
   let fallback: SymbolDefinition | undefined;
   for (const d of defs) {
     if (deriveSimpleName(d) !== name) continue;

--- a/gitnexus-shared/src/scope-resolution/finalize-algorithm.ts
+++ b/gitnexus-shared/src/scope-resolution/finalize-algorithm.ts
@@ -740,10 +740,46 @@ function findExportByName(
   defs: readonly SymbolDefinition[],
   name: string,
 ): SymbolDefinition | undefined {
+  // Languages like TypeScript can emit MULTIPLE `SymbolDefinition`s with
+  // the same simple name from a single declaration: `const fn = () =>
+  // {}` produces both a `Function` def (from `@declaration.function` on
+  // the inner arrow) AND a `Variable` def (from the generic
+  // `@declaration.variable` pattern matching the wrapping
+  // `lexical_declaration`). Both end up in `localDefs`. The CALLER who
+  // writes `import { fn }` wants the callable, not the variable
+  // shadow — without a preference rule, capture order silently decides
+  // which def the import binds to, which broke cross-file CALLS edges
+  // for arrow-typed exports (see `typescript-hof-callbacks.test.ts`).
+  //
+  // Prefer callable / class-like defs; fall back to first-name-match.
+  let fallback: SymbolDefinition | undefined;
   for (const d of defs) {
-    if (deriveSimpleName(d) === name) return d;
+    if (deriveSimpleName(d) !== name) continue;
+    if (isCallableOrTypeLike(d.type)) return d;
+    if (fallback === undefined) fallback = d;
   }
-  return undefined;
+  return fallback;
+}
+
+const CALLABLE_OR_TYPE_LIKE: ReadonlySet<string> = new Set([
+  'Function',
+  'Method',
+  'Constructor',
+  'Class',
+  'Interface',
+  'Enum',
+  'Struct',
+  'Record',
+  'Trait',
+  'Namespace',
+  'Module',
+  'TypeAlias',
+  'Type',
+  'Typedef',
+]);
+
+function isCallableOrTypeLike(type: string): boolean {
+  return CALLABLE_OR_TYPE_LIKE.has(type);
 }
 
 function countEdgesWithin(edgeIndex: Map<string, ImportEdgeDraft[]>, files: Set<string>): number {

--- a/gitnexus/src/core/ingestion/languages/typescript.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript.ts
@@ -57,8 +57,20 @@ import {
 } from './typescript/index.js';
 
 /**
- * TypeScript/JavaScript: arrow_function and function_expression get their name
- * from the parent variable_declarator (e.g. `const foo = () => {}`).
+ * TypeScript/JavaScript: arrow_function and function_expression are
+ * anonymous AST nodes — they take their name from the surrounding
+ * declarative context.
+ *
+ * Recognised contexts:
+ *   - `const foo = () => {}` (variable_declarator) → "foo"
+ *   - `{ addItem: (item) => ... }` (pair / property_assignment) → "addItem"
+ *     Covers Zustand stores, TanStack Query factories, React Context
+ *     providers, and most other HOF-heavy idioms (issue #1166).
+ *
+ * Returns `null` for funcName when the arrow lives in a context that has
+ * no static name — call arguments, computed keys, return-from-arrow
+ * positions. The parent walk in findEnclosingFunctionId then continues
+ * up to the next named ancestor (or to the file).
  */
 const tsExtractFunctionName = (
   node: SyntaxNode,
@@ -66,19 +78,45 @@ const tsExtractFunctionName = (
   if (node.type !== 'arrow_function' && node.type !== 'function_expression') return null;
 
   const parent = node.parent;
-  if (parent?.type !== 'variable_declarator') return null;
+  if (!parent) return null;
 
-  let nameNode = parent.childForFieldName?.('name');
-  if (!nameNode) {
-    for (let i = 0; i < parent.childCount; i++) {
-      const c = parent.child(i);
-      if (c?.type === 'identifier') {
-        nameNode = c;
-        break;
+  if (parent.type === 'variable_declarator') {
+    let nameNode = parent.childForFieldName?.('name');
+    if (!nameNode) {
+      for (let i = 0; i < parent.childCount; i++) {
+        const c = parent.child(i);
+        if (c?.type === 'identifier') {
+          nameNode = c;
+          break;
+        }
       }
     }
+    return { funcName: nameNode?.text ?? null, label: 'Function' };
   }
-  return { funcName: nameNode?.text ?? null, label: 'Function' };
+
+  // Object property pair: `{ addItem: (item) => ... }`.
+  // tree-sitter-typescript uses `pair`; tree-sitter-javascript also exposes
+  // `pair`. (Older grammars used `property_assignment`; we accept both.)
+  if (parent.type === 'pair' || parent.type === 'property_assignment') {
+    const keyNode = parent.childForFieldName?.('key');
+    if (!keyNode) return { funcName: null, label: 'Function' };
+    if (keyNode.type === 'property_identifier' || keyNode.type === 'identifier') {
+      return { funcName: keyNode.text, label: 'Function' };
+    }
+    if (keyNode.type === 'string') {
+      // `"add-item": () => ...` — the literal text inside the quotes.
+      const fragment = keyNode.children?.find(
+        (c: SyntaxNode) => c.type === 'string_fragment',
+      );
+      const text = fragment?.text ?? null;
+      return { funcName: text, label: 'Function' };
+    }
+    // computed_property_name (`[ACTION_KEY]`) and other dynamic keys have
+    // no static name — fall through anonymous.
+    return { funcName: null, label: 'Function' };
+  }
+
+  return { funcName: null, label: 'Function' };
 };
 
 export const BUILT_INS: ReadonlySet<string> = new Set([

--- a/gitnexus/src/core/ingestion/languages/typescript.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript.ts
@@ -105,9 +105,7 @@ const tsExtractFunctionName = (
     }
     if (keyNode.type === 'string') {
       // `"add-item": () => ...` — the literal text inside the quotes.
-      const fragment = keyNode.children?.find(
-        (c: SyntaxNode) => c.type === 'string_fragment',
-      );
+      const fragment = keyNode.children?.find((c: SyntaxNode) => c.type === 'string_fragment');
       const text = fragment?.text ?? null;
       return { funcName: text, label: 'Function' };
     }

--- a/gitnexus/src/core/ingestion/languages/typescript/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/captures.ts
@@ -240,6 +240,20 @@ export function emitTsScopeCaptures(
     // arity filter can narrow overloads. Count the `argument` named
     // children of the backing `arguments` node. TypeScript constructor
     // calls use `new_expression`; regular calls use `call_expression`.
+    //
+    // JSX call anchors (`jsx_self_closing_element` / `jsx_opening_element`
+    // captured by the TSX-only suffix in `query.ts`) intentionally do
+    // NOT carry arity metadata. The lookup below would resolve `callNode`
+    // to `null` for a JSX anchor (the anchor is neither a call_expression
+    // nor a new_expression), so the synthesis branch silently no-ops and
+    // the JSX call enters the registry with name-only resolution. This
+    // is acceptable for React: components are virtually never
+    // overloaded in the current GitNexus graph model, so name-only
+    // dispatch matches the single component definition. If a future
+    // codebase introduces overloaded React components AND needs JSX
+    // calls to disambiguate by props-arity, a JSX-aware arity
+    // synthesizer would need to count `jsx_attribute` children of the
+    // opening tag instead of `arguments`.
     const callAnchor = pickFirstDefined(grouped, CALL_TAGS);
     if (callAnchor !== undefined && grouped['@reference.arity'] === undefined) {
       const callNode =

--- a/gitnexus/src/core/ingestion/languages/typescript/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/captures.ts
@@ -84,6 +84,11 @@ function pickFirstDefined(grouped: CaptureMatch, tags: readonly string[]): Captu
  *      as `@reference.write.member`).
  *   4. The member_expression is the `function:` of an `await_expression`
  *      being called (handled by the member-call capture).
+ *   5. The member_expression is the `name:` of a `jsx_self_closing_element`
+ *      or `jsx_opening_element` (it's a JSX component invocation, already
+ *      captured as `@reference.call.member` by the TSX-only query suffix).
+ *      Without this filter, `<Foo.Bar />` would emit a phantom ACCESSES
+ *      edge to `Foo.Bar` IN ADDITION to the CALLS edge.
  *
  * Returns `true` when the capture should be kept as a read reference,
  * `false` when it should be dropped.
@@ -99,6 +104,9 @@ function shouldEmitReadMember(memberNode: SyntaxNode): boolean {
     case 'assignment_expression':
     case 'augmented_assignment_expression':
       return parent.childForFieldName('left')?.id !== memberNode.id;
+    case 'jsx_self_closing_element':
+    case 'jsx_opening_element':
+      return parent.childForFieldName('name')?.id !== memberNode.id;
     default:
       return true;
   }

--- a/gitnexus/src/core/ingestion/languages/typescript/query.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/query.ts
@@ -156,6 +156,27 @@ const TYPESCRIPT_SCOPE_QUERY = `
     name: (identifier) @declaration.name
     value: (function_expression))) @declaration.function
 
+;; Object-property arrows / function expressions named by their pair key:
+;; \`{ addItem: (item) => ... }\`. The legacy TYPESCRIPT_QUERIES emits the
+;; same shape; mirroring it here keeps scope-resolution declarations in
+;; sync (issue #1166). Computed keys (\`[K]: () => ...\`) intentionally
+;; fall through anonymous.
+(pair
+  key: (property_identifier) @declaration.name
+  value: (arrow_function)) @declaration.function
+
+(pair
+  key: (property_identifier) @declaration.name
+  value: (function_expression)) @declaration.function
+
+(pair
+  key: (string (string_fragment) @declaration.name)
+  value: (arrow_function)) @declaration.function
+
+(pair
+  key: (string (string_fragment) @declaration.name)
+  value: (function_expression)) @declaration.function
+
 ;; Method definitions — regular + private (#field) methods.
 (method_definition
   name: (property_identifier) @declaration.name) @declaration.method

--- a/gitnexus/src/core/ingestion/languages/typescript/query.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/query.ts
@@ -823,10 +823,7 @@ export function getTsParser(filePath?: string): Parser {
 export function getTsScopeQuery(filePath?: string): Parser.Query {
   if (filePath !== undefined && isTsxFile(filePath)) {
     if (_tsxQuery === null) {
-      _tsxQuery = new Parser.Query(
-        TSX_GRAMMAR,
-        TYPESCRIPT_SCOPE_QUERY + TSX_JSX_QUERY_SUFFIX,
-      );
+      _tsxQuery = new Parser.Query(TSX_GRAMMAR, TYPESCRIPT_SCOPE_QUERY + TSX_JSX_QUERY_SUFFIX);
     }
     return _tsxQuery;
   }

--- a/gitnexus/src/core/ingestion/languages/typescript/query.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/query.ts
@@ -169,25 +169,50 @@ const TYPESCRIPT_SCOPE_QUERY = `
     value: (function_expression) @declaration.function))
 
 ;; Object-property arrows / function expressions named by their pair key:
-;; \`{ addItem: (item) => ... }\`. The legacy TYPESCRIPT_QUERIES emits the
-;; same shape; mirroring it here keeps scope-resolution declarations in
-;; sync (issue #1166). Computed keys (\`[K]: () => ...\`) intentionally
-;; fall through anonymous.
+;; \`{ addItem: (item) => ..., removeItem: (item) => ... }\`. The legacy
+;; TYPESCRIPT_QUERIES emits the same shape; mirroring it here keeps
+;; scope-resolution declarations in sync (issue #1166). Computed keys
+;; (\`[K]: () => ...\`) intentionally fall through anonymous.
+;;
+;; Same anchor discipline as the \`lexical_declaration\` block above: the
+;; \`@declaration.function\` capture must sit on the INNER \`arrow_function\`
+;; / \`function_expression\` node — NOT the outer \`pair\`. The pair node
+;; starts at the property-key token, BEFORE the arrow's
+;; \`@scope.function\` range. \`pass2AttachDeclarations.atPosition(pair.startLine,
+;; pair.startCol)\` therefore resolves to the PARENT scope (the enclosing
+;; function-like, e.g. the \`(set) => ({...})\` callback in
+;; \`persist((set) => ({...}))\`), not the inner arrow's own scope.
+;;
+;; With the anchor on \`pair\`, ALL pair-function defs from the same object
+;; literal land in the same parent scope's \`ownedDefs\`. \`resolveCallerGraphId\`
+;; walking up from a call inside any of those arrows then matches the
+;; FIRST Function-like def via \`ownedDefs.find()\` — silently mis-attributing
+;; every call to the first sibling. Multi-action Zustand stores
+;; (\`{ addItem, removeItem, fetchData, … }\`) — the dominant 0%-capture
+;; pattern in the bug report — would land all calls on \`addItem\`.
+;;
+;; With the anchor on the inner \`arrow_function\` / \`function_expression\`,
+;; \`anchor.range\` matches the arrow's own \`@scope.function\` range; the
+;; def lands in the arrow scope's own \`ownedDefs\` and \`pass2AttachDeclarations\`'s
+;; auto-hoist (\`rangesEqual(anchor.range, innermost.range)\`) promotes
+;; the BINDING to the parent scope (so importers and lookups still find
+;; the name in the object's surrounding scope). Each pair-arrow becomes
+;; an independent caller anchor in the walk.
 (pair
   key: (property_identifier) @declaration.name
-  value: (arrow_function)) @declaration.function
+  value: (arrow_function) @declaration.function)
 
 (pair
   key: (property_identifier) @declaration.name
-  value: (function_expression)) @declaration.function
+  value: (function_expression) @declaration.function)
 
 (pair
   key: (string (string_fragment) @declaration.name)
-  value: (arrow_function)) @declaration.function
+  value: (arrow_function) @declaration.function)
 
 (pair
   key: (string (string_fragment) @declaration.name)
-  value: (function_expression)) @declaration.function
+  value: (function_expression) @declaration.function)
 
 ;; Method definitions — regular + private (#field) methods.
 (method_definition

--- a/gitnexus/src/core/ingestion/languages/typescript/query.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/query.ts
@@ -136,25 +136,37 @@ const TYPESCRIPT_SCOPE_QUERY = `
 ;; Arrow/function-expression assigned to a const/let/var — named by the
 ;; variable_declarator. Covers \`const fn = () => {}\` and its export
 ;; variant. Matches the legacy TYPESCRIPT_QUERIES pattern.
+;;
+;; The \`@declaration.function\` anchor sits on the INNER arrow_function /
+;; function_expression node (NOT the wrapping lexical_declaration), so
+;; \`anchor.range\` aligns with the corresponding \`@scope.function\` scope
+;; range. \`pass2AttachDeclarations\` then resolves \`innermost\` to the
+;; arrow's own scope (instead of the module scope) and the def is owned
+;; by the arrow itself. Without this alignment, calls inside the arrow
+;; body lose caller attribution: \`resolveCallerGraphId\` walks up past
+;; the empty arrow scope into the module scope and grabs whichever
+;; Function-like def appears first there — silently mis-attributing
+;; every nested call (Zustand stores, TanStack hooks, Promise-all/map,
+;; etc.). See \`typescript-hof-callbacks.test.ts\`.
 (lexical_declaration
   (variable_declarator
     name: (identifier) @declaration.name
-    value: (arrow_function))) @declaration.function
+    value: (arrow_function) @declaration.function))
 
 (lexical_declaration
   (variable_declarator
     name: (identifier) @declaration.name
-    value: (function_expression))) @declaration.function
+    value: (function_expression) @declaration.function))
 
 (variable_declaration
   (variable_declarator
     name: (identifier) @declaration.name
-    value: (arrow_function))) @declaration.function
+    value: (arrow_function) @declaration.function))
 
 (variable_declaration
   (variable_declarator
     name: (identifier) @declaration.name
-    value: (function_expression))) @declaration.function
+    value: (function_expression) @declaration.function))
 
 ;; Method definitions — regular + private (#field) methods.
 (method_definition
@@ -723,6 +735,53 @@ const TYPESCRIPT_SCOPE_QUERY = `
   property: (property_identifier) @reference.name) @reference.read.member
 `;
 
+/**
+ * JSX-only query suffix. Appended to the base query when compiling
+ * against the TSX grammar; NOT compiled against the plain TS grammar
+ * (which has no \`jsx_*\` node types and would reject these patterns).
+ *
+ * Why JSX as a CALLS edge: \`<Foo />\` is syntactic sugar for \`Foo(props)\`
+ * and the React component is invoked by the renderer, so for blast-radius
+ * (\`gitnexus_impact("Badge", direction: "upstream")\`) and call-graph
+ * (\`gitnexus_context("Foo")\`) purposes JSX usage IS a call. Routing
+ * through \`@reference.call.free\` / \`@reference.call.member\` makes the
+ * downstream caller-walk + edge-emission paths handle JSX uniformly with
+ * ordinary call expressions — no new edge type, no schema changes.
+ *
+ * Identifier-only JSX is filtered to PascalCase via \`(#match? ... "^[A-Z]")\`
+ * so \`<div>\`, \`<span>\`, \`<button>\` and other native HTML elements (which
+ * by JSX convention start lowercase) don't emit edges to nonexistent
+ * "div" / "span" symbols. Member-form JSX (\`<Foo.Bar />\`) is always a
+ * component (HTML element names can't contain dots), so no predicate
+ * filter is applied there.
+ *
+ * Both \`jsx_self_closing_element\` (\`<Foo />\`) and \`jsx_opening_element\`
+ * (\`<Foo>...</Foo>\`) emit; the closing tag is intentionally NOT captured —
+ * each JSX element should emit exactly one CALLS edge per use site.
+ */
+const TSX_JSX_QUERY_SUFFIX = `
+;; <Foo />
+((jsx_self_closing_element
+  name: (identifier) @reference.name) @reference.call.free
+  (#match? @reference.name "^[A-Z]"))
+
+;; <Foo> ... </Foo>  (paired form — match the opening tag only)
+((jsx_opening_element
+  name: (identifier) @reference.name) @reference.call.free
+  (#match? @reference.name "^[A-Z]"))
+
+;; <Foo.Bar />  /  <Container.Section.Title />  — namespaced JSX
+(jsx_self_closing_element
+  name: (member_expression
+    object: (_) @reference.receiver
+    property: (property_identifier) @reference.name)) @reference.call.member
+
+(jsx_opening_element
+  name: (member_expression
+    object: (_) @reference.receiver
+    property: (property_identifier) @reference.name)) @reference.call.member
+`;
+
 let _tsParser: Parser | null = null;
 let _tsxParser: Parser | null = null;
 let _tsQuery: Parser.Query | null = null;
@@ -753,11 +812,21 @@ export function getTsParser(filePath?: string): Parser {
  * executed against a Tree produced by the `tsx` grammar — tree-sitter
  * matches by node-type id, and the two grammars have separate id
  * spaces.
+ *
+ * The TSX query is compiled with the JSX-as-call patterns appended.
+ * Those patterns reference `jsx_self_closing_element` /
+ * `jsx_opening_element` which exist only in the TSX grammar — embedding
+ * them in the plain TS query would throw `Query.InvalidNodeType` at
+ * compile time (and even if it didn't, the patterns would never fire on
+ * `.ts` source).
  */
 export function getTsScopeQuery(filePath?: string): Parser.Query {
   if (filePath !== undefined && isTsxFile(filePath)) {
     if (_tsxQuery === null) {
-      _tsxQuery = new Parser.Query(TSX_GRAMMAR, TYPESCRIPT_SCOPE_QUERY);
+      _tsxQuery = new Parser.Query(
+        TSX_GRAMMAR,
+        TYPESCRIPT_SCOPE_QUERY + TSX_JSX_QUERY_SUFFIX,
+      );
     }
     return _tsxQuery;
   }

--- a/gitnexus/src/core/ingestion/scope-resolution/graph-bridge/ids.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/graph-bridge/ids.ts
@@ -20,12 +20,38 @@
 import type { NodeLabel, ScopeId, SymbolDefinition } from 'gitnexus-shared';
 import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
 import { generateId } from '../../../../lib/utils.js';
-import {
-  isLinkableLabel,
-  qualifiedKey,
-  simpleKey,
-  type GraphNodeLookup,
-} from '../graph-bridge/node-lookup.js';
+import { qualifiedKey, simpleKey, type GraphNodeLookup } from '../graph-bridge/node-lookup.js';
+
+/**
+ * Labels that may legitimately ANCHOR a CALLS/ACCESSES edge as the
+ * source ("caller"). A Variable / Property can be the TARGET of an
+ * edge (e.g., a write-access to `user.name`), but it cannot be a
+ * caller — variables don't execute code, so attributing a call to a
+ * sibling Variable in the same scope produces nonsense edges like
+ * `Variable:create → Function:create` (which the simpleKey fallback
+ * in `resolveDefGraphId` then silently rewrites to
+ * `Function:create → Function:create`, a self-loop that doesn't exist
+ * in the source).
+ *
+ * Module-level call expressions inside a `const X = expr(args)`
+ * declaration are the canonical case where this used to fail: the
+ * walk-up over module scope's ownedDefs (only Variables) would land
+ * on the FIRST Variable, get name-aliased to its sibling Function
+ * with the same simple name, and emit a self-CALLS. With this label
+ * restricted to function/class-likes, those calls correctly fall
+ * through to the File-node fallback at the bottom of the walk.
+ */
+function isCallerAnchorLabel(label: NodeLabel): boolean {
+  return (
+    label === 'Function' ||
+    label === 'Method' ||
+    label === 'Constructor' ||
+    label === 'Class' ||
+    label === 'Interface' ||
+    label === 'Struct' ||
+    label === 'Enum'
+  );
+}
 
 /**
  * Look up a `SymbolDefinition` in the graph node lookup.
@@ -105,7 +131,9 @@ export function resolveCallerGraphId(
     if (scope === undefined) break;
     lastFilePath = scope.filePath;
 
-    // Prefer Function/Method anchors; fall back to Class.
+    // Prefer Function/Method/Constructor anchors; fall back to
+    // Class/Interface/Struct/Enum. Variable/Property are NOT valid
+    // caller anchors — see `isCallerAnchorLabel` for why.
     const fnDef = scope.ownedDefs.find(
       (d) => d.type === 'Function' || d.type === 'Method' || d.type === 'Constructor',
     );
@@ -113,7 +141,7 @@ export function resolveCallerGraphId(
       const id = resolveDefGraphId(scope.filePath, fnDef, nodeLookup);
       if (id !== undefined) return id;
     }
-    const classDef = scope.ownedDefs.find((d) => isLinkableLabel(d.type));
+    const classDef = scope.ownedDefs.find((d) => isCallerAnchorLabel(d.type));
     if (classDef !== undefined) {
       const id = resolveDefGraphId(scope.filePath, classDef, nodeLookup);
       if (id !== undefined) return id;

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -61,6 +61,29 @@ export const TYPESCRIPT_QUERIES = `
       name: (identifier) @name
       value: (function_expression)))) @definition.function
 
+; Object-property arrows / function expressions: \`{ addItem: () => ... }\`.
+; The pair's key field carries the meaningful name. Without these patterns,
+; calls inside the arrow are attributed to the file (issue #1166), and the
+; arrow itself is invisible to context() / impact() despite carrying real
+; behaviour (Zustand actions, TanStack queryFn, React Context providers).
+; String-key variant covers \`"add-item": () => ...\`; computed keys
+; (\`[K]: () => ...\`) intentionally fall through anonymous.
+(pair
+  key: (property_identifier) @name
+  value: (arrow_function)) @definition.function
+
+(pair
+  key: (property_identifier) @name
+  value: (function_expression)) @definition.function
+
+(pair
+  key: (string (string_fragment) @name)
+  value: (arrow_function)) @definition.function
+
+(pair
+  key: (string (string_fragment) @name)
+  value: (function_expression)) @definition.function
+
 ; Variable/constant declarations (non-function values).
 ; Overlap with @definition.function patterns is handled by parse-worker dedup.
 (lexical_declaration
@@ -218,6 +241,24 @@ export const JAVASCRIPT_QUERIES = `
     (variable_declarator
       name: (identifier) @name
       value: (function_expression)))) @definition.function
+
+; Object-property arrows / function expressions: \`{ addItem: () => ... }\`.
+; See TYPESCRIPT_QUERIES for rationale (issue #1166).
+(pair
+  key: (property_identifier) @name
+  value: (arrow_function)) @definition.function
+
+(pair
+  key: (property_identifier) @name
+  value: (function_expression)) @definition.function
+
+(pair
+  key: (string (string_fragment) @name)
+  value: (arrow_function)) @definition.function
+
+(pair
+  key: (string (string_fragment) @name)
+  value: (function_expression)) @definition.function
 
 ; Variable/constant declarations (non-function values).
 ; Overlap with @definition.function patterns is handled by parse-worker dedup.

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -429,10 +429,24 @@ export const findSiblingChild = (
 
 /** Generic name extraction from a function-like AST node.
  *  Tries `node.childForFieldName('name')?.text`, then scans children for
- *  `identifier` / `property_identifier` / `simple_identifier`. */
+ *  `identifier` / `property_identifier` / `simple_identifier`.
+ *
+ *  `arrow_function` and `function_expression` (TS/JS) are inherently
+ *  anonymous — they have no `name` field, and their first identifier
+ *  child is a *parameter*, not a function name. Returning a parameter
+ *  identifier here would synthesize phantom Function IDs (e.g. callers
+ *  walking up from a call inside `arr.map(x => fn(x))` would get
+ *  attributed to a non-existent "Function x"). The language's
+ *  `methodExtractor.extractFunctionName` hook is responsible for naming
+ *  these via parent context (variable_declarator, pair, etc.); when it
+ *  declines, the parent walk should continue rather than fall through
+ *  here. See issue #1166. */
 export const genericFuncName = (node: SyntaxNode): string | null => {
   const nameField = node.childForFieldName?.('name');
   if (nameField) return nameField.text;
+  if (node.type === 'arrow_function' || node.type === 'function_expression') {
+    return null;
+  }
   for (let i = 0; i < node.childCount; i++) {
     const c = node.child(i);
     if (

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/control.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/control.ts
@@ -1,0 +1,6 @@
+import { transform } from './helpers';
+
+// Control: a "plain helper" pattern that the bug report says hits ~100%
+// capture. If THIS edge is missing, the bug is more fundamental than
+// HOF-callback attribution.
+export const direct = (x: string): string => transform(x);

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/helpers.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/helpers.ts
@@ -1,0 +1,6 @@
+// Plain helpers — the targets of HOF-callback calls.
+// `transform` is intentionally not a Node.js / browser global so naming
+// collisions with built-ins don't pollute the resolution test.
+export const fetchData = (): string => 'data';
+
+export const transform = (x: string): string => x.toUpperCase();

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/multi-action-store.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/multi-action-store.ts
@@ -1,0 +1,53 @@
+// Multi-action Zustand-shape store: the regression case the single-pair
+// `bump` fixture in `store.ts` masked.
+//
+// Mirrors the dominant Zustand idiom from the bug report:
+//
+//   create<State>()(persist((set) => ({
+//     addItem: (item) => doA(item),
+//     removeItem: (item) => doB(item),
+//     fetchData: async () => doC(),
+//   })))
+//
+// With the pre-fix `pair`-with-arrow query patterns, all three
+// pair-function defs landed in the same `(set) => ({...})` callback's
+// `ownedDefs`. `resolveCallerGraphId.ownedDefs.find(d => d.type === 'Function')`
+// then returned `addItem` for every walk-up — every call inside
+// `removeItem` and `fetchData` mis-attributed to `addItem`. `gitnexus_context("removeItem")`
+// returned zero outgoing edges; `gitnexus_impact("doB", direction:"upstream")`
+// missed `removeItem` entirely.
+//
+// After moving `@declaration.function` to the inner `arrow_function`,
+// each pair-arrow gets its own scope's `ownedDefs` populated with its own
+// def. Calls inside `removeItem` now stop at `removeItem`'s arrow scope,
+// resolve to `removeItem`, and the per-action attribution is correct.
+
+import { create, persist } from './store';
+
+interface MultiAction {
+  readonly count: number;
+  readonly addItem: (item: number) => void;
+  readonly removeItem: (item: number) => void;
+  readonly fetchData: () => void;
+}
+
+export const doA = (_item: number): void => {};
+export const doB = (_item: number): void => {};
+export const doC = (): void => {};
+
+export const useMultiActionStore = create<MultiAction>()(
+  persist((set) => ({
+    count: 0,
+    addItem: (item) => {
+      doA(item);
+      set({ count: 1 });
+    },
+    removeItem: (item) => {
+      doB(item);
+      set({ count: 0 });
+    },
+    fetchData: () => {
+      doC();
+    },
+  })),
+);

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/promise-ctor.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/promise-ctor.ts
@@ -1,0 +1,11 @@
+import { transform } from './helpers';
+
+// Pattern: call inside `new Promise((resolve, reject) => ...)` callback.
+// Mirrors `fileToDataUrl` from the bug report. The synchronous body of
+// the executor invokes `transform` directly — the edge `wrap → transform`
+// should exist regardless of the surrounding HOF.
+export const wrap = (x: string): Promise<string> =>
+  new Promise<string>((resolve) => {
+    const v = transform(x);
+    resolve(v);
+  });

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/promise-map.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/promise-map.ts
@@ -1,0 +1,9 @@
+import { transform } from './helpers';
+
+// Pattern: call inside `.map` callback inside `Promise.all(...)`.
+// Mirrors `clients/web/src/utils/file-upload.ts` `processSelectedFiles`
+// from the bug report — `transform` should be reachable as
+// `fanOut → transform`.
+export const fanOut = async (xs: string[]): Promise<string[]> => {
+  return Promise.all(xs.map((x) => transform(x)));
+};

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/query-hook.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/query-hook.ts
@@ -1,0 +1,18 @@
+import { fetchData } from './helpers';
+
+// Stand-in for TanStack Query's `useQuery` — accepts a config object.
+// Defined in-fixture (rather than imported from an external lib) so the
+// `useQuery` reference resolves to a real graph node and we can also
+// assert the `useFeature → useQuery` edge.
+export const useQuery = <T>(opts: { queryFn: () => T; queryKey: readonly string[] }): T => {
+  return opts.queryFn();
+};
+
+// Pattern: call inside `queryFn` callback passed to a HOF.
+// Mirrors `clients/*/src/hooks/use-gateway-queries.ts` from the bug
+// report (4% capture rate). `useFeature → fetchData` should be reachable.
+export const useFeature = (): string =>
+  useQuery({
+    queryFn: () => fetchData(),
+    queryKey: ['feature'],
+  });

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/store.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/src/store.ts
@@ -1,0 +1,46 @@
+// Stand-ins for Zustand's `create / persist / devtools`. Defined locally
+// so the references resolve to real graph nodes and the test doesn't
+// depend on an external library.
+//
+// The shape mirrors the actual Zustand API closely enough that the
+// nested-arrow-in-arguments pattern (which was the worst-case repro in
+// the bug report — Zustand store files hit 0% CALLS-edge capture) is
+// faithfully reproduced.
+
+type StateCreator<T> = (set: (next: Partial<T>) => void) => T;
+
+export const create = <T>() => {
+  return (initializer: (...wrappers: never[]) => StateCreator<T>): T => {
+    return initializer()(() => {
+      /* runtime no-op for this fixture */
+    });
+  };
+};
+
+export const persist = <T>(creator: StateCreator<T>): StateCreator<T> => creator;
+
+export const devtools = <T>(creator: StateCreator<T>): StateCreator<T> => creator;
+
+interface Counter {
+  readonly count: number;
+  readonly bump: () => void;
+}
+
+// The classic Zustand shape:
+//
+//   const useStore = create<State>()(devtools(persist((set) => ({ ... }))))
+//
+// Pre-fix: `useStore` lived as a Variable on the module scope; the
+// nested arrow callbacks had empty `ownedDefs`; calls inside them
+// walked up to the module's first Function-like def and silently
+// mis-attributed (or dropped). After the fix, each named arrow gets
+// its def attached to its own scope and HOF-wrapped declarations
+// participate in the call graph normally.
+export const useStore = create<Counter>()(
+  devtools(
+    persist((set) => ({
+      count: 0,
+      bump: () => set({ count: 1 }),
+    })),
+  ),
+);

--- a/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/components.tsx
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/components.tsx
@@ -1,0 +1,12 @@
+// Component targets used by the JSX-as-call tests. The bodies are
+// trivial — what matters is that they're declared as named arrow
+// functions returning JSX (the canonical React component shape) so the
+// scope-resolution pipeline emits Function defs for them.
+
+export const Foo = (): string => 'foo';
+
+export const Bar = (): string => 'bar';
+
+export const Inner = (): string => 'inner';
+
+export const Outer = (): string => 'outer';

--- a/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/hof-jsx.tsx
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/hof-jsx.tsx
@@ -1,0 +1,9 @@
+import { Foo } from './components';
+
+// Combined fix verification: an arrow-typed component (the HOF-callback
+// fix's central case — `const fn = () => ...`) whose body returns JSX
+// (the JSX-as-call fix). The HOF fix anchors the Function def on the
+// inner arrow so caller-attribution lands on `Wrapped`; the JSX fix
+// emits the `<Foo />` reference site as `@reference.call.free`. The
+// combined effect: `Wrapped → Foo` is captured.
+export const Wrapped = () => <Foo />;

--- a/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/html-only.tsx
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/html-only.tsx
@@ -1,0 +1,11 @@
+// Pure-HTML JSX — `<div>`, `<span>`, `<button>`. By JSX convention,
+// lowercase-first-character identifiers are native DOM elements (NOT
+// React components). The query's `(#match? @reference.name "^[A-Z]")`
+// predicate filters these out, so this caller must NOT emit any CALLS
+// edges to identifiers `div` / `span` / `button`.
+export const useHtml = () => (
+  <div>
+    <span>text</span>
+    <button>click</button>
+  </div>
+);

--- a/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/member-usage.tsx
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/member-usage.tsx
@@ -1,0 +1,12 @@
+import { Container } from './namespaced';
+
+// Namespaced JSX — `<Container.Title />`. The query's
+// `@reference.call.member` capture splits this into:
+//
+//   receiver: `Container`  (an identifier)
+//   property: `Title`      (the leaf identifier)
+//
+// Note: Member-form JSX is NOT filtered by the PascalCase predicate —
+// HTML element names can't contain dots, so any `.`-form is unambiguously
+// a component reference.
+export const useNamespaced = () => <Container.Title />;

--- a/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/namespaced.tsx
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/namespaced.tsx
@@ -1,0 +1,14 @@
+// Namespaced component — the canonical `<Container.Title />` idiom
+// (used by libraries like Radix UI, shadcn/ui, Headless UI). Exposes a
+// `Container` object whose members are themselves React components, so
+// JSX consumers write `<Container.Title>` instead of importing each
+// piece individually.
+//
+// The TSX grammar represents `<Foo.Bar />` as `jsx_self_closing_element
+// name: (member_expression ...)`. Our query's `@reference.call.member`
+// capture decomposes the member chain so the downstream member-call
+// resolver can route the edge to the right `Title` definition.
+
+const Title = () => 'title';
+
+export const Container = { Title };

--- a/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/nested-usage.tsx
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/nested-usage.tsx
@@ -1,0 +1,13 @@
+import { Inner, Outer } from './components';
+
+// Nested JSX — `<Outer><Inner /></Outer>`. Both `<Outer>` (paired) and
+// `<Inner />` (self-closing) are reference sites for the same enclosing
+// caller (`useNested`). Should emit TWO CALLS edges from `useNested`:
+//
+//   useNested → Outer
+//   useNested → Inner
+export const useNested = () => (
+  <Outer>
+    <Inner />
+  </Outer>
+);

--- a/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/paired-usage.tsx
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/paired-usage.tsx
@@ -1,0 +1,6 @@
+import { Bar } from './components';
+
+// Paired JSX element (`<Bar>...</Bar>`). The query captures
+// `jsx_opening_element` (NOT `jsx_closing_element`) so each JSX use
+// emits exactly one CALLS edge — the closing tag would double-count.
+export const useBar = () => <Bar>child text</Bar>;

--- a/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/simple-usage.tsx
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/src/simple-usage.tsx
@@ -1,0 +1,5 @@
+import { Foo } from './components';
+
+// Self-closing JSX element — the most common React-component invocation
+// shape. Should emit `useFoo → Foo` as a CALLS edge.
+export const useFoo = () => <Foo />;

--- a/gitnexus/test/integration/resolvers/typescript-hof-callbacks.test.ts
+++ b/gitnexus/test/integration/resolvers/typescript-hof-callbacks.test.ts
@@ -48,10 +48,7 @@ describe('TypeScript HOF-callback CALLS edges', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
-    result = await runPipelineFromRepo(
-      path.join(FIXTURES, 'typescript-hof-callbacks'),
-      () => {},
-    );
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'typescript-hof-callbacks'), () => {});
   }, 60000);
 
   it('control: direct (x) => transform(x) emits direct → transform', () => {
@@ -108,21 +105,30 @@ describe('TypeScript HOF-callback CALLS edges', () => {
     expect(fromCreate, 'create() must not be a phantom caller').toEqual([]);
   });
 
-  it('Zustand call expressions are attributable (to File or absent — never to a wrong sibling)', () => {
-    // The complement check: if any CALLS edge is emitted for the
-    // module-scope calls in store.ts, its source must be either
-    // `store.ts` (the File fallback) or undefined. We accept zero
-    // edges here as a valid outcome; the strict assertion is the
-    // anti-self-loop one above.
+  it('Zustand module-level calls source from the File node (not a sibling Function)', () => {
+    // The positive complement to the anti-self-loop assertion above:
+    // module-level calls in `store.ts` (`create()`, `devtools(...)`,
+    // `persist(...)`) MUST attribute to the `File` node — that's the
+    // entire point of `isCallerAnchorLabel` excluding `Variable` from
+    // the caller-walk fallback. If the fix regresses (Variable defs
+    // re-enter the fallback, or the walk-up grabs a sibling Function),
+    // the source would change away from `File:store.ts`.
+    //
+    // Earlier formulation iterated `for (c of calls)` and asserted each
+    // edge sourced from File. That passed VACUOUSLY when `calls` was
+    // empty — any change that silenced ALL CALLS edges from `store.ts`
+    // would have slipped through. The structural assertion below is
+    // explicit: at least one File-rooted edge must exist (proving the
+    // fallback fired), and no edge may source from anything else
+    // (proving the fallback fired EXCLUSIVELY, not as one option
+    // alongside a buggy sibling-Function attribution).
     const calls = getRelationships(result, 'CALLS').filter(
       (c) => c.sourceFilePath === 'src/store.ts',
     );
-    for (const c of calls) {
-      // Source must NOT be a sibling local Function. The only
-      // acceptable source for module-level calls in store.ts is the
-      // File node itself (label 'File', name 'store.ts').
-      expect([c.sourceLabel, c.source]).toEqual(['File', 'store.ts']);
-    }
+    const fromFile = calls.filter((c) => c.sourceLabel === 'File' && c.source === 'store.ts');
+    const fromOther = calls.filter((c) => !(c.sourceLabel === 'File' && c.source === 'store.ts'));
+    expect(fromOther, 'no module-level call may attribute to a non-File source').toEqual([]);
+    expect(fromFile.length, 'at least one File-rooted call edge must exist').toBeGreaterThan(0);
   });
 
   it('transform is reachable from at least 3 of {direct, fanOut, wrap}', () => {

--- a/gitnexus/test/integration/resolvers/typescript-hof-callbacks.test.ts
+++ b/gitnexus/test/integration/resolvers/typescript-hof-callbacks.test.ts
@@ -1,0 +1,141 @@
+/**
+ * TypeScript: CALLS edges from inside higher-order-function callbacks.
+ *
+ * Repro for the bug filed in `gitnexus-bug-report.md`: in a real
+ * TS+React monorepo, ~75% of `Function` nodes had no outgoing CALLS
+ * edges. The dominant pattern was call expressions nested inside
+ * callbacks passed as arguments to other functions:
+ *
+ *   - `Promise.all(items.map(item => transform(item)))`
+ *   - `useQuery({ queryFn: () => fetchData() })`
+ *   - `new Promise((resolve) => { reader.readAsDataURL(file); ... })`
+ *   - `create<State>()(devtools(persist((set) => ({ ... }))))` (Zustand)
+ *
+ * Two underlying issues fixed by this PR (see `query.ts` and
+ * `finalize-algorithm.ts`):
+ *
+ *   1. **Caller attribution.** `pass2AttachDeclarations` placed the
+ *      `Function` def for arrow-typed declarations on the wrapping
+ *      module scope (the `@declaration.function` anchor was the outer
+ *      `lexical_declaration`, whose start lies before the inner
+ *      arrow's scope). `resolveCallerGraphId` walked up past the empty
+ *      arrow scope into the module and grabbed the first Function-like
+ *      def in `ownedDefs` — frequently the wrong function entirely.
+ *
+ *   2. **Cross-file callee discovery.** TypeScript emits BOTH
+ *      `@declaration.function` (Function def) AND `@declaration.variable`
+ *      (Variable def) for `const fn = () => {}`. With (1) fixed, the
+ *      Function-def's anchor moved to the inner arrow, so the Variable
+ *      capture began appearing FIRST in `localDefs` (its match starts
+ *      earlier in the source). `findExportByName` returned the
+ *      Variable, the consumer's import bound to a non-callable, and
+ *      `findCallableBindingInScope` rejected it.
+ *
+ * Each test fixture below isolates one HOF-callback shape from the bug
+ * report with both caller and callee defined in-fixture.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'path';
+import {
+  FIXTURES,
+  getRelationships,
+  edgeSet,
+  runPipelineFromRepo,
+  type PipelineResult,
+} from './helpers.js';
+
+describe('TypeScript HOF-callback CALLS edges', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'typescript-hof-callbacks'),
+      () => {},
+    );
+  }, 60000);
+
+  it('control: direct (x) => transform(x) emits direct → transform', () => {
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.target === 'transform');
+    expect(edgeSet(calls)).toContain('direct → transform');
+  });
+
+  it('Promise.all(map(...)) emits fanOut → transform (call inside .map callback)', () => {
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.target === 'transform');
+    // `fanOut` is the named arrow declaration; the call to `transform`
+    // is syntactically nested inside `.map(...)` inside `Promise.all(...)`.
+    expect(edgeSet(calls)).toContain('fanOut → transform');
+  });
+
+  it('new Promise((resolve) => { ... }) emits wrap → transform (call inside executor)', () => {
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.target === 'transform');
+    expect(edgeSet(calls)).toContain('wrap → transform');
+  });
+
+  it('useQuery({ queryFn: () => fetchData() }) emits useFeature → fetchData (call inside queryFn callback)', () => {
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.target === 'fetchData');
+    expect(edgeSet(calls)).toContain('useFeature → fetchData');
+  });
+
+  it('useQuery({ queryFn: () => fetchData() }) emits useFeature → useQuery (direct call in body)', () => {
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.target === 'useQuery');
+    expect(edgeSet(calls)).toContain('useFeature → useQuery');
+  });
+
+  it('Zustand create()(devtools(persist((set) => ({ ... })))) does NOT emit phantom self-loops', () => {
+    // The Zustand idiom `export const useStore = create()(devtools(persist((set) => ({ ... }))))`
+    // has its module-level call expressions (`create()`, `devtools(...)`,
+    // `persist(...)`) in `useStore`'s declaration RHS, syntactically
+    // outside any function body. The bug-report case
+    // (`grouped-file-uploads-store.tsx`, "0% capture") was driven by
+    // these calls being mis-attributed to a sibling Function (the
+    // first declared callable in the module's `ownedDefs`), producing
+    // bogus self-loops like `Function:create → Function:create`. The
+    // fix in `resolveCallerGraphId` excludes Variable defs from the
+    // walk-up's class-fallback branch — module-level calls now fall
+    // through to the File node like any other module-level reference.
+    //
+    // What this test asserts: NO phantom self-loops, and NO phantom
+    // edges where one local function "calls" a sibling local
+    // function via misattribution.
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) => c.sourceFilePath === 'src/store.ts' && c.targetFilePath === 'src/store.ts',
+    );
+    const phantomSelfLoops = calls.filter((c) => c.source === c.target);
+    expect(phantomSelfLoops, 'phantom self-loop CALLS edges').toEqual([]);
+
+    // Specifically the regression: `create → create / devtools / persist`.
+    const fromCreate = calls.filter((c) => c.source === 'create');
+    expect(fromCreate, 'create() must not be a phantom caller').toEqual([]);
+  });
+
+  it('Zustand call expressions are attributable (to File or absent — never to a wrong sibling)', () => {
+    // The complement check: if any CALLS edge is emitted for the
+    // module-scope calls in store.ts, its source must be either
+    // `store.ts` (the File fallback) or undefined. We accept zero
+    // edges here as a valid outcome; the strict assertion is the
+    // anti-self-loop one above.
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) => c.sourceFilePath === 'src/store.ts',
+    );
+    for (const c of calls) {
+      // Source must NOT be a sibling local Function. The only
+      // acceptable source for module-level calls in store.ts is the
+      // File node itself (label 'File', name 'store.ts').
+      expect([c.sourceLabel, c.source]).toEqual(['File', 'store.ts']);
+    }
+  });
+
+  it('transform is reachable from at least 3 of {direct, fanOut, wrap}', () => {
+    // Catch-all: pre-fix, only `direct → transform` was captured (or
+    // even THAT was missing depending on file order). After fix, all
+    // three callers attribute their `transform` call correctly.
+    const callers = new Set(
+      getRelationships(result, 'CALLS')
+        .filter((c) => c.target === 'transform')
+        .map((c) => c.source),
+    );
+    expect(callers).toContain('direct');
+    expect(callers).toContain('fanOut');
+    expect(callers).toContain('wrap');
+  });
+});

--- a/gitnexus/test/integration/resolvers/typescript-hof-callbacks.test.ts
+++ b/gitnexus/test/integration/resolvers/typescript-hof-callbacks.test.ts
@@ -68,9 +68,24 @@ describe('TypeScript HOF-callback CALLS edges', () => {
     expect(edgeSet(calls)).toContain('wrap → transform');
   });
 
-  it('useQuery({ queryFn: () => fetchData() }) emits useFeature → fetchData (call inside queryFn callback)', () => {
+  it('useQuery({ queryFn: () => fetchData() }) emits queryFn → fetchData (call inside named pair-arrow)', () => {
+    // The structurally correct attribution: `fetchData()` is called
+    // from inside the named pair-arrow `queryFn: () => fetchData()`.
+    // After moving `@declaration.function` to the inner arrow (mirroring
+    // the `lexical_declaration` fix), the pair-arrow becomes its own
+    // caller anchor — `resolveCallerGraphId`'s walk-up stops at
+    // `queryFn`'s scope rather than continuing into `useFeature`'s.
+    //
+    // Pre-fix this test asserted `useFeature → fetchData` because the
+    // pair pattern's `@declaration.function` anchor was on the outer
+    // `pair`, sending `queryFn`'s def into `useFeature`'s `ownedDefs`
+    // and bypassing `queryFn` as a caller anchor. That attribution
+    // was wrong twice over: it crossed a syntactic function boundary
+    // (the arrow body), and it depended on the pair-pattern bug to
+    // reroute the walk. Edges that capture intent should follow the
+    // syntax tree.
     const calls = getRelationships(result, 'CALLS').filter((c) => c.target === 'fetchData');
-    expect(edgeSet(calls)).toContain('useFeature → fetchData');
+    expect(edgeSet(calls)).toContain('queryFn → fetchData');
   });
 
   it('useQuery({ queryFn: () => fetchData() }) emits useFeature → useQuery (direct call in body)', () => {
@@ -143,5 +158,88 @@ describe('TypeScript HOF-callback CALLS edges', () => {
     expect(callers).toContain('direct');
     expect(callers).toContain('fanOut');
     expect(callers).toContain('wrap');
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Multi-pair object literal — regression case the single-pair `bump`
+  // fixture in `store.ts` masked. See `multi-action-store.ts` and the
+  // anchor-discipline comment in `query.ts` above the four pair-with-
+  // arrow patterns. PR #1175 review (medium finding) flagged this.
+  // ─────────────────────────────────────────────────────────────────
+
+  it('multi-action store: addItem → doA (calls inside addItem attribute to addItem, not first sibling)', () => {
+    // The diagnostic test for the pair-anchor fix. With the broken
+    // anchor (on outer `pair`), all three pair-function defs (addItem,
+    // removeItem, fetchData) landed in the same `(set) => ({...})`
+    // callback's `ownedDefs`, and `resolveCallerGraphId.ownedDefs.find()`
+    // returned the FIRST one — `addItem` — for every walk-up. So
+    // calls inside `removeItem` and `fetchData` got mis-attributed.
+    //
+    // After the fix, each pair-arrow gets its def in its OWN arrow
+    // scope's `ownedDefs`; the walk-up stops one level earlier and
+    // resolves to the correct sibling.
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) => c.sourceFilePath === 'src/multi-action-store.ts',
+    );
+    const fromAddItem = calls.filter((c) => c.source === 'addItem' && c.target === 'doA');
+    expect(fromAddItem.length, 'addItem must call doA').toBeGreaterThan(0);
+  });
+
+  it('multi-action store: removeItem → doB (NOT addItem → doB)', () => {
+    // The exact regression fingerprint. Pre-fix, `removeItem`'s body
+    // would attribute its `doB(item)` call to `addItem` (the first
+    // pair-function def in the parent `(set) => ({...})` scope),
+    // producing the bogus edge `addItem → doB` and zero outgoing
+    // edges from `removeItem`. The negative + positive assertion
+    // pinpoints both halves: no mis-attribution AND a real edge.
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) => c.sourceFilePath === 'src/multi-action-store.ts' && c.target === 'doB',
+    );
+    const fromRemoveItem = calls.filter((c) => c.source === 'removeItem');
+    const fromAddItem = calls.filter((c) => c.source === 'addItem');
+    expect(
+      fromAddItem,
+      'doB must NOT be attributed to addItem (mis-attribution regression)',
+    ).toEqual([]);
+    expect(fromRemoveItem.length, 'removeItem must call doB').toBeGreaterThan(0);
+  });
+
+  it('multi-action store: fetchData → doC (third action also attributes correctly)', () => {
+    // Three actions in the same object guarantees the `find()`-returns-
+    // first defect would mis-attribute fetchData's call. With the fix,
+    // each action's body is its own caller anchor.
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) => c.sourceFilePath === 'src/multi-action-store.ts' && c.target === 'doC',
+    );
+    const fromFetch = calls.filter((c) => c.source === 'fetchData');
+    const fromAddItem = calls.filter((c) => c.source === 'addItem');
+    expect(fromAddItem, 'doC must NOT be attributed to addItem').toEqual([]);
+    expect(fromFetch.length, 'fetchData must call doC').toBeGreaterThan(0);
+  });
+
+  it('multi-action store: each action attributes calls to itself (no cross-sibling leakage)', () => {
+    // Whole-of-fixture invariant: the set of (source, target) pairs
+    // for the three action calls must be exactly {addItem→doA,
+    // removeItem→doB, fetchData→doC}. No sibling leakage allowed.
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) =>
+        c.sourceFilePath === 'src/multi-action-store.ts' &&
+        ['doA', 'doB', 'doC'].includes(c.target as string),
+    );
+    const pairs = new Set(calls.map((c) => `${c.source} → ${c.target}`));
+    expect(pairs).toContain('addItem → doA');
+    expect(pairs).toContain('removeItem → doB');
+    expect(pairs).toContain('fetchData → doC');
+    // No cross-attribution like `addItem → doB`, `addItem → doC`, etc.
+    const crossLeaks = [...pairs].filter(
+      (p) =>
+        p === 'addItem → doB' ||
+        p === 'addItem → doC' ||
+        p === 'removeItem → doA' ||
+        p === 'removeItem → doC' ||
+        p === 'fetchData → doA' ||
+        p === 'fetchData → doB',
+    );
+    expect(crossLeaks, 'no pair-arrow may attribute calls to a sibling action').toEqual([]);
   });
 });

--- a/gitnexus/test/integration/resolvers/typescript-jsx-as-call.test.ts
+++ b/gitnexus/test/integration/resolvers/typescript-jsx-as-call.test.ts
@@ -35,10 +35,7 @@ describe('TypeScript JSX-as-call CALLS edges', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
-    result = await runPipelineFromRepo(
-      path.join(FIXTURES, 'typescript-jsx-as-call'),
-      () => {},
-    );
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'typescript-jsx-as-call'), () => {});
   }, 60000);
 
   it('self-closing <Foo /> emits useFoo → Foo', () => {
@@ -110,14 +107,22 @@ describe('TypeScript JSX-as-call CALLS edges', () => {
     expect(accesses).toEqual([]);
   });
 
-  it('combined HOF + JSX: const Wrapped = () => <Foo /> emits Wrapped → Foo', () => {
+  it('combined HOF + JSX: const Wrapped = () => <Foo /> emits exactly one Wrapped → Foo', () => {
     // Probes the interaction between the HOF-callback caller-attribution
     // fix and the JSX-as-call fix. Pre-this-PR: caller mis-attribution
     // (HOF bug) plus invisible JSX (this fix's bug) both broke this
     // case. Post-PR: both are fixed and the edge lands.
+    //
+    // Asserts EXACTLY ONE edge: a single self-closing `<Foo />` is one
+    // logical invocation. If the JSX query suffix ever accidentally
+    // double-matched the same site (e.g. both
+    // `jsx_self_closing_element` and a generic call pattern firing, or
+    // both an opening-tag and a closing-tag capture), this would catch
+    // the regression — duplicate CALLS edges silently inflate
+    // blast-radius counts in `gitnexus_impact`.
     const calls = getRelationships(result, 'CALLS').filter(
       (c) => c.source === 'Wrapped' && c.target === 'Foo',
     );
-    expect(calls.length).toBeGreaterThan(0);
+    expect(calls).toHaveLength(1);
   });
 });

--- a/gitnexus/test/integration/resolvers/typescript-jsx-as-call.test.ts
+++ b/gitnexus/test/integration/resolvers/typescript-jsx-as-call.test.ts
@@ -1,0 +1,123 @@
+/**
+ * TypeScript: CALLS edges from JSX element invocations.
+ *
+ * `<Foo />` is syntactic sugar for `Foo(props)` — the React renderer
+ * invokes the component at runtime. For `gitnexus_impact` and
+ * `gitnexus_context` to give meaningful answers on `.tsx` codebases,
+ * JSX usage must surface as a CALLS edge.
+ *
+ * Pre-fix scope: in a real React monorepo (Sourcerer-fe), `.tsx` files
+ * had a 67.5% function-orphan rate vs 61.2% for plain `.ts`. Spot
+ * checks of orphan React components consistently traced back to JSX
+ * being the only "call" in the function body — invisible to the
+ * indexer because the TS scope query had no `jsx_*` patterns.
+ *
+ * Each test fixture below isolates one JSX shape:
+ *
+ *   - self-closing `<Foo />`           — simple-usage.tsx
+ *   - paired `<Foo>...</Foo>`          — paired-usage.tsx
+ *   - namespaced `<Container.Title />`         — member-usage.tsx
+ *   - nested `<Outer><Inner /></Outer>`— nested-usage.tsx
+ *   - HTML-only `<div>`/`<span>`       — html-only.tsx (negative test)
+ *   - HOF + JSX `const F = () => <X/>` — hof-jsx.tsx (combined-fix probe)
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'path';
+import {
+  FIXTURES,
+  getRelationships,
+  edgeSet,
+  runPipelineFromRepo,
+  type PipelineResult,
+} from './helpers.js';
+
+describe('TypeScript JSX-as-call CALLS edges', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'typescript-jsx-as-call'),
+      () => {},
+    );
+  }, 60000);
+
+  it('self-closing <Foo /> emits useFoo → Foo', () => {
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.target === 'Foo');
+    expect(edgeSet(calls)).toContain('useFoo → Foo');
+  });
+
+  it('paired <Bar>...</Bar> emits useBar → Bar (closing tag does NOT double-count)', () => {
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.target === 'Bar');
+    // Exactly one CALLS edge from useBar to Bar — the query captures
+    // jsx_opening_element only, NOT jsx_closing_element. Multiple matches
+    // here would mean the closing tag is also being captured (a bug —
+    // each JSX element is one logical invocation, not two).
+    const useBarToBar = calls.filter((c) => c.source === 'useBar');
+    expect(useBarToBar).toHaveLength(1);
+    expect(edgeSet(calls)).toContain('useBar → Bar');
+  });
+
+  it('namespaced <Container.Title /> is captured (no phantom read, no edge to receiver)', () => {
+    // What this PR tests at the query level: the JSX-as-member capture
+    // intercepts `<Container.Title />` BEFORE the generic
+    // `@reference.read.member` catch-all does. Two negative
+    // post-conditions verify the interception:
+    //
+    //   (a) NO ACCESSES edge `useNamespaced → Title` (the phantom read
+    //       suppression — see `shouldEmitReadMember`'s jsx-* cases).
+    //   (b) NO CALLS edge `useNamespaced → Container` (the member call
+    //       must NOT collapse to its receiver — that would mean we're
+    //       dispatching off `Container` rather than off `Container.Title`).
+    //
+    // The positive CALLS edge `useNamespaced → Title` requires
+    // chasing the receiver chain through `Container = { Title }`,
+    // which is a pre-existing compound-receiver limitation (object-
+    // literal namespaces aren't fully chained today). That gap is
+    // orthogonal to JSX-as-call and is left as future work.
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.source === 'useNamespaced');
+    const callTargets = new Set(calls.map((c) => c.target));
+    expect(callTargets).not.toContain('Container');
+  });
+
+  it('nested <Outer><Inner /></Outer> emits both useNested → Outer AND useNested → Inner', () => {
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.source === 'useNested');
+    const targets = new Set(calls.map((c) => c.target));
+    expect(targets).toContain('Outer');
+    expect(targets).toContain('Inner');
+  });
+
+  it('lowercase HTML elements (<div>, <span>, <button>) emit NO CALLS edges', () => {
+    // The PascalCase predicate must filter these out at the query level.
+    // If `useHtml` ends up with edges to `div` / `span` / `button`,
+    // the `(#match? @reference.name "^[A-Z]")` predicate isn't firing.
+    const calls = getRelationships(result, 'CALLS').filter((c) => c.source === 'useHtml');
+    const targets = new Set(calls.map((c) => c.target));
+    expect(targets).not.toContain('div');
+    expect(targets).not.toContain('span');
+    expect(targets).not.toContain('button');
+  });
+
+  it('namespaced <Container.Title /> does NOT emit a phantom ACCESSES edge', () => {
+    // `<Foo.Bar />`'s `member_expression` would normally fire BOTH
+    // `@reference.call.member` (our new JSX path) AND
+    // `@reference.read.member` (the generic read-member catch-all),
+    // producing a redundant ACCESSES edge alongside the CALLS edge.
+    // `shouldEmitReadMember`'s jsx_self_closing_element / jsx_opening_element
+    // case is what suppresses the read.
+    const accesses = getRelationships(result, 'ACCESSES').filter(
+      (a) => a.source === 'useNamespaced' && a.target === 'Title',
+    );
+    expect(accesses).toEqual([]);
+  });
+
+  it('combined HOF + JSX: const Wrapped = () => <Foo /> emits Wrapped → Foo', () => {
+    // Probes the interaction between the HOF-callback caller-attribution
+    // fix and the JSX-as-call fix. Pre-this-PR: caller mis-attribution
+    // (HOF bug) plus invisible JSX (this fix's bug) both broke this
+    // case. Post-PR: both are fixed and the edge lands.
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) => c.source === 'Wrapped' && c.target === 'Foo',
+    );
+    expect(calls.length).toBeGreaterThan(0);
+  });
+});

--- a/gitnexus/test/unit/call-attribution-issue-1166.test.ts
+++ b/gitnexus/test/unit/call-attribution-issue-1166.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Regression coverage for issue #1166: CALLS edge collector misses ~75% of
+ * functions in HOF / callback patterns.
+ *
+ * The bug had two distinct roots, both in the funcName fallback used by
+ * `findEnclosingFunctionId` (parse-worker.ts) and `findEnclosingFunction`
+ * (call-processor.ts):
+ *
+ *     const efnResult = provider.methodExtractor?.extractFunctionName?.(current);
+ *     const funcName = efnResult?.funcName ?? genericFuncName(current);
+ *
+ *  A. `genericFuncName` scanned `arrow_function` / `function_expression`
+ *     children for the first identifier and returned it. For unparenthesized
+ *     arrows like `file => processFile(file)` the first identifier is the
+ *     parameter `file`, so calls inside got attributed to a phantom
+ *     `Function file` ID. The CALLS edges were emitted with a dangling
+ *     sourceId and never showed up in `(:Function)-[:CALLS]->()` queries.
+ *
+ *  B. `tsExtractFunctionName` only named arrows whose parent was
+ *     `variable_declarator`. Object-property arrows like
+ *     `addItem: (item) => set(...)` (Zustand / TanStack / config objects)
+ *     have a `pair` parent and were treated as anonymous. With no named
+ *     ancestor up to the file, every call inside fell back to the File ID.
+ *
+ * These tests pin attribution behavior for both root causes and the common
+ * patterns from the issue (Zustand store, Promise.all+map, TanStack query).
+ */
+
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import TS from 'tree-sitter-typescript';
+import { TYPESCRIPT_QUERIES } from '../../src/core/ingestion/tree-sitter-queries.js';
+import { typescriptProvider } from '../../src/core/ingestion/languages/typescript.js';
+import {
+  FUNCTION_NODE_TYPES,
+  genericFuncName,
+  inferFunctionLabel,
+  type SyntaxNode,
+} from '../../src/core/ingestion/utils/ast-helpers.js';
+
+// ─── Test harness ────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TS_GRAMMAR = (TS as any).typescript as Parameters<Parser['setLanguage']>[0];
+
+function makeParserAndQuery(): { parser: Parser; query: Parser.Query } {
+  const parser = new Parser();
+  parser.setLanguage(TS_GRAMMAR);
+  const query = new Parser.Query(TS_GRAMMAR, TYPESCRIPT_QUERIES);
+  return { parser, query };
+}
+
+/**
+ * Mirror of the name-resolution slice of `findEnclosingFunctionId`
+ * (parse-worker.ts) and `findEnclosingFunction` (call-processor.ts).
+ *
+ * We deliberately re-implement the parent walk here rather than importing
+ * the production function: parse-worker.ts is a Worker entry point that
+ * can't be loaded from the main thread, and the function is private to
+ * its module. Using the same exported primitives (FUNCTION_NODE_TYPES,
+ * genericFuncName, provider.methodExtractor.extractFunctionName) means a
+ * real fix flows through here unchanged.
+ */
+function attributeCall(callNode: SyntaxNode): { name: string | null; nodeType: string | null } {
+  let current = callNode.parent;
+  while (current) {
+    if (FUNCTION_NODE_TYPES.has(current.type)) {
+      const efn = typescriptProvider.methodExtractor?.extractFunctionName?.(current);
+      const funcName = efn?.funcName ?? genericFuncName(current);
+      // Touch inferFunctionLabel so the import isn't dead — it's the same
+      // call the real findEnclosingFunctionId makes and we want to keep
+      // this harness aligned with production.
+      void inferFunctionLabel(current.type);
+      if (funcName) return { name: funcName, nodeType: current.type };
+    }
+    current = current.parent;
+  }
+  return { name: null, nodeType: null };
+}
+
+interface CallSite {
+  calledName: string;
+  line: number;
+  attributedTo: string | null;
+}
+
+function collectCallAttributions(code: string): CallSite[] {
+  const { parser, query } = makeParserAndQuery();
+  const tree = parser.parse(code);
+  const results: CallSite[] = [];
+  for (const match of query.matches(tree.rootNode)) {
+    const captures: Record<string, SyntaxNode> = {};
+    for (const c of match.captures) captures[c.name] = c.node;
+    if (!captures['call'] || !captures['call.name']) continue;
+    const callNode = captures['call'];
+    const name = captures['call.name'].text;
+    results.push({
+      calledName: name,
+      line: callNode.startPosition.row + 1,
+      attributedTo: attributeCall(callNode).name,
+    });
+  }
+  return results;
+}
+
+function findCall(sites: CallSite[], name: string): CallSite | undefined {
+  return sites.find((s) => s.calledName === name);
+}
+
+// ─── Bug A: genericFuncName must not return parameter identifiers ───────────
+
+describe('issue #1166 — Bug A: anonymous arrows do not borrow parameter names', () => {
+  it('returns null for arrow_function (would otherwise leak parameter identifier)', () => {
+    const { parser } = makeParserAndQuery();
+    // Single-param unparenthesized arrow: `file => processFile(file)`.
+    // tree-sitter-typescript wires the parameter as a direct identifier
+    // child of the arrow, so genericFuncName's "first identifier child"
+    // fallback used to return "file".
+    const tree = parser.parse('const x = files.map(file => processFile(file));');
+    let arrow: SyntaxNode | null = null;
+    const walk = (n: SyntaxNode) => {
+      if (n.type === 'arrow_function') {
+        arrow = n;
+        return;
+      }
+      for (let i = 0; i < n.namedChildCount; i++) {
+        if (arrow) return;
+        const child = n.namedChild(i);
+        if (child) walk(child);
+      }
+    };
+    walk(tree.rootNode);
+    expect(arrow).not.toBeNull();
+    expect(genericFuncName(arrow!)).toBeNull();
+  });
+
+  it('returns null for function_expression (would otherwise leak named-funexpr identifier)', () => {
+    const { parser } = makeParserAndQuery();
+    // `function (x) { return x; }` (anonymous function expression). We
+    // also accept named expressions like `function inner(x) { ... }`
+    // returning null here — naming for those flows through the parent
+    // (variable_declarator / pair / call argument), same as arrows.
+    const tree = parser.parse('const x = arr.filter(function (x) { return isOk(x); });');
+    let fnExpr: SyntaxNode | null = null;
+    const walk = (n: SyntaxNode) => {
+      if (n.type === 'function_expression') {
+        fnExpr = n;
+        return;
+      }
+      for (let i = 0; i < n.namedChildCount; i++) {
+        if (fnExpr) return;
+        const child = n.namedChild(i);
+        if (child) walk(child);
+      }
+    };
+    walk(tree.rootNode);
+    expect(fnExpr).not.toBeNull();
+    expect(genericFuncName(fnExpr!)).toBeNull();
+  });
+
+  it('attributes call inside `.map(file => fn(file))` to the outer named function, not "file"', () => {
+    const sites = collectCallAttributions(`
+      export const processSelectedFiles = async (files: File[]) => {
+        return Promise.all(files.map(file => processFile(file)));
+      };
+    `);
+    const processFileCall = findCall(sites, 'processFile');
+    expect(processFileCall, 'processFile call should be captured').toBeDefined();
+    expect(processFileCall!.attributedTo).toBe('processSelectedFiles');
+    // Defensive: assert we never produce the bogus parameter-as-name
+    // attribution for ANY call in this snippet.
+    for (const s of sites) {
+      expect(s.attributedTo, `call ${s.calledName} at L${s.line}`).not.toBe('file');
+    }
+  });
+
+  it('attributes call inside parenthesized single-param arrow to the outer function', () => {
+    // `(item) => doStuff(item)` — different from unparenthesized `item => ...`
+    // because the param sits inside `formal_parameters` and isn't a direct
+    // child. Used to work; we pin it to guard against future regressions.
+    const sites = collectCallAttributions(`
+      export const handler = (items: Item[]) => items.forEach((item) => doStuff(item));
+    `);
+    const doStuff = findCall(sites, 'doStuff');
+    expect(doStuff?.attributedTo).toBe('handler');
+  });
+});
+
+// ─── Bug B: object-property arrows take their name from pair.key ────────────
+
+describe('issue #1166 — Bug B: object-property arrows are named by pair.key', () => {
+  it('attributes call inside `addItem: (item) => fn(item)` to "addItem"', () => {
+    const sites = collectCallAttributions(`
+      export const store = {
+        addItem: (item) => doSomething(item),
+        fetchData: async () => {
+          const result = await api.fetch();
+          return result;
+        },
+      };
+    `);
+    const doSomething = findCall(sites, 'doSomething');
+    expect(doSomething?.attributedTo).toBe('addItem');
+    const fetchCall = findCall(sites, 'fetch');
+    // `fetch` is in BUILT_INS in typescript.ts, but the harness here doesn't
+    // filter built-ins — what we care about is the *attribution*, which
+    // should be 'fetchData', not the file.
+    expect(fetchCall?.attributedTo).toBe('fetchData');
+  });
+
+  it('handles function_expression pair values (`addItem: function(item) { ... }`)', () => {
+    const sites = collectCallAttributions(`
+      export const store = {
+        addItem: function (item) { doSomething(item); },
+      };
+    `);
+    expect(findCall(sites, 'doSomething')?.attributedTo).toBe('addItem');
+  });
+
+  it('handles string-key pairs (`"add-item": (item) => ...`)', () => {
+    const sites = collectCallAttributions(`
+      export const store = {
+        "add-item": (item) => doSomething(item),
+      };
+    `);
+    expect(findCall(sites, 'doSomething')?.attributedTo).toBe('add-item');
+  });
+
+  it('handles computed property keys gracefully — falls back to outer scope or file', () => {
+    // Computed keys like `[ACTION_KEY]: (item) => fn(item)` cannot be
+    // statically named. We don't want to invent a name from inner tokens.
+    // Either attribute to the enclosing named scope, or to null (file) —
+    // both are acceptable; what matters is no phantom IDs.
+    const sites = collectCallAttributions(`
+      export const buildStore = () => ({
+        [ACTION_KEY]: (item) => doSomething(item),
+      });
+    `);
+    const attr = findCall(sites, 'doSomething')?.attributedTo;
+    expect([null, 'buildStore']).toContain(attr);
+  });
+
+  it('handles Zustand-style nested HOF — calls inside addItem attribute to "addItem"', () => {
+    const sites = collectCallAttributions(`
+      export const useStore = create<State>()(
+        devtools(persist((set, get) => ({
+          addItem: (item) => set((state) => doSomething(state, item)),
+          fetchData: async () => {
+            const result = await api.fetch();
+            return result;
+          },
+        }), { name: 'store' }))
+      );
+    `);
+    const doSomething = findCall(sites, 'doSomething');
+    expect(doSomething, 'doSomething call should be captured').toBeDefined();
+    expect(doSomething!.attributedTo).toBe('addItem');
+    const fetchCall = findCall(sites, 'fetch');
+    expect(fetchCall?.attributedTo).toBe('fetchData');
+    // `set` and `state` are local to the callback chain. `set` lives in the
+    // body of the addItem arrow → addItem is the right caller.
+    const setCall = findCall(sites, 'set');
+    expect(setCall?.attributedTo).toBe('addItem');
+  });
+
+  it('handles TanStack Query factory — `queryFn: () => api.getUser()` attributes to "queryFn"', () => {
+    const sites = collectCallAttributions(`
+      export const useUserQuery = () =>
+        useQuery({
+          queryFn: () => api.getUser(),
+          queryKey: ['user'],
+        });
+    `);
+    const getUser = findCall(sites, 'getUser');
+    expect(getUser?.attributedTo).toBe('queryFn');
+  });
+});
+
+// ─── Definition-phase consistency ───────────────────────────────────────────
+
+describe('issue #1166 — definition-phase consistency', () => {
+  /** Run TYPESCRIPT_QUERIES and return the names captured under @definition.function. */
+  function definedFunctionNames(code: string): string[] {
+    const { parser, query } = makeParserAndQuery();
+    const tree = parser.parse(code);
+    const out: string[] = [];
+    for (const match of query.matches(tree.rootNode)) {
+      let isFn = false;
+      let name: string | undefined;
+      for (const c of match.captures) {
+        if (c.name === 'definition.function') isFn = true;
+        if (c.name === 'name') name = c.node.text;
+      }
+      if (isFn && name) out.push(name);
+    }
+    return out;
+  }
+
+  it('captures pair-with-arrow as @definition.function so call sourceIds resolve', () => {
+    const names = definedFunctionNames(`
+      export const store = {
+        addItem: (item) => doSomething(item),
+        fetchData: async () => api.fetch(),
+      };
+    `);
+    // Both addItem and fetchData should appear so that the Function nodes
+    // exist when calls inside them claim sourceId = Function:file:addItem.
+    expect(names).toContain('addItem');
+    expect(names).toContain('fetchData');
+  });
+
+  it('captures pair-with-function-expression as @definition.function', () => {
+    const names = definedFunctionNames(`
+      export const store = {
+        legacy: function (x) { return doStuff(x); },
+      };
+    `);
+    expect(names).toContain('legacy');
+  });
+
+  it('captures string-key pairs (`"add-item": () => ...`)', () => {
+    const names = definedFunctionNames(`
+      export const store = {
+        "add-item": (item) => doSomething(item),
+      };
+    `);
+    expect(names).toContain('add-item');
+  });
+
+  it('does not invent names for computed-key pairs (`[K]: () => ...`)', () => {
+    const names = definedFunctionNames(`
+      export const store = {
+        [ACTION_KEY]: (item) => doSomething(item),
+      };
+    `);
+    // Whatever else is captured, we must NOT capture a Function named
+    // "ACTION_KEY" (it's a value reference, not a property name).
+    expect(names).not.toContain('ACTION_KEY');
+  });
+
+  it('still captures top-level `const fn = () => ...` (regression)', () => {
+    const names = definedFunctionNames(`
+      export const helper = (x: number) => x + 1;
+    `);
+    expect(names).toContain('helper');
+  });
+});
+
+// ─── Regression guards: existing patterns still work ────────────────────────
+
+describe('issue #1166 — regression guards', () => {
+  it('attributes calls in plain helper functions correctly (control)', () => {
+    const sites = collectCallAttributions(`
+      export const validateFile = (file: File) => {
+        return sharedValidateFile(file);
+      };
+
+      export const processFile = async (file: File) => {
+        const result = validateFile(file);
+        return fileToDataUrl(file);
+      };
+    `);
+    expect(findCall(sites, 'sharedValidateFile')?.attributedTo).toBe('validateFile');
+    expect(findCall(sites, 'validateFile')?.attributedTo).toBe('processFile');
+    expect(findCall(sites, 'fileToDataUrl')?.attributedTo).toBe('processFile');
+  });
+
+  it('attributes calls inside Promise constructor callbacks to the enclosing named arrow', () => {
+    // `new Promise((resolve, reject) => { ... })` — the callback is anonymous,
+    // its parent is `arguments`. Walk continues to the outer
+    // `(file) => new Promise(...)` arrow, which IS named via variable_declarator.
+    const sites = collectCallAttributions(`
+      export const fileToDataUrl = (file: File): Promise<string> =>
+        new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.readAsDataURL(file);
+        });
+    `);
+    expect(findCall(sites, 'FileReader')?.attributedTo).toBe('fileToDataUrl');
+    expect(findCall(sites, 'readAsDataURL')?.attributedTo).toBe('fileToDataUrl');
+  });
+
+  it('attributes top-level calls in module-init expressions to the file (no enclosing function)', () => {
+    // `const useStore = create(...)(...)` — the calls live in the value
+    // expression of useStore itself, NOT inside any function body. The
+    // right answer here is "no enclosing function" (file-level). This pins
+    // that we don't accidentally start treating Variables as Functions.
+    const sites = collectCallAttributions(`
+      export const useStore = create<State>()(devtools(persist({}, { name: 'store' })));
+    `);
+    expect(findCall(sites, 'create')?.attributedTo).toBeNull();
+    expect(findCall(sites, 'devtools')?.attributedTo).toBeNull();
+    expect(findCall(sites, 'persist')?.attributedTo).toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
-    "lint:fix": "eslint --fix ."
+    "lint:fix": "eslint --fix .",
+    "gitnexus:refresh": "gitnexus analyze --embeddings --skills",
+    "gitnexus:full": "gitnexus analyze --force --embeddings --skills"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.57.2",


### PR DESCRIPTION
Fixes #1166.

## Summary

This is the **umbrella PR for issue #1166** — `Function` nodes had zero outgoing `CALLS` edges for ~73% of all TypeScript functions in real React + TanStack + Zustand codebases. The umbrella consolidates two complementary fix-sets that hit the same root cause from different angles:

- **Registry-primary scope-resolution (originally PR #1175 / `@ReidenXerx`)** — closes two architectural gaps in the migrated TS path: HOF/arrow-callback caller-attribution (`query.ts` arrow anchor + `finalize-algorithm.ts` callable preference + `ids.ts` Variable exclusion) and JSX-as-call edge emission (TSX-only `query.ts` suffix + `captures.ts` phantom-ACCESSES suppression).
- **Legacy Call-Resolution DAG + named object-property arrows (originally PR #1179 / `@abhigyanpatwari`, merged in via `bb6aa0c8`)** — fixes parallel attribution gaps in the legacy path that the registry-primary fix can't reach: `genericFuncName` returning phantom Function IDs for unparenthesized arrows like `file => fn(file)` (Bug A), and `tsExtractFunctionName` failing to name arrows under `pair` parents like `addItem: (item) => set(...)` (Bug B). Adds 4 `pair`-with-arrow declaration patterns to the registry-primary `query.ts` so the two paths agree on which nodes are functions.

Per `AGENTS.md`, TypeScript is in `MIGRATED_LANGUAGES` so the registry-primary path is authoritative for production behavior — but the CI parity gate runs both paths per migrated language on every PR, so the legacy-path fixes were a hard requirement to unify the two paths' definition sets and keep the gate green.

On the bug reporter's repo (`Sourcerer-fe`, scoped to `src/` production code only, with `src/types/` declarations excluded — the repo has zero tests / `.d.ts` / stories / build artifacts in the index): **`Function`→`Function` `CALLS` edges grow from 818 to 1,378 (+560, +68.5%)**. Function-node count grows from 1,185 to 1,560 because the legacy-path fix promotes 375 previously-anonymous object-property arrows (Zustand actions, TanStack `queryFn`, React Context configs) into proper named functions with their own caller scopes — every one of those is a brand-new `gitnexus_impact` target that didn't exist on `main`.

## Motivation / context

Issue #1166 reported quantified observations: `Function` nodes were indexed correctly (100%) but the **CALLS edge collector silently dropped most call expressions** when the call sat inside a callback passed as an argument to another function. In one typical TS+React codebase: 75% of all functions had zero outgoing CALLS, 56% were fully orphaned, and some file classes (Zustand stores, React providers) hit 0% capture. Downstream effect: `gitnexus_context()` returned `{}` for hot symbols, and `gitnexus_impact("Badge", direction: "upstream")` returned `risk: LOW, impactedCount: 0` for components used 15+ times — silently mis-reporting blast radius.

The orphan rate was driven by **four cooperating issues across both call-resolution pipelines**:

### Registry-primary path (TypeScript is in `MIGRATED_LANGUAGES`, so this is authoritative)

1. **HOF / arrow-callback attribution.** `pass2AttachDeclarations` placed the `Function` def for arrow-typed declarations on the wrapping module scope (the `@declaration.function` anchor was the outer `lexical_declaration`, whose start lay before the inner arrow's scope). `resolveCallerGraphId` then walked up past the empty arrow scope into the module and grabbed the first Function-like def in `ownedDefs` — frequently the wrong one. Calls inside `Promise.all(items.map(x => fn(x)))`, `useQuery({ queryFn: () => fetchData() })`, or `create()(devtools(persist((set) => ({ ... }))))` were either lost or attributed to a sibling. As a follow-on, `findExportByName` returned whichever def appeared first in `localDefs` — frequently the `Variable` def TS emits alongside every `const fn = () => {}`, breaking cross-file callee discovery whenever the import resolved to the non-callable. As a third follow-on, the caller walk-up's class-fallback considered any linkable label as a valid caller anchor, including `Variable`, which produced phantom `Function:create → Function:create` self-loops at module scope (Zustand store-creation idiom).

2. **JSX as a CALLS edge.** `<Foo />` is syntactic sugar for `Foo(props)` invoked at runtime by React, but the TS scope query had no `jsx_*` patterns, so React-component invocations were invisible to the call graph. Every `<Component />` in every `.tsx` file produced zero outgoing edges from the enclosing function (and zero incoming edges to the component) — the dominant cause of the .tsx-vs-.ts asymmetry in the orphan rate.

### Legacy Call-Resolution DAG (still runs in parallel for the CI parity gate)

3. **Bug A — phantom Function IDs.** `genericFuncName` scanned `arrow_function` / `function_expression` children for the first identifier and returned it. For unparenthesized arrows like `file => processFile(file)` the first identifier was the parameter `file`, so calls inside got attributed to a synthetic `Function file` and emitted dangling CALLS edges. User queries like `(:Function)-[:CALLS]->()` never saw them.

4. **Bug B — anonymous object-property arrows.** `tsExtractFunctionName` only named arrows whose parent was `variable_declarator`. `addItem: (item) => set(...)` (Zustand actions, TanStack `queryFn`, React Context providers, config objects) lives under a `pair` parent — treated as anonymous. With no named ancestor up to the file, calls inside fell back to the File and were invisible to `context()` / `impact()`.

The four fixes are orthogonal in failure-mode but cooperate in coverage: registry-primary fixes (1) and (2) restore proper attribution for named arrows; legacy fixes (3) and (4) ensure the parallel path agrees on what counts as a named function and which scope to attribute under. **Crucially, fix (4) also adds 4 `pair`-with-arrow patterns to the registry-primary `query.ts`** so the two paths produce the same set of `Function` nodes — the CI parity gate would have failed otherwise.

This PR is the umbrella consolidation of two contributors' work:
- `@ReidenXerx`'s registry-primary scope-resolution fixes (commits `7be595d3`, `851d2ab7`)
- `@abhigyanpatwari`'s legacy-path attribution fixes from PR #1179 (commit `93a0be23`, merged in via `bb6aa0c8`)

References:
- Issue: #1166 — original bug report with quantified scope (75% no-outgoing, 56% fully orphaned).
- Closes: #1179 (this PR supersedes it; the `pair`-with-arrow patterns are merged in here).
- Architecture: `ARCHITECTURE.md` § Scope-Resolution Pipeline; TypeScript is in `MIGRATED_LANGUAGES`, so it goes through the registry-primary path. The legacy DAG runs in parallel for the CI parity gate per migrated language.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

**Files (umbrella):**

Registry-primary path (`@ReidenXerx`):
- `gitnexus/src/core/ingestion/languages/typescript/query.ts` — arrow-anchor inner-node move + TSX_JSX_QUERY_SUFFIX
- `gitnexus/src/core/ingestion/languages/typescript/captures.ts` — JSX cases in `shouldEmitReadMember` + arity-synthesis JSX comment
- `gitnexus/src/core/ingestion/scope-resolution/graph-bridge/ids.ts` — `isCallerAnchorLabel` Variable exclusion
- `gitnexus-shared/src/scope-resolution/finalize-algorithm.ts` — `findExportByName` callable preference

Legacy DAG path + name-resolution alignment (`@abhigyanpatwari`, merged from #1179):
- `gitnexus/src/core/ingestion/languages/typescript.ts` — `tsExtractFunctionName` resolves names from `pair` parents
- `gitnexus/src/core/ingestion/languages/typescript/query.ts` — adds 4 `pair`-with-arrow patterns to mirror the legacy queries (registry-primary half of fix B)
- `gitnexus/src/core/ingestion/tree-sitter-queries.ts` — same `pair`-with-arrow patterns in TYPESCRIPT_QUERIES / JAVASCRIPT_QUERIES (legacy-path half)
- `gitnexus/src/core/ingestion/utils/ast-helpers.ts` — `genericFuncName` returns null for anonymous JS/TS function-likes

Tests + fixtures:
- `gitnexus/test/integration/resolvers/typescript-hof-callbacks.test.ts` (8 assertions, registry-primary path)
- `gitnexus/test/integration/resolvers/typescript-jsx-as-call.test.ts` (7 assertions, registry-primary path)
- `gitnexus/test/unit/call-attribution-issue-1166.test.ts` (18 assertions, legacy DAG path)
- `gitnexus/test/fixtures/lang-resolution/typescript-hof-callbacks/` (6 fixtures)
- `gitnexus/test/fixtures/lang-resolution/typescript-jsx-as-call/` (8 fixtures)

## Scope & constraints

**In scope**

- HOF / arrow-callback caller-attribution for TypeScript (3 cooperating fixes: arrow-anchor in tree-sitter query, `findExportByName` callable preference, `isCallerAnchorLabel` Variable exclusion).
- JSX-as-call CALLS-edge emission for TSX files (TSX-only query suffix + `shouldEmitReadMember` JSX cases to suppress phantom ACCESSES on `<Foo.Bar />`).
- Two new integration test files (`typescript-hof-callbacks.test.ts` 8 assertions, `typescript-jsx-as-call.test.ts` 7 assertions) plus 13 minimal fixtures pinning the exact patterns from the bug report (TanStack `useQuery`/`useMutation`, Zustand `create()(devtools(persist(...)))`, `Promise.all(map)`, `new Promise(executor)`, self-closing JSX, paired JSX, namespaced `<Foo.Bar />`, nested JSX, lowercase HTML negative test, combined HOF+JSX `const F = () => <X />`).

**Explicitly out of scope / not done here** (the residual `.tsx` orphans after this PR — kept off this PR's surface so review stays focused):

- **External-only callers** (~25% of remaining .tsx orphans) — function bodies whose only calls are to `node_modules` symbols (`twMerge`, `dayjs`, `useState`). Working as intended; would require indexing dependencies. Better addressed at the UX layer ("external-only" label, not "orphan").
- **Bare function-reference passing** (~10%) — `queryFn: fetchData` without an arrow wrapper. Not syntactically a call at the use site; deferred for a follow-up that introduces a `WIRES_TO` edge type or an `indirect: true` flag on `CALLS`.
- **Destructured-from-hook-return + prop-callback invocation** (~30%) — `const { fn } = useStore(); fn()` and `function F({ onChange }) { onChange(x) }`. Both require return-type tracking and/or React data-flow analysis. Larger projects; deferred.
- **End-to-end positive resolution of `<Container.Title />` through an object-literal namespace** (`export const Container = { Title }`). The JSX *capture* is verified in tests (member-call interception suppresses the phantom ACCESSES; the receiver doesn't collapse to the wrong target). The full positive-edge to the leaf `Title` requires the existing compound-receiver resolver to chain through object-literal namespaces — pre-existing gap, orthogonal to JSX-as-call.

## Implementation notes

### Fix 1 — HOF / arrow-callback attribution (3 cooperating changes)

| File | Change |
|---|---|
| `gitnexus/src/core/ingestion/languages/typescript/query.ts` | `@declaration.function` anchor moved from the wrapping `lexical_declaration` to the inner `arrow_function` / `function_expression` so `anchor.range` aligns with `@scope.function` and `pass2AttachDeclarations` lands the def on the arrow's own scope. |
| `gitnexus-shared/src/scope-resolution/finalize-algorithm.ts` | `findExportByName` now prefers callable / class-like defs (`Function`/`Method`/`Constructor`/`Class`/`Interface`/`Enum`/`Struct`/`Record`/`Trait`/`Namespace`/`Module`/`TypeAlias`) over `Variable` when `localDefs` contains both for the same name. (TS emits two defs per `const fn = () => {}` — a Function and a Variable; capture order silently decided which an importer bound to.) The behavior is a tie-break: when only one def with the name exists, the existing first-match path fires unchanged. |
| `gitnexus/src/core/ingestion/scope-resolution/graph-bridge/ids.ts` | New `isCallerAnchorLabel` predicate (a strict subset of `isLinkableLabel`) restricted to `Function` / `Method` / `Constructor` / `Class` / `Interface` / `Struct` / `Enum`. `Variable` / `Property` are no longer valid caller anchors — module-level call expressions inside `const X = expr(args)` declarations correctly fall through to the `File`-node fallback instead of being mis-attributed to a sibling Function via simpleKey (the Zustand `create()(devtools(persist(...)))` regression). |

### Fix 2 — JSX as CALLS edge (2 changes)

| File | Change |
|---|---|
| `gitnexus/src/core/ingestion/languages/typescript/query.ts` | Adds a `TSX_JSX_QUERY_SUFFIX` constant (compiled only against the `tsx` grammar — `jsx_*` node types don't exist in the plain `typescript` grammar, so embedding them in the shared query would throw `Query.InvalidNodeType`). Captures `jsx_self_closing_element` and `jsx_opening_element` as `@reference.call.free` / `@reference.call.member`. Lowercase HTML elements (`<div>`, `<span>`) are filtered with the `(#match? @reference.name "^[A-Z]")` predicate so they don't emit edges to nonexistent targets; member-form (`<Foo.Bar />`) is unfiltered (HTML element names can't contain dots, so any `.`-form is unambiguously a component). The closing tag is intentionally NOT captured — each JSX element should emit exactly one CALLS edge per use site. |
| `gitnexus/src/core/ingestion/languages/typescript/captures.ts` | `shouldEmitReadMember` extended with `jsx_self_closing_element` / `jsx_opening_element` parent cases. Without this, `<Foo.Bar />`'s inner `member_expression` would emit BOTH a `@reference.call.member` (the new path) AND a `@reference.read.member` (the generic catch-all), producing a redundant phantom ACCESSES edge alongside the CALLS edge. Verified by the JSX integration test. |

### Sourcerer-fe end-to-end validation

I built the patched CLI from this branch and re-analyzed the reporter's `Sourcerer-fe` repo at the same commit, three times — clean `main`, registry-primary fixes only (PR #1175 alone), umbrella with legacy-DAG fixes merged in (this PR). Sourcerer-fe is a Next.js + Capacitor mobile app; the indexer respects `.gitignore` and skips `android/`, `ios/`, `node_modules/`, `out/`, `.next/`. Of the 525 indexed files, 508 live in `src/` and the remaining 17 are root configs (`next.config.js`, `tailwind.config.ts`, etc.); the repo has zero test files, zero `.d.ts`, zero stories. Metrics below are scoped to **`src/` only, with `src/types/` declarations excluded** — purely production code patterns.

| Metric | Clean `main` | Registry only (#1175) | **Umbrella (this PR)** | Δ vs main |
|---|---:|---:|---:|---:|
| `Function` nodes (in `src/`) | 1,185 | 1,185 | **1,560** | **+375** |
| **`Function`→`Function` CALLS edges** | **818** | **1,322** | **1,378** | **+560 (+68.5%)** |
| All CALLS edges (incl. File-anchored) | 979 | 1,528 | 1,541 | +562 (+57.4%) |
| .tsx no-outgoing orphans | 521 | 405 | 471 | −50 |
| .ts no-outgoing orphans | 347 | 309 | 586 | +239 (see note) |

**Why the .ts orphan count grows in the umbrella column:** the legacy-path fix (Bug B) promotes 375 previously-anonymous object-property arrows in `.ts` files (Zustand store actions, TanStack hook configs, React Context setup objects) into proper named `Function` nodes. Many of those promoted leaves are tiny one-liners that legitimately have zero outgoing calls (`addItem: (item) => set(...)` only calls `set`, which is itself a parameter), so they appear as orphans-by-numerator while not being a regression. **The right way to read the table:** function count grew by 375 because that many *new* `gitnexus_impact` targets exist that never existed before, and Function→Function edges still grew by 560 — 56 of those edges originate from the newly-promoted leaves and 504 from existing functions that were previously misattributing or invisible.

Concrete bug-report cases that now work:

**Registry-primary path (HOF + JSX):**
- **TanStack hooks** — `src/api-modules/notifications/push-notifications.hooks.ts`: pre-fix 0/16 captures (matches the bug report's "0%" hook number). Post-fix: arrow-form `mutationFn: (data) => registerDevice(data)` correctly emits `useRegisterDevice → registerDevice` and 4 sibling hook-to-API edges.
- **React component invocations** — `src/components/subscription/subscription-management.tsx::getStatusBadge`: previously orphan (its only "call" was `<Badge variant=... />`). Post-fix: `getStatusBadge → Badge` is captured. Across the codebase, `Badge` now has 15 incoming CALLS edges from .tsx files. Top JSX-restored receivers: `cn` (83×), `usePlatform` (37×), `Loader` (35×), `toast` (31×), `useToast` (23×), `Badge` (15×), `TopBarWrapper`/`TopBarPortal` (11× each), Lucide icons like `Share2` (10×) — all 0 incoming on clean `main`.
- **Zustand mis-attribution** — `useStore = create()(devtools(persist((set) => ({ ... }))))` no longer produces phantom `Function:create → Function:create` self-loops. Module-level call expressions correctly fall through to the `File` node when no enclosing function scope owns them (covered by the Zustand-fixture assertions in `typescript-hof-callbacks.test.ts`).

**Legacy DAG path (Bugs A + B):**
- **Phantom `Function file` IDs eliminated** — `processSelectedFiles → processFile` inside `Promise.all(files.map(file => processFile(file)))` previously attributed to a synthetic `Function file` (the parameter name). Now correctly attributes to `processSelectedFiles`.
- **Object-property arrows promoted** — `addItem: (item) => set(...)` and TanStack `queryFn: () => fetchData()` now appear as named `Function` nodes; calls inside their bodies attribute to the action name instead of the file. The reporter's specific Zustand reproducer from #1166 (`useStore = create<State>()(devtools(persist((set, get) => ({ addItem: ..., fetchData: ... }))))`) now resolves all expected edges.

## Testing & verification

Template's standard checklist:

- [x] `cd gitnexus && npm test` — ran the suites covering changed code paths (see custom rows below). Skipped the full `npm test` because the 146 `kotlin.test.ts` failures it would surface are a pre-existing local environment issue (missing optional `tree-sitter-kotlin` native binding, documented in `AGENTS.md` § Gotchas) that reproduces on `main` at `dafda284` without these patches. CI runs the full suite in a clean container where the binding is present.
- [x] `cd gitnexus && npm run test:integration` — covered the relevant subset (changes are confined to TS scope-resolution; integration entry points listed below).
- [x] `cd gitnexus && npx tsc --noEmit` — clean
- [x] `cd gitnexus-web && npx tsc -b --noEmit` — clean (this PR doesn't touch `gitnexus-web/`, but ran per checklist to confirm the `gitnexus-shared` re-exports stay binary-compatible after the `finalize-algorithm.ts` change)
- [ ] `cd gitnexus-web && npm test` — skipped (web not changed)
- [ ] Manual / Playwright E2E — N/A

Specific commands run on the umbrella branch (after merging #1179):

- [x] `cd gitnexus && npx vitest run test/integration/resolvers/typescript-hof-callbacks.test.ts` — **8/8 ✓** (registry-primary HOF assertions)
- [x] `cd gitnexus && npx vitest run test/integration/resolvers/typescript-jsx-as-call.test.ts` — **7/7 ✓** (registry-primary JSX assertions)
- [x] `cd gitnexus && npx vitest run test/unit/call-attribution-issue-1166.test.ts` — **18/18 ✓** (legacy-DAG attribution + Bug A / Bug B assertions, from #1179)
- [x] `cd gitnexus && npx vitest run test/integration/resolvers/typescript.test.ts` — **236/236 ✓** (no regressions in either path)
- [x] `cd gitnexus && npx vitest run test/integration/resolvers/api-deep-flow.test.ts` — **11/11 ✓**
- [x] `cd gitnexus && npx vitest run test/unit/scope-resolution test/unit/scope-extractor test/unit/typescript` — **613/613 ✓**
- [x] **Combined regression run** — all five files in one `vitest run`: **280/280 ✓** (registry-primary integration + legacy-DAG unit + existing TS suite all coexist with both fix sets active)
- [x] `cd gitnexus-shared && npx tsc --noEmit` — clean
- [x] Pre-commit hook (`.husky/pre-commit`) clean during umbrella commits
- [x] End-to-end: re-analyzed `Sourcerer-fe` three times (clean `main`, registry-primary only, umbrella) with patched CLIs; captured the orphan-rate / edge-count numbers in the table above; spot-checked per-file deltas against the specific patterns from #1166 (`file-upload.ts`, `use-gateway-queries.ts`, `grouped-file-uploads-store.tsx`, `push-notifications.hooks.ts`, `subscription-management.tsx`).

## Risk & rollout

**Risk: LOW.**

- Scope is fully contained in the TypeScript scope-resolution path. No behavior change for any other indexed language. The shared library change (`finalize-algorithm.ts::findExportByName`) is a tie-break refinement when both a Function and a Variable definition share a name within the same module — a TypeScript-specific situation; in every other migrated language tested, no callable/variable name collisions of this shape occur in `localDefs`, so the fallback path (first-match) still fires unchanged.
- The new `isCallerAnchorLabel` predicate in `graph-bridge/ids.ts` strictly narrows the existing `isLinkableLabel` predicate (it's a subset). The only legacy behavior it removes is "if the only owned def at module scope is a `Variable`, attribute the call to it as a caller" — a path that produced phantom self-loops in practice (the Zustand regression covered by the test).
- The TSX-only JSX query suffix is appended at TSX-grammar compile time (in `getTsScopeQuery`); plain `.ts` files don't see it. The TSX grammar has been the indexer's `.tsx` path since `MIGRATED_LANGUAGES` flipped — no parser swap.
- Impact analysis (`gitnexus_impact`) on `getTsScopeQuery`, `shouldEmitReadMember`, `emitTsScopeCaptures`, `resolveCallerGraphId`, and `findExportByName` returned `risk: LOW` for all five — direct callers are localized, no execution flows downstream, no cross-module fan-out.
- The legacy-path `genericFuncName` change is a strict narrowing: it returns `null` for anonymous JS/TS function-likes where it previously returned the wrong identifier (the first parameter). Anonymous arrows now correctly fall through to the language hook instead of producing phantom Function IDs.
- The legacy-path `tsExtractFunctionName` change extends naming to `pair` parents (object-property arrows). Computed keys (`[K]: () => ...`) intentionally stay anonymous to avoid resolving runtime expressions. No previously-named function changes its name.
- The 4 new `pair`-with-arrow patterns added to the registry-primary `query.ts` are new pattern matches (not edits to existing patterns) — they only fire on object-property arrows, which previously matched no declaration pattern at all in that path. This is what keeps the CI parity gate green: both pipelines now agree on the set of `Function` nodes.
- 0 regressions across the **280 TypeScript-relevant integration + unit tests** (8 HOF + 7 JSX + 18 issue-1166 + 236 typescript + 11 api-deep-flow) and 613 scope-resolution unit tests on the merged branch.

**Breaking changes: none.** No public API changes (CLI flags, MCP tools, edge types, node labels, schema). The graph emits more edges than before — strictly additive — and eliminates a small number of phantom self-loops. Consumers of the graph (existing `gitnexus_impact` / `gitnexus_query` / `gitnexus_context` callers) will see strictly more truthful results.

**Migrations: none required to ship.** No DB schema change, no node/edge property additions.

**Index refresh: required for users to see the new edges.** Existing indexed repositories will need `npx gitnexus analyze` to surface the additional CALLS edges in their graph (no `--force` needed — the analyzer detects the file/grammar change and re-extracts). Without re-analyzing, existing graphs will continue to render the pre-fix edge set (correct behavior — staleness check writes a marker, see `AGENTS.md` § "If any GitNexus tool warns the index is stale").

**Release notes: lands under 🐛 Bug Fixes** (per `.github/release.yml`, type=`fix`).

**Rollback.** Each of the source-level changes is independently revertible without breaking the others:

Registry-primary path (commits `7be595d3`, `851d2ab7`):

| Revert this | Effect |
|---|---|
| `gitnexus/src/core/ingestion/languages/typescript/query.ts` HOF chunk (arrow-anchor patterns ~lines 151-170) | Restores legacy outer-`lexical_declaration` anchor; HOF-callback caller-attribution returns to pre-fix behavior. JSX and legacy-path fixes still active. |
| `gitnexus-shared/src/scope-resolution/finalize-algorithm.ts` (`findExportByName`) | Returns to first-match behavior across languages. |
| `gitnexus/src/core/ingestion/scope-resolution/graph-bridge/ids.ts` (`isCallerAnchorLabel`) | Reverts to `isLinkableLabel` for caller-walk fallback; phantom self-loop case (Zustand) returns. |
| `gitnexus/src/core/ingestion/languages/typescript/query.ts` `TSX_JSX_QUERY_SUFFIX` (constant + concatenation in `getTsScopeQuery`) | JSX-as-call disabled; HOF and legacy-path fixes still active. |
| `gitnexus/src/core/ingestion/languages/typescript/captures.ts` (jsx cases in `shouldEmitReadMember`) | Phantom ACCESSES edges on `<Foo.Bar />` re-appear; CALLS edges unaffected. |

Legacy DAG path (commit `93a0be23`, originally PR #1179):

| Revert this | Effect |
|---|---|
| `gitnexus/src/core/ingestion/utils/ast-helpers.ts` (`genericFuncName` returning null for anonymous JS/TS) | Phantom Function IDs from unparenthesized arrow parameters re-appear in the legacy path. |
| `gitnexus/src/core/ingestion/languages/typescript.ts` (`tsExtractFunctionName` `pair` parent handling) | Object-property arrows fall back to anonymous in the legacy path; calls inside revert to File attribution. |
| `gitnexus/src/core/ingestion/tree-sitter-queries.ts` `pair`-with-arrow patterns | Legacy queries no longer emit Function nodes for object-property arrows. |
| `gitnexus/src/core/ingestion/languages/typescript/query.ts` 4 `pair`-with-arrow patterns | Registry-primary path no longer produces Function nodes for object-property arrows. **Reverting just this without also reverting the legacy-side patterns will fail the CI parity gate** — the two paths must agree on the Function set. |

A full revert is `git revert <merge-commit>` for the umbrella merge `bb6aa0c8` plus the registry-primary commits. Each commit is independently revertible with `git revert <sha>`. No migrations / data-shape changes. Re-running `npx gitnexus analyze` after a revert restores the pre-fix edge set.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions — **N/A, no overlay files in this PR**
- [x] No secrets, tokens, or machine-specific paths committed — verified by scanning the diff for `/Users/`, `/home/`, `sk-`, `ghp_`, `github_pat_`, `password`, `api_key` (none found)
