### PR TITLE
fix(local-backend): #1178 skip vector index query on unsupported pla…

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -35,7 +35,10 @@ import {
   type ExactEmbeddingRow,
 } from '../../core/embeddings/exact-search.js';
 import { EMBEDDING_TABLE_NAME, EMBEDDING_INDEX_NAME } from '../../core/lbug/schema.js';
-import { getExactScanLimit } from '../../core/platform/capabilities.js';
+import {
+  getExactScanLimit,
+  isVectorExtensionSupportedByPlatform,
+} from '../../core/platform/capabilities.js';
 import { PhaseTimer } from '../../core/search/phase-timer.js';
 import { checkStaleness, checkCwdMatch } from '../../core/git-staleness.js';
 // AI context generation is CLI-only (gitnexus analyze)
@@ -222,6 +225,14 @@ export class LocalBackend {
    * making MCP stderr unreadable.
    */
   private warnedSiblingDrift: Set<string> = new Set();
+
+  /**
+   * One-shot stderr warning for the VECTOR-extension fallback. Without this
+   * guard the diagnostic would fire on every `semanticSearch()` call on
+   * platforms where the extension is unsupported (e.g. Windows), making MCP
+   * stderr noisy per DoD §2.8.
+   */
+  private warnedVectorUnsupported = false;
 
   /**
    * Cross-repo group tools (CLI). Shares logic with MCP `group_*` handlers.
@@ -1071,9 +1082,10 @@ export class LocalBackend {
         string,
         { distance: number; chunkIndex: number; startLine: number; endLine: number }
       >();
-      try {
-        bestChunks = await collectBestChunks(limit, async (fetchLimit) => {
-          const vectorQuery = `
+      if (isVectorExtensionSupportedByPlatform()) {
+        try {
+          bestChunks = await collectBestChunks(limit, async (fetchLimit) => {
+            const vectorQuery = `
             CALL QUERY_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}',
               CAST(${queryVecStr} AS FLOAT[${dims}]), ${fetchLimit})
             YIELD node AS emb, distance
@@ -1084,17 +1096,28 @@ export class LocalBackend {
             ORDER BY distance
           `;
 
-          const embResults = await executeQuery(repo.id, vectorQuery);
-          return embResults.map((row) => ({
-            nodeId: row.nodeId ?? row[0],
-            chunkIndex: row.chunkIndex ?? row[1] ?? 0,
-            startLine: row.startLine ?? row[2] ?? 0,
-            endLine: row.endLine ?? row[3] ?? 0,
-            distance: row.distance ?? row[4],
-          }));
-        });
-      } catch {
-        bestChunks = new Map();
+            const embResults = await executeQuery(repo.id, vectorQuery);
+            return embResults.map((row) => ({
+              nodeId: row.nodeId ?? row[0],
+              chunkIndex: row.chunkIndex ?? row[1] ?? 0,
+              startLine: row.startLine ?? row[2] ?? 0,
+              endLine: row.endLine ?? row[3] ?? 0,
+              distance: row.distance ?? row[4],
+            }));
+          });
+        } catch {
+          bestChunks = new Map();
+        }
+      } else if (!this.warnedVectorUnsupported) {
+        // Rare diagnostic: surface why we fell back to the exact scan path so
+        // operators can see at a glance that the VECTOR extension is missing on
+        // this runtime (e.g. Windows builds without the optional native
+        // dependency). Emitted once per `LocalBackend` instance lifetime to
+        // avoid noisy stderr on hot semantic-search paths (DoD §2.8).
+        this.warnedVectorUnsupported = true;
+        console.error(
+          'GitNexus [query:vector]: VECTOR index unavailable for this runtime; using exact scan fallback',
+        );
       }
 
       if (bestChunks.size === 0) {

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -13,13 +13,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // local-backend.ts imports from core/lbug/pool-adapter.js; the mcp/core/lbug-adapter.js
 // re-exports from the same module, so we mock the canonical source.
 // vi.hoisted runs before vi.mock hoisting, making the fns available to both factories.
-const { lbugMocks } = vi.hoisted(() => ({
+const { lbugMocks, platformMocks } = vi.hoisted(() => ({
   lbugMocks: {
     initLbug: vi.fn().mockResolvedValue(undefined),
     executeQuery: vi.fn().mockResolvedValue([]),
     executeParameterized: vi.fn().mockResolvedValue([]),
     closeLbug: vi.fn().mockResolvedValue(undefined),
     isLbugReady: vi.fn().mockReturnValue(true),
+  },
+  platformMocks: {
+    isVectorExtensionSupportedByPlatform: vi.fn().mockReturnValue(true),
   },
 }));
 
@@ -47,6 +50,14 @@ vi.mock('../../src/core/git-staleness.js', () => ({
   checkStaleness: vi.fn().mockReturnValue({ isStale: false, commitsBehind: 0 }),
   checkCwdMatch: vi.fn().mockResolvedValue({ match: 'none' }),
 }));
+
+vi.mock('../../src/core/platform/capabilities.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/core/platform/capabilities.js')>();
+  return {
+    ...actual,
+    isVectorExtensionSupportedByPlatform: platformMocks.isVectorExtensionSupportedByPlatform,
+  };
+});
 
 // Also mock the search modules to avoid loading onnxruntime
 vi.mock('../../src/core/search/bm25-index.js', () => ({
@@ -157,6 +168,7 @@ describe('LocalBackend.callTool', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    platformMocks.isVectorExtensionSupportedByPlatform.mockReturnValue(true);
     backend = new LocalBackend();
     setupSingleRepo();
     await backend.init();
@@ -179,6 +191,38 @@ describe('LocalBackend.callTool', () => {
     const result = await backend.callTool('query', { query: 'auth' });
     expect(result).toHaveProperty('processes');
     expect(result).toHaveProperty('definitions');
+  });
+
+  it('skips vector index query when VECTOR is unsupported by the platform', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    platformMocks.isVectorExtensionSupportedByPlatform.mockReturnValue(false);
+    (executeQuery as any).mockImplementation(async (_repoId: string, cypher: string) => {
+      if (cypher.includes('COUNT(*) AS cnt')) return [{ cnt: 1 }];
+      if (cypher.includes('MATCH (e:CodeEmbedding)')) return [];
+      return [];
+    });
+    (executeParameterized as any).mockResolvedValue([]);
+
+    try {
+      await backend.callTool('query', { query: 'auth' });
+
+      const queries = (executeQuery as any).mock.calls.map(
+        ([, cypher]: [string, string]) => cypher,
+      );
+      expect(queries.some((cypher: string) => cypher.includes('QUERY_VECTOR_INDEX'))).toBe(false);
+      expect(
+        queries.some(
+          (cypher: string) =>
+            cypher.includes('RETURN e.nodeId AS nodeId') &&
+            cypher.includes('e.embedding AS embedding'),
+        ),
+      ).toBe(true);
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('GitNexus [query:vector]: VECTOR index unavailable'),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('query tool returns error for empty query', async () => {


### PR DESCRIPTION
## Summary



This PR makes the local MCP semantic search path respect the existing VECTOR platform capability guard.



GitNexus already treats LadybugDB VECTOR as unsupported on `win32` via `isVectorExtensionSupportedByPlatform()`. The core embedding pipeline uses that guard before attempting to load or use VECTOR. However, `src/mcp/local/local-backend.ts` still had one direct `CALL QUERY_VECTOR_INDEX(...)` path that did not check the same capability first.



This PR fixes that remaining inconsistency by skipping the VECTOR index fast path on unsupported platforms and letting the existing exact-scan fallback run.



## Background



On Windows, `@ladybugdb/core` can terminate the process with a native access violation when executing:



```sql

LOAD EXTENSION VECTOR

```



Observed exit code:



```text

0xC0000005 / -1073741819

```



This is a native crash, so JavaScript `try/catch` cannot reliably recover from it once the unsafe native path is entered.



The current main branch already has the primary guard:



- `src/core/platform/capabilities.ts`

  - `isVectorExtensionSupportedByPlatform('win32') === false`

- `src/core/lbug/lbug-adapter.ts`

  - `loadVectorExtension()` checks platform support before calling into LadybugDB VECTOR loading



The local MCP backend should follow the same capability policy.



## Problem



`LocalBackend.semanticSearch()` in `src/mcp/local/local-backend.ts` directly attempted:



```sql

CALL QUERY_VECTOR_INDEX(...)

```



without checking whether VECTOR is supported on the current platform.



On Windows this usually falls back after query failure, because the pool path does not load the VECTOR extension by default. However, it is still inconsistent with the rest of the codebase:



- core embedding semantic search checks VECTOR availability first

- local MCP semantic search attempted the vector index query directly

- unsupported platforms should go straight to exact-scan fallback



## Change



This PR updates `LocalBackend.semanticSearch()` to reuse:



```ts

isVectorExtensionSupportedByPlatform()

```



Behavior after this change:



- Supported platforms:

  - unchanged

  - still try `CALL QUERY_VECTOR_INDEX(...)`

  - fall back to exact scan if the vector query fails or returns no chunks



- Unsupported platforms:

  - skip `CALL QUERY_VECTOR_INDEX(...)`

  - go directly to the existing exact-scan fallback



This does not disable semantic search. It only skips the LadybugDB VECTOR index fast path on platforms where VECTOR is already marked unsupported.



## Why this approach



This follows the existing project architecture instead of introducing a new policy.



I intentionally did not call `loadVectorExtension()` from `local-backend.ts`, because local backend uses the repo-scoped `pool-adapter` connection model, while `loadVectorExtension()` belongs to the singleton `lbug-adapter` path. Mixing those connection models would make the change larger and riskier.



I also did not add a new environment variable or change extension install policy. This PR only makes the local backend respect the existing platform capability helper.



## Tests



Added a regression test in `test/unit/calltool-dispatch.test.ts` verifying that when VECTOR is unsupported by the platform:



- `LocalBackend` does not send a `QUERY_VECTOR_INDEX` query

- the code proceeds to the exact-scan `CodeEmbedding` query path



Validation run locally:



```powershell

npx vitest run --project default "test/unit/platform-capabilities.test.ts"

npx vitest run --project default "test/unit/calltool-dispatch.test.ts"

npx tsc --noEmit

```



Results:



```text

platform-capabilities.test.ts: 2 tests passed

calltool-dispatch.test.ts: 67 tests passed

TypeScript check: passed

```



## Scope



This PR does not attempt to fix the underlying LadybugDB native crash itself. That should be addressed upstream in `@ladybugdb/core`.



This PR only ensures that GitNexus' local MCP semantic search path does not bypass the existing platform capability guard.