### PR TITLE
fix(docker): use HEAD probe so SSE heartbeat doesn't time out healthcheck

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - ${WORKSPACE_DIR:-./workspace}:/workspace:ro
     restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'curl', '-fsS', 'http://localhost:4747/api/heartbeat']
+      test: ['CMD', 'curl', '-fsSI', 'http://localhost:4747/api/heartbeat']
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
**Bug:** `docker compose up -d` fails with dependency failed to start: container gitnexus-server is unhealthy even though the server is running and serving requests.

**Root cause:** the compose healthcheck uses `curl -fsS http://localhost:4747/api/heartbeat`, but that endpoint returns Content-Type: text/event-stream and keeps the connection open indefinitely. The 200 status arrives instantly, but curl reads until the body ends — which it never does — so every probe trips the 5s timeout and Docker marks the container unhealthy. gitnexus-web then refuses to start because of its condition: service_healthy dependency.

**Fix:** switch the probe to `curl -fsSI (HEAD)`. Same 200, no body, curl exits cleanly. Verified locally: gitnexus-server reports healthy and gitnexus-web starts.