### PR TITLE
fix(mcp): pass numeric exit codes to shutdown on SIGINT/SIGTERM (#1132)

### DIFF
--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -313,9 +313,19 @@ export async function startMCPServer(backend: LocalBackend): Promise<void> {
     process.exit(exitCode);
   };
 
-  // Handle graceful shutdown
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  // Handle graceful shutdown.
+  //
+  // Wrap `shutdown` so the signal handler doesn't pass Node's signal NAME
+  // (string) into `shutdown`'s `exitCode` parameter (#1132). When the signal
+  // arg flowed through unchanged it landed in `process.exit('SIGTERM')`,
+  // which throws TypeError [ERR_INVALID_ARG_TYPE] ("The 'code' argument must
+  // be of type number") and crashes the MCP server immediately on shutdown.
+  //
+  // POSIX-conventional codes (`128 + signal-number`) communicate
+  // signal-driven termination to monitoring/orchestration: SIGINT=2 → 130,
+  // SIGTERM=15 → 143.
+  process.on('SIGINT', () => shutdown(130));
+  process.on('SIGTERM', () => shutdown(143));
 
   // Log crashes to stderr so they aren't silently lost.
   // uncaughtException is fatal — shut down.


### PR DESCRIPTION
## Summary

Reported in #1132 by @CommanderwinSmile: the GitNexus MCP server crashes immediately on receipt of any termination signal with `TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type string ('SIGTERM')`. This breaks every MCP client that expects the server to start and remain running — they see the immediate crash as a startup failure and time out.

## Root cause

`gitnexus/src/mcp/server.ts:317–318`:

```ts
const shutdown = async (exitCode = 0) => { ...; process.exit(exitCode); };
process.on('SIGINT', shutdown);
process.on('SIGTERM', shutdown);
```

When the signal fires, Node passes the **signal name string** (`'SIGTERM'`) as the first argument to the registered listener. `shutdown` accepts `exitCode = 0` as its first parameter, so it becomes `exitCode = 'SIGTERM'`, and `process.exit('SIGTERM')` throws because Node's `process.exit` requires a number (`0–255`).

Reproducible on `1.6.1`, `1.6.4-rc.18`, and `1.6.4-rc.32` (current `main` head).

## Fix

Wrap the handlers so each signal maps to its **POSIX-conventional exit code** (`128 + signal-number`):

```diff
- process.on('SIGINT', shutdown);
- process.on('SIGTERM', shutdown);
+ process.on('SIGINT', () => shutdown(130));   // 128 + SIGINT=2
+ process.on('SIGTERM', () => shutdown(143));  // 128 + SIGTERM=15
```

These are the same codes a POSIX shell synthesises when a child is killed by the corresponding signal, so monitoring / orchestration systems can distinguish signal-driven termination from a clean `exit(0)` and from generic errors.

A comment block in the source explains the bug and the convention so the next contributor doesn't accidentally regress it back to bare `shutdown` references.

## Why no unit test

The bug is **signal-handler wiring**, not logic. Reasonable test approaches both fail the cost/benefit bar:

- **Spawning the MCP CLI as a child process and sending SIGTERM** — heavyweight integration test for a 2-line wiring fix; would slow the unit suite and depend on platform signal semantics.
- **Mocking `process.on` and `process.exit` to capture the handler** — invasive, brittle, and would essentially re-implement the wiring inside the test rather than verify it.

The correctness is provable by code review: the handlers now wrap `shutdown` with explicit numeric exit codes; no path forwards the signal name string into `shutdown`'s `exitCode` parameter. Reporter independently arrived at the same fix shape (`process.exit(143)`) by inspection.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | ✅ clean |
| `npm run test:unit` (full) | ✅ 4819 passed / 10 skipped |
| Failures | 4 pre-existing env failures on `upstream/main` (2× `git-utils.test.ts` Windows tmpdir + 2× `skip-git-cli.test.ts` from #1232/#1233 lifecycle) — verified pre-fix on a clean tree, identical 4. None related to this change. |

## Why this is safe

| Property | Status |
|---|---|
| **Scope** | 1 file, 2 lines of code (+ comment) |
| **Backward compatibility** | ✅ — `shutdown()` callers (none currently) and graceful-exit semantics unchanged. The only changed behaviour is *not crashing* on the signal path. |
| **Cross-platform** | ✅ POSIX exit codes are conventional on macOS/Linux; Windows ignores the specific value but no longer crashes. |
| **No public API change** | ✅ `startMCPServer` / `shutdown` signatures unchanged. |
| **No GUARDRAILS non-negotiable touched** | ✅ no destructive ops, no native bindings, no embeddings policy, no registry writes. |

Closes #1132.