### PR TITLE
feat(bash): add Bash language support

### DIFF
--- a/gitnexus-shared/src/language-detection.ts
+++ b/gitnexus-shared/src/language-detection.ts
@@ -41,6 +41,7 @@ const EXTENSION_MAP: Record<SupportedLanguages, readonly string[]> = {
   [SupportedLanguages.Kotlin]: ['.kt', '.kts'],
   [SupportedLanguages.Swift]: ['.swift'],
   [SupportedLanguages.Dart]: ['.dart'],
+  [SupportedLanguages.Bash]: ['.sh', '.bash'],
   [SupportedLanguages.Vue]: ['.vue'],
   [SupportedLanguages.Cobol]: ['.cbl', '.cob', '.cpy', '.cobol'],
 } satisfies Record<SupportedLanguages, readonly string[]>; // Ensure exhaustiveness
@@ -99,6 +100,7 @@ const SYNTAX_MAP: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Kotlin]: 'kotlin',
   [SupportedLanguages.Swift]: 'swift',
   [SupportedLanguages.Dart]: 'dart',
+  [SupportedLanguages.Bash]: 'bash',
   [SupportedLanguages.Vue]: 'typescript',
   [SupportedLanguages.Cobol]: 'cobol',
 } satisfies Record<SupportedLanguages, string>; // Ensure exhaustiveness

--- a/gitnexus-shared/src/languages.ts
+++ b/gitnexus-shared/src/languages.ts
@@ -20,6 +20,7 @@ export enum SupportedLanguages {
   Swift = 'swift',
   Dart = 'dart',
   Vue = 'vue',
+  Bash = 'bash',
   /** Standalone regex processor — no tree-sitter, no LanguageProvider. */
   Cobol = 'cobol',
 }

--- a/gitnexus-shared/src/scope-resolution/language-classification.ts
+++ b/gitnexus-shared/src/scope-resolution/language-classification.ts
@@ -39,6 +39,7 @@ export const LanguageClassifications: Readonly<Record<SupportedLanguages, Langua
     [SupportedLanguages.Kotlin]: 'production',
     [SupportedLanguages.Swift]: 'production',
     [SupportedLanguages.Dart]: 'production',
+    [SupportedLanguages.Bash]: 'experimental',
     [SupportedLanguages.Vue]: 'experimental',
     [SupportedLanguages.Cobol]: 'experimental',
   };

--- a/gitnexus/src/core/ingestion/call-extractors/configs/bash.ts
+++ b/gitnexus/src/core/ingestion/call-extractors/configs/bash.ts
@@ -1,0 +1,6 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { CallExtractionConfig } from '../../call-types.js';
+
+export const bashCallConfig: CallExtractionConfig = {
+  language: SupportedLanguages.Bash,
+};

--- a/gitnexus/src/core/ingestion/class-extractors/configs/bash.ts
+++ b/gitnexus/src/core/ingestion/class-extractors/configs/bash.ts
@@ -1,0 +1,8 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { ClassExtractionConfig } from '../../class-types.js';
+
+export const bashClassConfig: ClassExtractionConfig = {
+  language: SupportedLanguages.Bash,
+  typeDeclarationNodes: [],
+  fileScopeNodeTypes: ['program'],
+};

--- a/gitnexus/src/core/ingestion/entry-point-scoring.ts
+++ b/gitnexus/src/core/ingestion/entry-point-scoring.ts
@@ -226,6 +226,7 @@ export const ENTRY_POINT_PATTERNS = {
     /^onEvent$/, // BLoC event handler
     /^mapEventToState$/, // Legacy BLoC pattern
   ],
+  [SupportedLanguages.Bash]: [/^main$/],
   [SupportedLanguages.Vue]: [], // Vue uses TypeScript queries — entry points handled via TS patterns
   [SupportedLanguages.Cobol]: [], // Standalone regex processor — no tree-sitter entry points
 } satisfies Record<SupportedLanguages, RegExp[]>;

--- a/gitnexus/src/core/ingestion/export-detection.ts
+++ b/gitnexus/src/core/ingestion/export-detection.ts
@@ -246,3 +246,6 @@ export const rubyExportChecker: ExportChecker = (_node, _name) => true;
 
 /** Dart: public if no leading underscore (convention, same as Python). */
 export const dartExportChecker: ExportChecker = (_node, name) => !name.startsWith('_');
+
+/** Bash: all definitions are public (no visibility modifiers in shell). */
+export const bashExportChecker: ExportChecker = (_node, _name) => true;

--- a/gitnexus/src/core/ingestion/field-extractors/configs/bash.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/configs/bash.ts
@@ -1,0 +1,26 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { FieldExtractionConfig } from '../generic.js';
+
+export const bashFieldConfig: FieldExtractionConfig = {
+  language: SupportedLanguages.Bash,
+  typeDeclarationNodes: [],
+  fieldNodeTypes: [],
+  bodyNodeTypes: [],
+  defaultVisibility: 'public',
+
+  extractName(_node) {
+    return undefined;
+  },
+  extractType(_node) {
+    return undefined;
+  },
+  extractVisibility(_node) {
+    return 'public';
+  },
+  isStatic(_node) {
+    return false;
+  },
+  isReadonly(_node) {
+    return false;
+  },
+};

--- a/gitnexus/src/core/ingestion/framework-detection.ts
+++ b/gitnexus/src/core/ingestion/framework-detection.ts
@@ -895,6 +895,7 @@ export const AST_FRAMEWORK_PATTERNS_BY_LANGUAGE = {
       patterns: FRAMEWORK_AST_PATTERNS.riverpod,
     },
   ],
+  [SupportedLanguages.Bash]: [],
   [SupportedLanguages.Vue]: [], // Vue uses TypeScript AST framework detection
   [SupportedLanguages.Cobol]: [], // Standalone regex processor — no AST framework patterns
 } satisfies Record<SupportedLanguages, AstFrameworkPatternConfig[]>;

--- a/gitnexus/src/core/ingestion/heritage-extractors/configs/bash.ts
+++ b/gitnexus/src/core/ingestion/heritage-extractors/configs/bash.ts
@@ -1,0 +1,6 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { HeritageExtractionConfig } from '../../heritage-types.js';
+
+export const bashHeritageConfig: HeritageExtractionConfig = {
+  language: SupportedLanguages.Bash,
+};

--- a/gitnexus/src/core/ingestion/import-resolvers/configs/bash.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/configs/bash.ts
@@ -1,0 +1,21 @@
+/**
+ * Bash import resolution config.
+ * Bash uses `source file.sh` or `. file.sh` to include other scripts.
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { ImportResolutionConfig, ImportResolverStrategy } from '../types.js';
+import { suffixResolve } from '../utils.js';
+
+export const bashSourceStrategy: ImportResolverStrategy = (rawImportPath, _filePath, ctx) => {
+  const cleanPath = rawImportPath.replace(/^['"]|['"]$/g, '').replace(/^\$\{.*\}\/?/, '');
+  if (!cleanPath) return null;
+  const pathParts = cleanPath.split('/').filter(Boolean);
+  const resolved = suffixResolve(pathParts, ctx.normalizedFileList, ctx.allFileList, ctx.index);
+  return resolved ? { kind: 'files', files: [resolved] } : null;
+};
+
+export const bashImportConfig: ImportResolutionConfig = {
+  language: SupportedLanguages.Bash,
+  strategies: [bashSourceStrategy],
+};

--- a/gitnexus/src/core/ingestion/import-resolvers/utils.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/utils.ts
@@ -47,6 +47,9 @@ export const EXTENSIONS = [
   '.swift',
   // Ruby
   '.rb',
+  // Bash
+  '.sh',
+  '.bash',
 ];
 
 /**

--- a/gitnexus/src/core/ingestion/languages/bash.ts
+++ b/gitnexus/src/core/ingestion/languages/bash.ts
@@ -1,0 +1,108 @@
+/**
+ * Bash Language Provider
+ *
+ * Key Bash traits:
+ *   - importSemantics: 'wildcard-leaf' (source brings everything into scope)
+ *   - No classes or OO constructs
+ *   - Functions defined with `function foo() {}` or `foo() {}`
+ *   - Variables are untyped (all strings)
+ *   - Imports via `source file.sh` or `. file.sh`
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import { createClassExtractor } from '../class-extractors/generic.js';
+import { bashClassConfig } from '../class-extractors/configs/bash.js';
+import { defineLanguage } from '../language-provider.js';
+import { typeConfig as bashConfig } from '../type-extractors/bash.js';
+import { bashExportChecker } from '../export-detection.js';
+import { createImportResolver } from '../import-resolvers/resolver-factory.js';
+import { bashImportConfig } from '../import-resolvers/configs/bash.js';
+import { BASH_QUERIES } from '../tree-sitter-queries.js';
+import { createFieldExtractor } from '../field-extractors/generic.js';
+import { bashFieldConfig } from '../field-extractors/configs/bash.js';
+import { createMethodExtractor } from '../method-extractors/generic.js';
+import { bashMethodConfig } from '../method-extractors/configs/bash.js';
+import { createVariableExtractor } from '../variable-extractors/generic.js';
+import { bashVariableConfig } from '../variable-extractors/configs/bash.js';
+import { createCallExtractor } from '../call-extractors/generic.js';
+import { bashCallConfig } from '../call-extractors/configs/bash.js';
+import { createHeritageExtractor } from '../heritage-extractors/generic.js';
+import { bashHeritageConfig } from '../heritage-extractors/configs/bash.js';
+
+const BUILT_INS: ReadonlySet<string> = new Set([
+  'echo',
+  'printf',
+  'read',
+  'cd',
+  'pwd',
+  'ls',
+  'cat',
+  'grep',
+  'sed',
+  'awk',
+  'find',
+  'xargs',
+  'sort',
+  'uniq',
+  'wc',
+  'head',
+  'tail',
+  'cut',
+  'tr',
+  'tee',
+  'test',
+  'true',
+  'false',
+  'exit',
+  'return',
+  'export',
+  'unset',
+  'local',
+  'declare',
+  'readonly',
+  'shift',
+  'set',
+  'eval',
+  'exec',
+  'trap',
+  'wait',
+  'kill',
+  'sleep',
+  'date',
+  'basename',
+  'dirname',
+  'mktemp',
+  'mkdir',
+  'rm',
+  'cp',
+  'mv',
+  'chmod',
+  'chown',
+  'touch',
+  'ln',
+  'which',
+  'command',
+  'type',
+  'hash',
+  'getopts',
+  'pushd',
+  'popd',
+  'dirs',
+]);
+
+export const bashProvider = defineLanguage({
+  id: SupportedLanguages.Bash,
+  extensions: ['.sh', '.bash'],
+  treeSitterQueries: BASH_QUERIES,
+  typeConfig: bashConfig,
+  exportChecker: bashExportChecker,
+  importResolver: createImportResolver(bashImportConfig),
+  importSemantics: 'wildcard-leaf',
+  callExtractor: createCallExtractor(bashCallConfig),
+  fieldExtractor: createFieldExtractor(bashFieldConfig),
+  methodExtractor: createMethodExtractor(bashMethodConfig),
+  variableExtractor: createVariableExtractor(bashVariableConfig),
+  classExtractor: createClassExtractor(bashClassConfig),
+  heritageExtractor: createHeritageExtractor(bashHeritageConfig),
+  builtInNames: BUILT_INS,
+});

--- a/gitnexus/src/core/ingestion/languages/index.ts
+++ b/gitnexus/src/core/ingestion/languages/index.ts
@@ -24,6 +24,7 @@ import { rubyProvider } from './ruby.js';
 import { swiftProvider } from './swift.js';
 import { dartProvider } from './dart.js';
 import { vueProvider } from './vue.js';
+import { bashProvider } from './bash.js';
 import { cobolProvider } from './cobol.js';
 
 export const providers = {
@@ -41,6 +42,7 @@ export const providers = {
   [SupportedLanguages.Ruby]: rubyProvider,
   [SupportedLanguages.Swift]: swiftProvider,
   [SupportedLanguages.Dart]: dartProvider,
+  [SupportedLanguages.Bash]: bashProvider,
   [SupportedLanguages.Vue]: vueProvider,
   [SupportedLanguages.Cobol]: cobolProvider,
 } satisfies Record<SupportedLanguages, LanguageProvider>;

--- a/gitnexus/src/core/ingestion/method-extractors/configs/bash.ts
+++ b/gitnexus/src/core/ingestion/method-extractors/configs/bash.ts
@@ -1,0 +1,38 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { MethodExtractionConfig, ParameterInfo } from '../../method-types.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+export const bashMethodConfig: MethodExtractionConfig = {
+  language: SupportedLanguages.Bash,
+  typeDeclarationNodes: [],
+  methodNodeTypes: ['function_definition'],
+  bodyNodeTypes: [],
+
+  extractName(node: SyntaxNode) {
+    return node.childForFieldName('name')?.text;
+  },
+
+  extractReturnType(_node) {
+    return undefined;
+  },
+
+  extractParameters(_node): ParameterInfo[] {
+    return [];
+  },
+
+  extractVisibility(_node) {
+    return 'public';
+  },
+
+  isStatic(_node) {
+    return false;
+  },
+
+  isAbstract(_node) {
+    return false;
+  },
+
+  isFinal(_node) {
+    return false;
+  },
+};

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -1373,6 +1373,23 @@ export const DART_QUERIES = `
       (type_identifier) @heritage.trait))) @heritage
 `;
 
+export const BASH_QUERIES = `
+; Functions: function foo() {} or foo() {}
+(function_definition name: (word) @name) @definition.function
+
+; Source imports: source file.sh or . file.sh
+(command
+  name: (command_name) @_cmd
+  argument: (_) @import.source
+  (#match? @_cmd "^(source|\\\\.)$")) @import
+
+; Command calls: foo args...
+(command name: (command_name (word) @call.name)) @call
+
+; Variable assignments: FOO=bar
+(variable_assignment name: (variable_name) @name) @definition.variable
+`;
+
 import { SupportedLanguages } from 'gitnexus-shared';
 
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
@@ -1390,6 +1407,7 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Ruby]: RUBY_QUERIES,
   [SupportedLanguages.Swift]: SWIFT_QUERIES,
   [SupportedLanguages.Dart]: DART_QUERIES,
+  [SupportedLanguages.Bash]: BASH_QUERIES,
   [SupportedLanguages.Vue]: TYPESCRIPT_QUERIES, // Vue <script> blocks are parsed as TypeScript
   [SupportedLanguages.Cobol]: '', // Standalone regex processor — no tree-sitter queries
 };

--- a/gitnexus/src/core/ingestion/type-extractors/bash.ts
+++ b/gitnexus/src/core/ingestion/type-extractors/bash.ts
@@ -1,0 +1,18 @@
+import type { SyntaxNode } from '../utils/ast-helpers.js';
+import type { LanguageTypeConfig, ParameterExtractor, TypeBindingExtractor } from './types.js';
+
+const extractDeclaration: TypeBindingExtractor = (
+  _node: SyntaxNode,
+  _env: Map<string, string>,
+): void => {};
+
+const extractParameter: ParameterExtractor = (
+  _node: SyntaxNode,
+  _env: Map<string, string>,
+): void => {};
+
+export const typeConfig: LanguageTypeConfig = {
+  declarationNodeTypes: new Set(['variable_assignment']),
+  extractDeclaration,
+  extractParameter,
+};

--- a/gitnexus/src/core/ingestion/variable-extractors/configs/bash.ts
+++ b/gitnexus/src/core/ingestion/variable-extractors/configs/bash.ts
@@ -1,0 +1,34 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { VariableExtractionConfig, VariableVisibility } from '../../variable-types.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+export const bashVariableConfig: VariableExtractionConfig = {
+  language: SupportedLanguages.Bash,
+  constNodeTypes: [],
+  staticNodeTypes: [],
+  variableNodeTypes: ['variable_assignment'],
+
+  extractName(node: SyntaxNode) {
+    return node.childForFieldName('name')?.text;
+  },
+
+  extractType(_node) {
+    return undefined;
+  },
+
+  extractVisibility(_node): VariableVisibility {
+    return 'public';
+  },
+
+  isConst(_node) {
+    return false;
+  },
+
+  isStatic(_node) {
+    return false;
+  },
+
+  isMutable(_node) {
+    return true;
+  },
+};

--- a/gitnexus/src/core/tree-sitter/parser-loader.ts
+++ b/gitnexus/src/core/tree-sitter/parser-loader.ts
@@ -153,6 +153,11 @@ const SOURCES: Record<string, GrammarSource> = {
       'Likely cause: native compile failed at install (missing python3/make/g++). ' +
       `See ${ISSUES_URL}/1125.`,
   },
+  [SupportedLanguages.Bash]: {
+    load: () => _require('tree-sitter-bash'),
+    unavailableNote:
+      'Bash parsing requires `tree-sitter-bash`. Check the install and native binding.',
+  },
   [SupportedLanguages.Kotlin]: {
     load: () => _require('tree-sitter-kotlin'),
     optional: true,

--- a/gitnexus/test/fixtures/lang-resolution/bash-app/lib/service.sh
+++ b/gitnexus/test/fixtures/lang-resolution/bash-app/lib/service.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source lib/utils.sh
+
+SERVICE_NAME="myapp"
+
+create_user() {
+	local name="$1"
+	local email="$2"
+	log_message "info" "Creating user: $name"
+	echo "$name:$email"
+}
+
+process_user() {
+	local user="$1"
+	local formatted
+	formatted=$(format_name "$user")
+	log_message "info" "Processed: $formatted"
+}

--- a/gitnexus/test/fixtures/lang-resolution/bash-app/lib/utils.sh
+++ b/gitnexus/test/fixtures/lang-resolution/bash-app/lib/utils.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+LOG_LEVEL="info"
+
+log_message() {
+	local level="$1"
+	local msg="$2"
+	echo "[$level] $msg"
+}
+
+format_name() {
+	local name="$1"
+	echo "${name^^}"
+}

--- a/gitnexus/test/fixtures/lang-resolution/bash-app/main.sh
+++ b/gitnexus/test/fixtures/lang-resolution/bash-app/main.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source lib/service.sh
+
+main() {
+	local user
+	user=$(create_user "Alice" "alice@example.com")
+	process_user "$user"
+}
+
+main "$@"

--- a/gitnexus/test/integration/resolvers/bash.test.ts
+++ b/gitnexus/test/integration/resolvers/bash.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Bash: basic pipeline integration — functions, source imports, calls, variables.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'path';
+import {
+  FIXTURES,
+  getRelationships,
+  getNodesByLabel,
+  runPipelineFromRepo,
+  type PipelineResult,
+} from './helpers.js';
+import { isLanguageAvailable } from '../../../src/core/tree-sitter/parser-loader.js';
+import { SupportedLanguages } from '../../../src/config/supported-languages.js';
+
+const bashAvailable = isLanguageAvailable(SupportedLanguages.Bash);
+
+describe.skipIf(!bashAvailable)('Bash pipeline integration', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'bash-app'), () => {});
+  }, 60000);
+
+  it('detects Bash files', () => {
+    const files = getNodesByLabel(result, 'File');
+    expect(files).toContain('main.sh');
+    expect(files).toContain('utils.sh');
+    expect(files).toContain('service.sh');
+  });
+
+  it('extracts functions', () => {
+    const functions = getNodesByLabel(result, 'Function');
+    expect(functions).toContain('main');
+    expect(functions).toContain('log_message');
+    expect(functions).toContain('format_name');
+    expect(functions).toContain('create_user');
+    expect(functions).toContain('process_user');
+  });
+
+  it('extracts call edges', () => {
+    const calls = getRelationships(result, 'CALLS');
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const callNames = calls.map((c) => c.target);
+    expect(callNames).toContain('create_user');
+  });
+
+  it('extracts source import edges', () => {
+    const imports = getRelationships(result, 'IMPORTS');
+    expect(imports.length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add full tree-sitter-based Bash/shell language support
- Uses tree-sitter-bash@0.23.3 (N-API binding, ABI version 14 — no vendoring needed)
- Minimal but complete extractors: functions, variables, source/dot imports, command calls
- Integration test with 3-file fixture

## Bash Language Traits

| Trait | Implementation |
|-------|---------------|
| Import semantics | `wildcard-leaf` (source brings everything into scope) |
| Export checking | All public (no visibility modifiers in shell) |
| Class constructs | None (shell has no OO) |
| Type annotations | None (dynamically typed — all strings) |
| Functions | `function foo() {}` and `foo() {}` syntax |
| Import resolution | `source file.sh` and `. file.sh` path resolution |

## Changes

### gitnexus-shared (3 files)
- `languages.ts`: Add `Bash = 'bash'` enum member
- `language-detection.ts`: `.sh`/`.bash` extensions + Prism syntax
- `language-classification.ts`: Classify as `experimental`

### gitnexus/src (16 files)
- `tree-sitter-queries.ts`: BASH_QUERIES — functions, source imports, command calls, variable assignments
- `parser-loader.ts`: SOURCES entry
- `languages/bash.ts`: Main provider with shell built-ins
- `languages/index.ts`: Register in providers
- 8 extractor configs (minimal — no classes, no fields, no heritage)
- `export-detection.ts`: bashExportChecker
- `import-resolvers/utils.ts`: `.sh`/`.bash` extensions
- Exhaustive record entries

### Tests (4 files)
- 3-file Bash fixture: utils.sh (library), service.sh (cross-file source), main.sh (entry point)
- Integration test: 4 tests covering files, functions, calls, source imports

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 4 Bash integration tests pass
- [ ] CI passes on upstream