### PR TITLE
fix(detect-changes): remove symbol and process list truncation

### DIFF
--- a/gitnexus/src/cli/tool.ts
+++ b/gitnexus/src/cli/tool.ts
@@ -182,11 +182,8 @@ function formatDetectChangesResult(result: any): string {
   const changed = result?.changed_symbols || [];
   if (changed.length > 0) {
     lines.push('Changed symbols:');
-    for (const symbol of changed.slice(0, 15)) {
+    for (const symbol of changed) {
       lines.push(`  ${symbol.type} ${symbol.name} → ${symbol.filePath}`);
-    }
-    if (changed.length > 15) {
-      lines.push(`  ... and ${changed.length - 15} more`);
     }
     lines.push('');
   }
@@ -194,7 +191,7 @@ function formatDetectChangesResult(result: any): string {
   const affected = result?.affected_processes || [];
   if (affected.length > 0) {
     lines.push('Affected execution flows:');
-    for (const processInfo of affected.slice(0, 10)) {
+    for (const processInfo of affected) {
       const steps = (processInfo.changed_steps || []).map((s: any) => s.symbol).join(', ');
       lines.push(`  • ${processInfo.name} (${processInfo.step_count} steps) — changed: ${steps}`);
     }


### PR DESCRIPTION
## Problem

`formatDetectChanges` capped the output at **15 symbols** and **10 affected processes**, appending `... and N more` for the rest. AI agents that consume this output (e.g. ymir) received an incomplete picture of what changed.

## Fix

Remove both `slice(0, 15)` / `slice(0, 10)` limits and the trailing `... and N more` line so the full lists are always emitted.

## Changes

- `gitnexus/src/cli/tool.ts`: removed truncation for `changed_symbols` (was 15) and `affected_processes` (was 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)