### PR TITLE
fix(cli): keep GitNexus ignores inside .gitnexus

### DIFF
--- a/gitnexus/src/cli/index-repo.ts
+++ b/gitnexus/src/cli/index-repo.ts
@@ -14,7 +14,7 @@ import fs from 'fs/promises';
 import {
   getStoragePaths,
   loadMeta,
-  addToGitignore,
+  ensureGitNexusInternalGitignore,
   registerRepo,
 } from '../storage/repo-manager.js';
 import { getGitRoot, getRemoteUrl, isGitRepo } from '../storage/git.js';
@@ -115,7 +115,7 @@ export const indexCommand = async (inputPathParts?: string[], options?: IndexOpt
     meta.remoteUrl = getRemoteUrl(repoPath);
   }
   await registerRepo(repoPath, meta);
-  await addToGitignore(repoPath);
+  await ensureGitNexusInternalGitignore(repoPath);
 
   const projectName = path.basename(repoPath);
   const { stats } = meta;

--- a/gitnexus/src/cli/index-repo.ts
+++ b/gitnexus/src/cli/index-repo.ts
@@ -14,7 +14,7 @@ import fs from 'fs/promises';
 import {
   getStoragePaths,
   loadMeta,
-  ensureGitNexusInternalGitignore,
+  ensureGitNexusIgnored,
   registerRepo,
 } from '../storage/repo-manager.js';
 import { getGitRoot, getRemoteUrl, isGitRepo } from '../storage/git.js';
@@ -115,7 +115,7 @@ export const indexCommand = async (inputPathParts?: string[], options?: IndexOpt
     meta.remoteUrl = getRemoteUrl(repoPath);
   }
   await registerRepo(repoPath, meta);
-  await ensureGitNexusInternalGitignore(repoPath);
+  await ensureGitNexusIgnored(repoPath);
 
   const projectName = path.basename(repoPath);
   const { stats } = meta;

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -449,9 +449,7 @@ export async function runFullAnalysis(
     });
 
     // Keep generated .gitnexus contents ignored without editing the user's root .gitignore.
-    if (hasGitDir(repoPath)) {
-      await ensureGitNexusIgnored(repoPath);
-    }
+    await ensureGitNexusIgnored(repoPath);
 
     // ── Generate AI context files (best-effort) ───────────────────────
     let aggregatedClusterCount = 0;

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -26,7 +26,7 @@ import {
   getStoragePaths,
   saveMeta,
   loadMeta,
-  ensureGitNexusInternalGitignore,
+  ensureGitNexusIgnored,
   registerRepo,
   cleanupOldKuzuFiles,
 } from '../storage/repo-manager.js';
@@ -166,7 +166,7 @@ export async function runFullAnalysis(
   if (existingMeta && !options.force && existingMeta.lastCommit === currentCommit) {
     // Non-git folders have currentCommit = '' — always rebuild since we can't detect changes
     if (currentCommit !== '') {
-      await ensureGitNexusInternalGitignore(repoPath);
+      await ensureGitNexusIgnored(repoPath);
       return {
         repoName: options.registryName ?? getInferredRepoName(repoPath) ?? path.basename(repoPath),
         repoPath,
@@ -450,7 +450,7 @@ export async function runFullAnalysis(
 
     // Keep generated .gitnexus contents ignored without editing the user's root .gitignore.
     if (hasGitDir(repoPath)) {
-      await ensureGitNexusInternalGitignore(repoPath);
+      await ensureGitNexusIgnored(repoPath);
     }
 
     // ── Generate AI context files (best-effort) ───────────────────────

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -26,7 +26,7 @@ import {
   getStoragePaths,
   saveMeta,
   loadMeta,
-  addToGitignore,
+  ensureGitNexusInternalGitignore,
   registerRepo,
   cleanupOldKuzuFiles,
 } from '../storage/repo-manager.js';
@@ -166,6 +166,7 @@ export async function runFullAnalysis(
   if (existingMeta && !options.force && existingMeta.lastCommit === currentCommit) {
     // Non-git folders have currentCommit = '' — always rebuild since we can't detect changes
     if (currentCommit !== '') {
+      await ensureGitNexusInternalGitignore(repoPath);
       return {
         repoName: options.registryName ?? getInferredRepoName(repoPath) ?? path.basename(repoPath),
         repoPath,
@@ -447,9 +448,9 @@ export async function runFullAnalysis(
       allowDuplicateName: options.allowDuplicateName,
     });
 
-    // Only attempt to update .gitignore when a .git directory is present.
+    // Keep generated .gitnexus contents ignored without editing the user's root .gitignore.
     if (hasGitDir(repoPath)) {
-      await addToGitignore(repoPath);
+      await ensureGitNexusInternalGitignore(repoPath);
     }
 
     // ── Generate AI context files (best-effort) ───────────────────────

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -96,6 +96,7 @@ export interface RegistryEntry {
 }
 
 const GITNEXUS_DIR = '.gitnexus';
+const GITNEXUS_EXCLUDE_ENTRY = `${GITNEXUS_DIR}/`;
 
 // ─── Local Storage Helpers ─────────────────────────────────────────────
 
@@ -240,11 +241,43 @@ export const findRepo = async (startPath: string): Promise<IndexedRepo | null> =
 /**
  * Keep generated index files ignored without modifying the user's root .gitignore.
  */
-export const ensureGitNexusInternalGitignore = async (repoPath: string): Promise<void> => {
+export const ensureGitNexusIgnored = async (repoPath: string): Promise<void> => {
   const gitignorePath = path.join(getStoragePath(repoPath), '.gitignore');
 
   await fs.mkdir(path.dirname(gitignorePath), { recursive: true });
   await fs.writeFile(gitignorePath, '*\n', 'utf-8');
+
+  await ensureGitInfoExclude(repoPath);
+};
+
+const ensureGitInfoExclude = async (repoPath: string): Promise<void> => {
+  const gitDirPath = path.join(path.resolve(repoPath), '.git');
+  const excludePath = path.join(gitDirPath, 'info', 'exclude');
+
+  try {
+    const gitDir = await fs.stat(gitDirPath);
+    if (!gitDir.isDirectory()) return;
+  } catch {
+    return;
+  }
+
+  await fs.mkdir(path.dirname(excludePath), { recursive: true });
+
+  let content = '';
+  try {
+    content = await fs.readFile(excludePath, 'utf-8');
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') throw err;
+  }
+
+  const excludes = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+  if (excludes.includes(GITNEXUS_DIR) || excludes.includes(GITNEXUS_EXCLUDE_ENTRY)) return;
+
+  const separator = content.length === 0 || content.endsWith('\n') ? '' : '\n';
+  await fs.writeFile(excludePath, `${content}${separator}${GITNEXUS_EXCLUDE_ENTRY}\n`, 'utf-8');
 };
 
 // ─── Global Registry (~/.gitnexus/registry.json) ───────────────────────

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -238,23 +238,13 @@ export const findRepo = async (startPath: string): Promise<IndexedRepo | null> =
 };
 
 /**
- * Add .gitnexus to .gitignore if not already present
+ * Keep generated index files ignored without modifying the user's root .gitignore.
  */
-export const addToGitignore = async (repoPath: string): Promise<void> => {
-  const gitignorePath = path.join(repoPath, '.gitignore');
+export const ensureGitNexusInternalGitignore = async (repoPath: string): Promise<void> => {
+  const gitignorePath = path.join(getStoragePath(repoPath), '.gitignore');
 
-  try {
-    const content = await fs.readFile(gitignorePath, 'utf-8');
-    if (content.includes(GITNEXUS_DIR)) return;
-
-    const newContent = content.endsWith('\n')
-      ? `${content}${GITNEXUS_DIR}\n`
-      : `${content}\n${GITNEXUS_DIR}\n`;
-    await fs.writeFile(gitignorePath, newContent, 'utf-8');
-  } catch {
-    // .gitignore doesn't exist, create it
-    await fs.writeFile(gitignorePath, `${GITNEXUS_DIR}\n`, 'utf-8');
-  }
+  await fs.mkdir(path.dirname(gitignorePath), { recursive: true });
+  await fs.writeFile(gitignorePath, '*\n', 'utf-8');
 };
 
 // ─── Global Registry (~/.gitnexus/registry.json) ───────────────────────

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -198,6 +198,8 @@ describe('CLI end-to-end', () => {
     const gitnexusDir = path.join(MINI_REPO, '.gitnexus');
     expect(fs.existsSync(gitnexusDir)).toBe(true);
     expect(fs.statSync(gitnexusDir).isDirectory()).toBe(true);
+    expect(fs.existsSync(path.join(MINI_REPO, '.gitignore'))).toBe(false);
+    expect(fs.readFileSync(path.join(gitnexusDir, '.gitignore'), 'utf-8')).toBe('*\n');
   }, 60_000);
 
   // Regression guard for issue #1169 — analyze must produce BOTH a

--- a/gitnexus/test/unit/index-repo-command.test.ts
+++ b/gitnexus/test/unit/index-repo-command.test.ts
@@ -5,7 +5,7 @@ const mockAccess = vi.fn();
 const mockGetStoragePaths = vi.fn();
 const mockLoadMeta = vi.fn();
 const mockRegisterRepo = vi.fn();
-const mockAddToGitignore = vi.fn();
+const mockEnsureGitNexusInternalGitignore = vi.fn();
 const mockGetGitRoot = vi.fn();
 const mockIsGitRepo = vi.fn();
 
@@ -19,7 +19,7 @@ vi.mock('../../src/storage/repo-manager.js', () => ({
   getStoragePaths: mockGetStoragePaths,
   loadMeta: mockLoadMeta,
   registerRepo: mockRegisterRepo,
-  addToGitignore: mockAddToGitignore,
+  ensureGitNexusInternalGitignore: mockEnsureGitNexusInternalGitignore,
 }));
 
 vi.mock('../../src/storage/git.js', () => ({
@@ -53,7 +53,7 @@ describe('indexCommand', () => {
       stats: { nodes: 10, edges: 20 },
     });
     mockAccess.mockResolvedValue(undefined);
-    mockAddToGitignore.mockResolvedValue(undefined);
+    mockEnsureGitNexusInternalGitignore.mockResolvedValue(undefined);
     mockGetGitRoot.mockReturnValue(resolvedRepo);
     mockIsGitRepo.mockReturnValue(true);
   });
@@ -134,8 +134,8 @@ describe('indexCommand', () => {
       resolvedRepo,
       expect.objectContaining({ repoPath: resolvedRepo }),
     );
-    expect(mockAddToGitignore).toHaveBeenCalledTimes(1);
-    expect(mockAddToGitignore).toHaveBeenCalledWith(resolvedRepo);
+    expect(mockEnsureGitNexusInternalGitignore).toHaveBeenCalledTimes(1);
+    expect(mockEnsureGitNexusInternalGitignore).toHaveBeenCalledWith(resolvedRepo);
     expect(process.exitCode).toBeUndefined();
   });
 
@@ -170,7 +170,7 @@ describe('indexCommand', () => {
       resolvedRepo,
       expect.objectContaining({ repoPath: resolvedRepo }),
     );
-    expect(mockAddToGitignore).toHaveBeenCalledWith(resolvedRepo);
+    expect(mockEnsureGitNexusInternalGitignore).toHaveBeenCalledWith(resolvedRepo);
     expect(process.exitCode).toBeUndefined();
   });
 
@@ -189,7 +189,7 @@ describe('indexCommand', () => {
     await indexCommand(['/repo', '/other']);
 
     expect(mockRegisterRepo).not.toHaveBeenCalled();
-    expect(mockAddToGitignore).not.toHaveBeenCalled();
+    expect(mockEnsureGitNexusInternalGitignore).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
     expect(logSpy).toHaveBeenCalledWith('  The `index` command accepts a single path only.');
   });

--- a/gitnexus/test/unit/index-repo-command.test.ts
+++ b/gitnexus/test/unit/index-repo-command.test.ts
@@ -5,7 +5,7 @@ const mockAccess = vi.fn();
 const mockGetStoragePaths = vi.fn();
 const mockLoadMeta = vi.fn();
 const mockRegisterRepo = vi.fn();
-const mockEnsureGitNexusInternalGitignore = vi.fn();
+const mockEnsureGitNexusIgnored = vi.fn();
 const mockGetGitRoot = vi.fn();
 const mockIsGitRepo = vi.fn();
 
@@ -19,7 +19,7 @@ vi.mock('../../src/storage/repo-manager.js', () => ({
   getStoragePaths: mockGetStoragePaths,
   loadMeta: mockLoadMeta,
   registerRepo: mockRegisterRepo,
-  ensureGitNexusInternalGitignore: mockEnsureGitNexusInternalGitignore,
+  ensureGitNexusIgnored: mockEnsureGitNexusIgnored,
 }));
 
 vi.mock('../../src/storage/git.js', () => ({
@@ -53,7 +53,7 @@ describe('indexCommand', () => {
       stats: { nodes: 10, edges: 20 },
     });
     mockAccess.mockResolvedValue(undefined);
-    mockEnsureGitNexusInternalGitignore.mockResolvedValue(undefined);
+    mockEnsureGitNexusIgnored.mockResolvedValue(undefined);
     mockGetGitRoot.mockReturnValue(resolvedRepo);
     mockIsGitRepo.mockReturnValue(true);
   });
@@ -134,8 +134,8 @@ describe('indexCommand', () => {
       resolvedRepo,
       expect.objectContaining({ repoPath: resolvedRepo }),
     );
-    expect(mockEnsureGitNexusInternalGitignore).toHaveBeenCalledTimes(1);
-    expect(mockEnsureGitNexusInternalGitignore).toHaveBeenCalledWith(resolvedRepo);
+    expect(mockEnsureGitNexusIgnored).toHaveBeenCalledTimes(1);
+    expect(mockEnsureGitNexusIgnored).toHaveBeenCalledWith(resolvedRepo);
     expect(process.exitCode).toBeUndefined();
   });
 
@@ -170,7 +170,7 @@ describe('indexCommand', () => {
       resolvedRepo,
       expect.objectContaining({ repoPath: resolvedRepo }),
     );
-    expect(mockEnsureGitNexusInternalGitignore).toHaveBeenCalledWith(resolvedRepo);
+    expect(mockEnsureGitNexusIgnored).toHaveBeenCalledWith(resolvedRepo);
     expect(process.exitCode).toBeUndefined();
   });
 
@@ -189,7 +189,7 @@ describe('indexCommand', () => {
     await indexCommand(['/repo', '/other']);
 
     expect(mockRegisterRepo).not.toHaveBeenCalled();
-    expect(mockEnsureGitNexusInternalGitignore).not.toHaveBeenCalled();
+    expect(mockEnsureGitNexusIgnored).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
     expect(logSpy).toHaveBeenCalledWith('  The `index` command accepts a single path only.');
   });

--- a/gitnexus/test/unit/repo-manager.test.ts
+++ b/gitnexus/test/unit/repo-manager.test.ts
@@ -11,7 +11,7 @@ import fs from 'fs/promises';
 import {
   getStoragePath,
   getStoragePaths,
-  ensureGitNexusInternalGitignore,
+  ensureGitNexusIgnored,
   readRegistry,
   loadCLIConfig,
   registerRepo,
@@ -63,9 +63,9 @@ describe('getStoragePaths', () => {
   });
 });
 
-// ─── Internal .gitnexus/.gitignore (#1233) ─────────────────────────────
+// ─── GitNexus ignore rules (#1233) ─────────────────────────────────────
 
-describe('ensureGitNexusInternalGitignore (#1233)', () => {
+describe('ensureGitNexusIgnored (#1233)', () => {
   let tmpRepo: Awaited<ReturnType<typeof createTempDir>>;
 
   beforeEach(async () => {
@@ -77,7 +77,7 @@ describe('ensureGitNexusInternalGitignore (#1233)', () => {
   });
 
   it('creates .gitnexus/.gitignore containing a catch-all ignore rule', async () => {
-    await ensureGitNexusInternalGitignore(tmpRepo.dbPath);
+    await ensureGitNexusIgnored(tmpRepo.dbPath);
 
     await expect(
       fs.readFile(path.join(tmpRepo.dbPath, '.gitnexus', '.gitignore'), 'utf-8'),
@@ -88,9 +88,39 @@ describe('ensureGitNexusInternalGitignore (#1233)', () => {
     const rootGitignorePath = path.join(tmpRepo.dbPath, '.gitignore');
     await fs.writeFile(rootGitignorePath, 'node_modules/\n');
 
-    await ensureGitNexusInternalGitignore(tmpRepo.dbPath);
+    await ensureGitNexusIgnored(tmpRepo.dbPath);
 
     await expect(fs.readFile(rootGitignorePath, 'utf-8')).resolves.toBe('node_modules/\n');
+  });
+
+  it('adds .gitnexus/ to .git/info/exclude when the repo has a real .git directory', async () => {
+    const excludePath = path.join(tmpRepo.dbPath, '.git', 'info', 'exclude');
+    await fs.mkdir(path.dirname(excludePath), { recursive: true });
+
+    await ensureGitNexusIgnored(tmpRepo.dbPath);
+
+    await expect(fs.readFile(excludePath, 'utf-8')).resolves.toBe('.gitnexus/\n');
+  });
+
+  it('appends .gitnexus/ to .git/info/exclude once without disturbing existing rules', async () => {
+    const excludePath = path.join(tmpRepo.dbPath, '.git', 'info', 'exclude');
+    await fs.mkdir(path.dirname(excludePath), { recursive: true });
+    await fs.writeFile(excludePath, '# local excludes\nnode_modules/\n');
+
+    await ensureGitNexusIgnored(tmpRepo.dbPath);
+    await ensureGitNexusIgnored(tmpRepo.dbPath);
+
+    await expect(fs.readFile(excludePath, 'utf-8')).resolves.toBe(
+      '# local excludes\nnode_modules/\n.gitnexus/\n',
+    );
+  });
+
+  it('does not create .git/info/exclude when .git is not a directory', async () => {
+    await fs.writeFile(path.join(tmpRepo.dbPath, '.git'), 'gitdir: ../real-git-dir\n');
+
+    await ensureGitNexusIgnored(tmpRepo.dbPath);
+
+    await expect(fs.access(path.join(tmpRepo.dbPath, '.git', 'info', 'exclude'))).rejects.toThrow();
   });
 
   it('keeps generated .gitnexus files out of git status', async () => {
@@ -100,7 +130,7 @@ describe('ensureGitNexusInternalGitignore (#1233)', () => {
       stdio: 'pipe',
     });
 
-    await ensureGitNexusInternalGitignore(tmpRepo.dbPath);
+    await ensureGitNexusIgnored(tmpRepo.dbPath);
     await fs.writeFile(path.join(tmpRepo.dbPath, '.gitnexus', 'meta.json'), '{}\n');
 
     const status = execSync('git status --short', {

--- a/gitnexus/test/unit/repo-manager.test.ts
+++ b/gitnexus/test/unit/repo-manager.test.ts
@@ -11,6 +11,7 @@ import fs from 'fs/promises';
 import {
   getStoragePath,
   getStoragePaths,
+  ensureGitNexusInternalGitignore,
   readRegistry,
   loadCLIConfig,
   registerRepo,
@@ -59,6 +60,54 @@ describe('getStoragePaths', () => {
     const paths = getStoragePaths('/home/user/project');
     expect(paths.lbugPath.startsWith(paths.storagePath)).toBe(true);
     expect(paths.metaPath.startsWith(paths.storagePath)).toBe(true);
+  });
+});
+
+// ─── Internal .gitnexus/.gitignore (#1233) ─────────────────────────────
+
+describe('ensureGitNexusInternalGitignore (#1233)', () => {
+  let tmpRepo: Awaited<ReturnType<typeof createTempDir>>;
+
+  beforeEach(async () => {
+    tmpRepo = await createTempDir('gitnexus-internal-gitignore-');
+  });
+
+  afterEach(async () => {
+    await tmpRepo.cleanup();
+  });
+
+  it('creates .gitnexus/.gitignore containing a catch-all ignore rule', async () => {
+    await ensureGitNexusInternalGitignore(tmpRepo.dbPath);
+
+    await expect(
+      fs.readFile(path.join(tmpRepo.dbPath, '.gitnexus', '.gitignore'), 'utf-8'),
+    ).resolves.toBe('*\n');
+  });
+
+  it('does not create or modify the repository root .gitignore', async () => {
+    const rootGitignorePath = path.join(tmpRepo.dbPath, '.gitignore');
+    await fs.writeFile(rootGitignorePath, 'node_modules/\n');
+
+    await ensureGitNexusInternalGitignore(tmpRepo.dbPath);
+
+    await expect(fs.readFile(rootGitignorePath, 'utf-8')).resolves.toBe('node_modules/\n');
+  });
+
+  it('keeps generated .gitnexus files out of git status', async () => {
+    execSync('git init', { cwd: tmpRepo.dbPath, stdio: 'pipe' });
+    execSync('git -c user.name=test -c user.email=test@test commit --allow-empty -m init', {
+      cwd: tmpRepo.dbPath,
+      stdio: 'pipe',
+    });
+
+    await ensureGitNexusInternalGitignore(tmpRepo.dbPath);
+    await fs.writeFile(path.join(tmpRepo.dbPath, '.gitnexus', 'meta.json'), '{}\n');
+
+    const status = execSync('git status --short', {
+      cwd: tmpRepo.dbPath,
+      encoding: 'utf-8',
+    });
+    expect(status).toBe('');
   });
 });
 

--- a/gitnexus/test/unit/run-analyze.test.ts
+++ b/gitnexus/test/unit/run-analyze.test.ts
@@ -1,5 +1,10 @@
+import { execSync } from 'child_process';
+import fs from 'fs/promises';
+import path from 'path';
 import { describe, it, expect } from 'vitest';
 import { deriveEmbeddingMode } from '../../src/core/embedding-mode.js';
+import { getStoragePaths, saveMeta, type RepoMeta } from '../../src/storage/repo-manager.js';
+import { createTempDir } from '../helpers/test-db.js';
 
 describe('run-analyze module', () => {
   it('exports runFullAnalysis as a function', async () => {
@@ -11,6 +16,44 @@ describe('run-analyze module', () => {
     const mod = await import('../../src/core/run-analyze.js');
     expect(mod.PHASE_LABELS).toBeDefined();
     expect(mod.PHASE_LABELS.parsing).toBe('Parsing code');
+  });
+
+  it('creates .gitnexus/.gitignore on the already-up-to-date fast path (#1233)', async () => {
+    const tmpRepo = await createTempDir('gitnexus-run-analyze-fast-path-');
+    try {
+      execSync('git init', { cwd: tmpRepo.dbPath, stdio: 'pipe' });
+      execSync('git -c user.name=test -c user.email=test@test commit --allow-empty -m init', {
+        cwd: tmpRepo.dbPath,
+        stdio: 'pipe',
+      });
+      const currentCommit = execSync('git rev-parse HEAD', {
+        cwd: tmpRepo.dbPath,
+        encoding: 'utf-8',
+      }).trim();
+      const { storagePath } = getStoragePaths(tmpRepo.dbPath);
+      const meta: RepoMeta = {
+        repoPath: tmpRepo.dbPath,
+        lastCommit: currentCommit,
+        indexedAt: new Date().toISOString(),
+      };
+      await saveMeta(storagePath, meta);
+
+      const { runFullAnalysis } = await import('../../src/core/run-analyze.js');
+      const result = await runFullAnalysis(
+        tmpRepo.dbPath,
+        {},
+        {
+          onProgress: () => {},
+        },
+      );
+
+      expect(result.alreadyUpToDate).toBe(true);
+      await expect(
+        fs.readFile(path.join(tmpRepo.dbPath, '.gitnexus', '.gitignore'), 'utf-8'),
+      ).resolves.toBe('*\n');
+    } finally {
+      await tmpRepo.cleanup();
+    }
   });
 });
 

--- a/gitnexus/test/unit/skip-git-cli.test.ts
+++ b/gitnexus/test/unit/skip-git-cli.test.ts
@@ -40,18 +40,19 @@ describe('--skip-git CLI flag', () => {
   describe('--skip-git does not walk up to parent git repo (#1232)', () => {
     const cliPath = path.resolve(__dirname, '../../dist/cli/index.js');
     let parentDir: string;
+    let gitnexusHome: string;
 
     function testEnv() {
       return {
         ...process.env,
         HOME: parentDir,
-        GITNEXUS_HOME: path.join(parentDir, '.gitnexus-home'),
+        GITNEXUS_HOME: gitnexusHome,
         GITNEXUS_LBUG_EXTENSION_INSTALL: 'never',
       };
     }
 
     function readRegistry(): Array<{ name: string; path: string }> {
-      const registryPath = path.join(parentDir, '.gitnexus-home', 'registry.json');
+      const registryPath = path.join(gitnexusHome, 'registry.json');
       expect(fs.existsSync(registryPath)).toBe(true);
       return JSON.parse(fs.readFileSync(registryPath, 'utf8'));
     }
@@ -99,6 +100,7 @@ describe('--skip-git CLI flag', () => {
       //       package.json
       //       src/index.ts
       parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-skip-git-'));
+      gitnexusHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-skip-git-home-'));
       initParentGitRepo();
       fs.mkdirSync(path.join(parentDir, 'COOLIO', 'src'), { recursive: true });
       fs.writeFileSync(
@@ -125,6 +127,9 @@ describe('--skip-git CLI flag', () => {
       if (parentDir) {
         fs.rmSync(parentDir, { recursive: true, force: true });
       }
+      if (gitnexusHome) {
+        fs.rmSync(gitnexusHome, { recursive: true, force: true });
+      }
     }
 
     it('from subdir inside parent git repo, indexes subdir not parent', () => {
@@ -150,6 +155,36 @@ describe('--skip-git CLI flag', () => {
         });
         expect(siblingQuery).not.toContain('SubWooder');
         expect(siblingQuery).not.toContain('bass');
+      } finally {
+        cleanup();
+      }
+    });
+
+    it('keeps parent git status clean for --skip-git subdir analyze (#1233)', () => {
+      createTestStructure();
+      try {
+        fs.writeFileSync(path.join(parentDir, '.gitignore'), '.claude/\n');
+        execSync('git add .gitignore COOLIO SubWooder', { cwd: parentDir, stdio: 'ignore' });
+        execSync('git -c user.name=test -c user.email=test@example.com commit -m fixtures', {
+          cwd: parentDir,
+          stdio: 'ignore',
+        });
+
+        execSync(`node "${cliPath}" analyze --skip-git --skip-agents-md`, {
+          cwd: path.join(parentDir, 'COOLIO'),
+          encoding: 'utf8',
+          timeout: 60000,
+          env: testEnv(),
+        });
+
+        expect(
+          fs.readFileSync(path.join(parentDir, 'COOLIO', '.gitnexus', '.gitignore'), 'utf8'),
+        ).toBe('*\n');
+        const status = execSync('git status --short', {
+          cwd: parentDir,
+          encoding: 'utf8',
+        });
+        expect(status).toBe('');
       } finally {
         cleanup();
       }


### PR DESCRIPTION
## Summary
- Stop mutating analyzed repositories' root `.gitignore` during `analyze` and `index`.
- Create `.gitnexus/.gitignore` with `*` so generated GitNexus storage stays untracked from inside the storage directory.
- Cover full analyze, index, and already-up-to-date analyze fast-path behavior.

Closes #1233

## Test plan
- `cd gitnexus && npx prettier --check src/storage/repo-manager.ts src/core/run-analyze.ts src/cli/index-repo.ts test/unit/repo-manager.test.ts test/unit/index-repo-command.test.ts test/unit/run-analyze.test.ts test/integration/cli-e2e.test.ts`
- `cd gitnexus && npx vitest run test/unit/repo-manager.test.ts test/unit/index-repo-command.test.ts test/unit/run-analyze.test.ts test/integration/cli-e2e.test.ts -t "ensureGitNexusInternalGitignore|already-up-to-date|analyze command runs pipeline|registers successfully"`
- `cd gitnexus && npx tsc --noEmit`
- `cd gitnexus && npm test` (final rerun passed: 254 files, 7505 tests)
- `cd gitnexus && npx tsx src/cli/index.ts detect-changes --repo GitNexus` (low risk, 0 affected processes)