### PR TITLE
feat(scala): add Scala language support

### DIFF
--- a/gitnexus-shared/src/language-detection.ts
+++ b/gitnexus-shared/src/language-detection.ts
@@ -41,6 +41,7 @@ const EXTENSION_MAP: Record<SupportedLanguages, readonly string[]> = {
   [SupportedLanguages.Kotlin]: ['.kt', '.kts'],
   [SupportedLanguages.Swift]: ['.swift'],
   [SupportedLanguages.Dart]: ['.dart'],
+  [SupportedLanguages.Scala]: ['.scala', '.sc'],
   [SupportedLanguages.Vue]: ['.vue'],
   [SupportedLanguages.Cobol]: ['.cbl', '.cob', '.cpy', '.cobol'],
 } satisfies Record<SupportedLanguages, readonly string[]>; // Ensure exhaustiveness
@@ -99,6 +100,7 @@ const SYNTAX_MAP: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Kotlin]: 'kotlin',
   [SupportedLanguages.Swift]: 'swift',
   [SupportedLanguages.Dart]: 'dart',
+  [SupportedLanguages.Scala]: 'scala',
   [SupportedLanguages.Vue]: 'typescript',
   [SupportedLanguages.Cobol]: 'cobol',
 } satisfies Record<SupportedLanguages, string>; // Ensure exhaustiveness

--- a/gitnexus-shared/src/languages.ts
+++ b/gitnexus-shared/src/languages.ts
@@ -20,6 +20,7 @@ export enum SupportedLanguages {
   Swift = 'swift',
   Dart = 'dart',
   Vue = 'vue',
+  Scala = 'scala',
   /** Standalone regex processor — no tree-sitter, no LanguageProvider. */
   Cobol = 'cobol',
 }

--- a/gitnexus-shared/src/scope-resolution/language-classification.ts
+++ b/gitnexus-shared/src/scope-resolution/language-classification.ts
@@ -39,6 +39,7 @@ export const LanguageClassifications: Readonly<Record<SupportedLanguages, Langua
     [SupportedLanguages.Kotlin]: 'production',
     [SupportedLanguages.Swift]: 'production',
     [SupportedLanguages.Dart]: 'production',
+    [SupportedLanguages.Scala]: 'experimental',
     [SupportedLanguages.Vue]: 'experimental',
     [SupportedLanguages.Cobol]: 'experimental',
   };

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -40,6 +40,7 @@
         "tree-sitter-python": "0.23.4",
         "tree-sitter-ruby": "^0.23.1",
         "tree-sitter-rust": "0.23.1",
+        "tree-sitter-scala": "^0.24.0",
         "tree-sitter-typescript": "^0.23.2",
         "uuid": "^14.0.0"
       },
@@ -5188,6 +5189,25 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.23.1.tgz",
       "integrity": "sha512-wrMptzUAfbl3DbNrldZveyNM2CWmRw2VvEo2j/855qQbMMz4dlCF+TBwRN/1FL1S6cYvAEAJaCMesGqhocFJhQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-scala": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-scala/-/tree-sitter-scala-0.24.0.tgz",
+      "integrity": "sha512-vkMuAUrBZ1zZz2XcGDQk18Kz73JkpgaeXzbNVobPke0G35sd9jH32aUxG6OLRKM7et0TbsfqkWf4DeJoGk4K1g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -82,6 +82,7 @@
     "tree-sitter-python": "0.23.4",
     "tree-sitter-ruby": "^0.23.1",
     "tree-sitter-rust": "0.23.1",
+    "tree-sitter-scala": "^0.24.0",
     "tree-sitter-typescript": "^0.23.2",
     "uuid": "^14.0.0"
   },

--- a/gitnexus/src/core/ingestion/call-extractors/configs/scala.ts
+++ b/gitnexus/src/core/ingestion/call-extractors/configs/scala.ts
@@ -1,0 +1,6 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { CallExtractionConfig } from '../../call-types.js';
+
+export const scalaCallConfig: CallExtractionConfig = {
+  language: SupportedLanguages.Scala,
+};

--- a/gitnexus/src/core/ingestion/class-extractors/configs/scala.ts
+++ b/gitnexus/src/core/ingestion/class-extractors/configs/scala.ts
@@ -1,0 +1,33 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { ClassExtractionConfig, ClassLikeNodeLabel } from '../../class-types.js';
+
+export const scalaClassConfig: ClassExtractionConfig = {
+  language: SupportedLanguages.Scala,
+  typeDeclarationNodes: [
+    'class_definition',
+    'object_definition',
+    'trait_definition',
+    'enum_definition',
+  ],
+  fileScopeNodeTypes: ['compilation_unit'],
+  ancestorScopeNodeTypes: ['class_definition', 'object_definition', 'trait_definition'],
+
+  extractName(node) {
+    return node.childForFieldName('name')?.text;
+  },
+
+  extractType(node): ClassLikeNodeLabel | undefined {
+    switch (node.type) {
+      case 'class_definition':
+        return 'Class';
+      case 'trait_definition':
+        return 'Interface';
+      case 'object_definition':
+        return 'Class';
+      case 'enum_definition':
+        return 'Enum';
+      default:
+        return undefined;
+    }
+  },
+};

--- a/gitnexus/src/core/ingestion/export-detection.ts
+++ b/gitnexus/src/core/ingestion/export-detection.ts
@@ -246,3 +246,26 @@ export const rubyExportChecker: ExportChecker = (_node, _name) => true;
 
 /** Dart: public if no leading underscore (convention, same as Python). */
 export const dartExportChecker: ExportChecker = (_node, name) => !name.startsWith('_');
+
+/**
+ * Scala: default visibility is public (like Kotlin).
+ * Only private/protected are non-exported. Walk up to find modifier.
+ */
+export const scalaExportChecker: ExportChecker = (node, _name) => {
+  let current: SyntaxNode | null = node;
+  while (current) {
+    if (current.type === 'modifiers') {
+      const text = current.text;
+      if (text?.includes('private') || text?.includes('protected')) return false;
+    }
+    for (let i = 0; i < (current.childCount ?? 0); i++) {
+      const child = current.child?.(i);
+      if (child?.type === 'modifiers') {
+        const text = child.text;
+        if (text?.includes('private') || text?.includes('protected')) return false;
+      }
+    }
+    current = current.parent;
+  }
+  return true;
+};

--- a/gitnexus/src/core/ingestion/field-extractors/configs/scala.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/configs/scala.ts
@@ -1,0 +1,42 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { FieldExtractionConfig } from '../generic.js';
+import { extractSimpleTypeName } from '../../type-extractors/shared.js';
+
+export const scalaFieldConfig: FieldExtractionConfig = {
+  language: SupportedLanguages.Scala,
+  typeDeclarationNodes: ['class_definition', 'object_definition', 'trait_definition'],
+  fieldNodeTypes: ['val_definition', 'var_definition', 'val_declaration', 'var_declaration'],
+  bodyNodeTypes: ['template_body'],
+  defaultVisibility: 'public',
+
+  extractName(node) {
+    const pattern = node.childForFieldName('pattern');
+    if (pattern?.type === 'identifier') return pattern.text;
+    return undefined;
+  },
+
+  extractType(node) {
+    const typeNode = node.childForFieldName('type');
+    if (typeNode) return extractSimpleTypeName(typeNode) ?? typeNode.text?.trim();
+    return undefined;
+  },
+
+  extractVisibility(node) {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child?.type === 'modifiers') {
+        if (child.text?.includes('private')) return 'private';
+        if (child.text?.includes('protected')) return 'protected';
+      }
+    }
+    return 'public';
+  },
+
+  isStatic(_node) {
+    return false;
+  },
+
+  isReadonly(node) {
+    return node.type === 'val_definition' || node.type === 'val_declaration';
+  },
+};

--- a/gitnexus/src/core/ingestion/heritage-extractors/configs/scala.ts
+++ b/gitnexus/src/core/ingestion/heritage-extractors/configs/scala.ts
@@ -1,0 +1,6 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { HeritageExtractionConfig } from '../../heritage-types.js';
+
+export const scalaHeritageConfig: HeritageExtractionConfig = {
+  language: SupportedLanguages.Scala,
+};

--- a/gitnexus/src/core/ingestion/import-resolvers/configs/scala.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/configs/scala.ts
@@ -1,0 +1,47 @@
+/**
+ * Scala import resolution config.
+ * Reuses JVM wildcard/member import strategy, then standard fallback.
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { ImportResolutionConfig, ImportResolverStrategy } from '../types.js';
+import { createStandardStrategy } from '../standard.js';
+import { resolveJvmWildcard, resolveJvmMemberImport } from '../jvm.js';
+
+export const scalaJvmStrategy: ImportResolverStrategy = (rawImportPath, _filePath, ctx) => {
+  const dotPath = rawImportPath
+    .replace(/\{[^}]*\}/g, '')
+    .trim()
+    .replace(/\._$/, '.*');
+
+  const exts = ['.scala', '.java'];
+
+  if (dotPath.endsWith('.*') || dotPath.endsWith('._')) {
+    const files = resolveJvmWildcard(
+      dotPath,
+      ctx.normalizedFileList,
+      ctx.allFileList,
+      exts,
+      ctx.index,
+    );
+    if (files.length > 0) {
+      const pkgPath = dotPath.slice(0, -2).replace(/\./g, '/');
+      return { kind: 'package', files, dirSuffix: pkgPath };
+    }
+    return null;
+  }
+
+  const resolved = resolveJvmMemberImport(
+    dotPath,
+    ctx.normalizedFileList,
+    ctx.allFileList,
+    exts,
+    ctx.index,
+  );
+  return resolved ? { kind: 'files', files: [resolved] } : null;
+};
+
+export const scalaImportConfig: ImportResolutionConfig = {
+  language: SupportedLanguages.Scala,
+  strategies: [scalaJvmStrategy, createStandardStrategy(SupportedLanguages.Scala)],
+};

--- a/gitnexus/src/core/ingestion/import-resolvers/utils.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/utils.ts
@@ -47,6 +47,9 @@ export const EXTENSIONS = [
   '.swift',
   // Ruby
   '.rb',
+  // Scala
+  '.scala',
+  '.sc',
 ];
 
 /**

--- a/gitnexus/src/core/ingestion/languages/index.ts
+++ b/gitnexus/src/core/ingestion/languages/index.ts
@@ -24,6 +24,7 @@ import { rubyProvider } from './ruby.js';
 import { swiftProvider } from './swift.js';
 import { dartProvider } from './dart.js';
 import { vueProvider } from './vue.js';
+import { scalaProvider } from './scala.js';
 import { cobolProvider } from './cobol.js';
 
 export const providers = {
@@ -41,6 +42,7 @@ export const providers = {
   [SupportedLanguages.Ruby]: rubyProvider,
   [SupportedLanguages.Swift]: swiftProvider,
   [SupportedLanguages.Dart]: dartProvider,
+  [SupportedLanguages.Scala]: scalaProvider,
   [SupportedLanguages.Vue]: vueProvider,
   [SupportedLanguages.Cobol]: cobolProvider,
 } satisfies Record<SupportedLanguages, LanguageProvider>;

--- a/gitnexus/src/core/ingestion/languages/scala.ts
+++ b/gitnexus/src/core/ingestion/languages/scala.ts
@@ -1,0 +1,71 @@
+/**
+ * Scala Language Provider
+ *
+ * Assembles all Scala-specific ingestion capabilities into a single
+ * LanguageProvider, following the Strategy pattern used by the pipeline.
+ *
+ * Key Scala traits:
+ *   - importSemantics: 'named' (explicit imports like Java/Kotlin)
+ *   - JVM package resolution reused from Java
+ *   - class/trait/object as first-class constructs
+ *   - Methods are function_definition inside template_body
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import { createClassExtractor } from '../class-extractors/generic.js';
+import { scalaClassConfig } from '../class-extractors/configs/scala.js';
+import { defineLanguage } from '../language-provider.js';
+import { typeConfig as scalaConfig } from '../type-extractors/scala.js';
+import { scalaExportChecker } from '../export-detection.js';
+import { createImportResolver } from '../import-resolvers/resolver-factory.js';
+import { scalaImportConfig } from '../import-resolvers/configs/scala.js';
+import { SCALA_QUERIES } from '../tree-sitter-queries.js';
+import { createFieldExtractor } from '../field-extractors/generic.js';
+import { scalaFieldConfig } from '../field-extractors/configs/scala.js';
+import { createMethodExtractor } from '../method-extractors/generic.js';
+import { scalaMethodConfig } from '../method-extractors/configs/scala.js';
+import { createVariableExtractor } from '../variable-extractors/generic.js';
+import { scalaVariableConfig } from '../variable-extractors/configs/scala.js';
+import { createCallExtractor } from '../call-extractors/generic.js';
+import { scalaCallConfig } from '../call-extractors/configs/scala.js';
+import { createHeritageExtractor } from '../heritage-extractors/generic.js';
+import { scalaHeritageConfig } from '../heritage-extractors/configs/scala.js';
+
+const BUILT_INS: ReadonlySet<string> = new Set([
+  'println',
+  'print',
+  'require',
+  'assert',
+  'assume',
+  'throw',
+  'sys',
+  'classOf',
+  'isInstanceOf',
+  'asInstanceOf',
+  'toString',
+  'hashCode',
+  'equals',
+  'getClass',
+  'synchronized',
+  'wait',
+  'notify',
+  'notifyAll',
+]);
+
+export const scalaProvider = defineLanguage({
+  id: SupportedLanguages.Scala,
+  extensions: ['.scala', '.sc'],
+  treeSitterQueries: SCALA_QUERIES,
+  typeConfig: scalaConfig,
+  exportChecker: scalaExportChecker,
+  importResolver: createImportResolver(scalaImportConfig),
+  importSemantics: 'named',
+  mroStrategy: 'implements-split',
+  callExtractor: createCallExtractor(scalaCallConfig),
+  fieldExtractor: createFieldExtractor(scalaFieldConfig),
+  methodExtractor: createMethodExtractor(scalaMethodConfig),
+  variableExtractor: createVariableExtractor(scalaVariableConfig),
+  classExtractor: createClassExtractor(scalaClassConfig),
+  heritageExtractor: createHeritageExtractor(scalaHeritageConfig),
+  builtInNames: BUILT_INS,
+});

--- a/gitnexus/src/core/ingestion/languages/scala.ts
+++ b/gitnexus/src/core/ingestion/languages/scala.ts
@@ -55,6 +55,8 @@ const BUILT_INS: ReadonlySet<string> = new Set([
 export const scalaProvider = defineLanguage({
   id: SupportedLanguages.Scala,
   extensions: ['.scala', '.sc'],
+  entryPointPatterns: [/^main$/],
+  astFrameworkPatterns: [],
   treeSitterQueries: SCALA_QUERIES,
   typeConfig: scalaConfig,
   exportChecker: scalaExportChecker,

--- a/gitnexus/src/core/ingestion/method-extractors/configs/scala.ts
+++ b/gitnexus/src/core/ingestion/method-extractors/configs/scala.ts
@@ -1,0 +1,83 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { MethodExtractionConfig, ParameterInfo } from '../../method-types.js';
+import { extractSimpleTypeName } from '../../type-extractors/shared.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+function extractScalaName(node: SyntaxNode): string | undefined {
+  return node.childForFieldName('name')?.text;
+}
+
+function extractScalaReturnType(node: SyntaxNode): string | undefined {
+  const retType = node.childForFieldName('return_type');
+  if (retType) return extractSimpleTypeName(retType) ?? retType.text?.trim();
+  return undefined;
+}
+
+function extractScalaParameters(node: SyntaxNode): ParameterInfo[] {
+  const params: ParameterInfo[] = [];
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child?.type !== 'parameters') continue;
+    for (let j = 0; j < child.namedChildCount; j++) {
+      const param = child.namedChild(j);
+      if (param?.type !== 'parameter') continue;
+      const nameNode = param.childForFieldName('name');
+      const typeNode = param.childForFieldName('type');
+      const typeName = typeNode
+        ? (extractSimpleTypeName(typeNode) ?? typeNode.text?.trim() ?? null)
+        : null;
+      params.push({
+        name: nameNode?.text ?? `_${j}`,
+        type: typeName,
+        rawType: typeNode?.text?.trim() ?? null,
+        isOptional: false,
+        isVariadic: param.text?.includes('*') ?? false,
+      });
+    }
+  }
+  return params;
+}
+
+function extractScalaVisibility(node: SyntaxNode): 'public' | 'private' | 'protected' {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child?.type === 'modifiers') {
+      if (child.text?.includes('private')) return 'private';
+      if (child.text?.includes('protected')) return 'protected';
+    }
+  }
+  return 'public';
+}
+
+export const scalaMethodConfig: MethodExtractionConfig = {
+  language: SupportedLanguages.Scala,
+  typeDeclarationNodes: [
+    'class_definition',
+    'object_definition',
+    'trait_definition',
+    'enum_definition',
+  ],
+  methodNodeTypes: ['function_definition', 'function_declaration'],
+  bodyNodeTypes: ['template_body'],
+
+  extractName: extractScalaName,
+  extractReturnType: extractScalaReturnType,
+  extractParameters: extractScalaParameters,
+  extractVisibility: extractScalaVisibility,
+
+  isStatic(_node) {
+    return false;
+  },
+
+  isAbstract(node) {
+    return node.type === 'function_declaration';
+  },
+
+  isFinal(node) {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child?.type === 'modifiers' && child.text?.includes('final')) return true;
+    }
+    return false;
+  },
+};

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -1373,6 +1373,62 @@ export const DART_QUERIES = `
       (type_identifier) @heritage.trait))) @heritage
 `;
 
+export const SCALA_QUERIES = `
+; Classes
+(class_definition name: (identifier) @name) @definition.class
+
+; Traits
+(trait_definition name: (identifier) @name) @definition.trait
+
+; Objects (companion or standalone)
+(object_definition name: (identifier) @name) @definition.class
+
+; Enums (Scala 3)
+(enum_definition name: (identifier) @name) @definition.enum
+
+; Methods (def inside class/trait/object)
+(function_definition name: (identifier) @name) @definition.method
+
+; Abstract method declarations
+(function_declaration name: (identifier) @name) @definition.method
+
+; Imports — capture the whole declaration (path extracted from text)
+(import_declaration) @import
+
+; Calls — field access: obj.method(...)
+(call_expression
+  function: (field_expression
+    field: (identifier) @call.name)) @call
+
+; Calls — constructor: new Foo(...)
+(instance_expression (type_identifier) @call.name) @call
+
+; Calls — free function (rare in Scala, but possible)
+(call_expression function: (identifier) @call.name) @call
+
+; Val declarations
+(val_definition pattern: (identifier) @name) @definition.const
+
+; Var declarations
+(var_definition pattern: (identifier) @name) @definition.variable
+
+; Heritage — extends
+(class_definition
+  name: (identifier) @heritage.class
+  (extends_clause (type_identifier) @heritage.extends)) @heritage
+
+; Heritage — trait extends trait
+(trait_definition
+  name: (identifier) @heritage.class
+  (extends_clause (type_identifier) @heritage.extends)) @heritage
+
+; Write access: obj.field = value
+(assignment_expression
+  left: (field_expression
+    value: (_) @assignment.receiver
+    field: (identifier) @assignment.property)) @assignment
+`;
+
 import { SupportedLanguages } from 'gitnexus-shared';
 
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
@@ -1390,6 +1446,7 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Ruby]: RUBY_QUERIES,
   [SupportedLanguages.Swift]: SWIFT_QUERIES,
   [SupportedLanguages.Dart]: DART_QUERIES,
+  [SupportedLanguages.Scala]: SCALA_QUERIES,
   [SupportedLanguages.Vue]: TYPESCRIPT_QUERIES, // Vue <script> blocks are parsed as TypeScript
   [SupportedLanguages.Cobol]: '', // Standalone regex processor — no tree-sitter queries
 };

--- a/gitnexus/src/core/ingestion/type-extractors/scala.ts
+++ b/gitnexus/src/core/ingestion/type-extractors/scala.ts
@@ -1,0 +1,68 @@
+import type { SyntaxNode } from '../utils/ast-helpers.js';
+import type {
+  ConstructorBindingScanner,
+  LanguageTypeConfig,
+  ParameterExtractor,
+  TypeBindingExtractor,
+} from './types.js';
+import { extractSimpleTypeName, extractVarName } from './shared.js';
+
+const DECLARATION_NODE_TYPES: ReadonlySet<string> = new Set([
+  'val_definition',
+  'var_definition',
+]);
+
+const extractDeclaration: TypeBindingExtractor = (
+  node: SyntaxNode,
+  env: Map<string, string>,
+): void => {
+  const pattern = node.childForFieldName('pattern');
+  const typeNode = node.childForFieldName('type');
+  if (!pattern || !typeNode) return;
+  const varName = extractVarName(pattern);
+  const typeName = extractSimpleTypeName(typeNode);
+  if (varName && typeName) env.set(varName, typeName);
+};
+
+const extractParameter: ParameterExtractor = (
+  node: SyntaxNode,
+  env: Map<string, string>,
+): void => {
+  if (node.type !== 'parameter' && node.type !== 'class_parameter') return;
+  const nameNode = node.childForFieldName('name');
+  const typeNode = node.childForFieldName('type');
+  if (!nameNode || !typeNode) return;
+  const varName = extractVarName(nameNode);
+  const typeName = extractSimpleTypeName(typeNode);
+  if (varName && typeName) env.set(varName, typeName);
+};
+
+const scanConstructorBinding: ConstructorBindingScanner = (node) => {
+  if (node.type !== 'val_definition') return undefined;
+  const pattern = node.childForFieldName('pattern');
+  const value = node.childForFieldName('value');
+  if (!pattern || !value) return undefined;
+  const varName = extractVarName(pattern);
+  if (!varName) return undefined;
+
+  if (value.type === 'call_expression') {
+    const funcNode = value.childForFieldName('function');
+    if (funcNode) {
+      const calleeName = funcNode.text;
+      if (calleeName) return { varName, calleeName };
+    }
+  }
+  if (value.type === 'instance_expression') {
+    const typeNode = value.namedChildren.find((c: SyntaxNode) => c.type === 'type_identifier');
+    if (typeNode) return { varName, calleeName: typeNode.text };
+  }
+  return undefined;
+};
+
+export const typeConfig: LanguageTypeConfig = {
+  declarationNodeTypes: DECLARATION_NODE_TYPES,
+  forLoopNodeTypes: new Set(['for_expression']),
+  extractDeclaration,
+  extractParameter,
+  scanConstructorBinding,
+};

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -95,6 +95,8 @@ export const FUNCTION_NODE_TYPES = new Set([
   // Dart
   'function_signature',
   'method_signature',
+  // Scala
+  'function_definition',
 ]);
 
 /**
@@ -132,6 +134,10 @@ export const CLASS_CONTAINER_TYPES = new Set([
   // Kotlin
   'object_declaration',
   'companion_object',
+  // Scala
+  'object_definition',
+  'trait_definition',
+  'enum_definition',
 ]);
 
 export const CONTAINER_TYPE_TO_LABEL: Record<string, string> = {
@@ -164,6 +170,9 @@ export const CONTAINER_TYPE_TO_LABEL: Record<string, string> = {
   singleton_class: 'Class', // Ruby: class << self inherits enclosing class name
   object_declaration: 'Class',
   companion_object: 'Class',
+  object_definition: 'Class',
+  trait_definition: 'Trait',
+  enum_definition: 'Enum',
 };
 
 /** Return the first matching ancestor unless a boundary ancestor is reached first. */

--- a/gitnexus/src/core/ingestion/variable-extractors/configs/scala.ts
+++ b/gitnexus/src/core/ingestion/variable-extractors/configs/scala.ts
@@ -1,0 +1,49 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { VariableExtractionConfig, VariableVisibility } from '../../variable-types.js';
+import { extractSimpleTypeName } from '../../type-extractors/shared.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+function extractScalaVarName(node: SyntaxNode): string | undefined {
+  const pattern = node.childForFieldName('pattern');
+  if (pattern?.type === 'identifier') return pattern.text;
+  return undefined;
+}
+
+function extractScalaVarType(node: SyntaxNode): string | undefined {
+  const typeNode = node.childForFieldName('type');
+  if (typeNode) return extractSimpleTypeName(typeNode) ?? typeNode.text?.trim();
+  return undefined;
+}
+
+export const scalaVariableConfig: VariableExtractionConfig = {
+  language: SupportedLanguages.Scala,
+  constNodeTypes: ['val_definition'],
+  staticNodeTypes: [],
+  variableNodeTypes: ['var_definition'],
+
+  extractName: extractScalaVarName,
+  extractType: extractScalaVarType,
+
+  extractVisibility(node): VariableVisibility {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child?.type === 'modifiers') {
+        if (child.text?.includes('private')) return 'private';
+        if (child.text?.includes('protected')) return 'protected';
+      }
+    }
+    return 'public';
+  },
+
+  isConst(node) {
+    return node.type === 'val_definition';
+  },
+
+  isStatic(_node) {
+    return false;
+  },
+
+  isMutable(node) {
+    return node.type === 'var_definition';
+  },
+};

--- a/gitnexus/src/core/tree-sitter/parser-loader.ts
+++ b/gitnexus/src/core/tree-sitter/parser-loader.ts
@@ -153,6 +153,11 @@ const SOURCES: Record<string, GrammarSource> = {
       'Likely cause: native compile failed at install (missing python3/make/g++). ' +
       `See ${ISSUES_URL}/1125.`,
   },
+  [SupportedLanguages.Scala]: {
+    load: () => _require('tree-sitter-scala'),
+    unavailableNote:
+      'Scala parsing requires `tree-sitter-scala`. Check the install and native binding.',
+  },
   [SupportedLanguages.Kotlin]: {
     load: () => _require('tree-sitter-kotlin'),
     optional: true,

--- a/gitnexus/test/fixtures/lang-resolution/scala-app/Main.scala
+++ b/gitnexus/test/fixtures/lang-resolution/scala-app/Main.scala
@@ -1,0 +1,8 @@
+import services.UserService
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val user = UserService.createUser("Alice", "alice@example.com")
+    UserService.process(user)
+  }
+}

--- a/gitnexus/test/fixtures/lang-resolution/scala-app/models/User.scala
+++ b/gitnexus/test/fixtures/lang-resolution/scala-app/models/User.scala
@@ -1,0 +1,15 @@
+package models
+
+trait Greeter {
+  def greet(name: String): String
+}
+
+class User(val name: String, val email: String) extends Greeter {
+  def greet(name: String): String = s"Hello, $name"
+
+  def getEmail: String = email
+}
+
+object User {
+  def create(name: String, email: String): User = new User(name, email)
+}

--- a/gitnexus/test/fixtures/lang-resolution/scala-app/services/UserService.scala
+++ b/gitnexus/test/fixtures/lang-resolution/scala-app/services/UserService.scala
@@ -1,0 +1,14 @@
+package services
+
+import models.User
+
+object UserService {
+  def createUser(name: String, email: String): User = {
+    User.create(name, email)
+  }
+
+  def process(user: User): Unit = {
+    val greeting = user.greet(user.name)
+    println(greeting)
+  }
+}

--- a/gitnexus/test/integration/resolvers/scala.test.ts
+++ b/gitnexus/test/integration/resolvers/scala.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Scala: basic pipeline integration — classes, traits, objects, methods, imports, calls.
+ * Verifies that the Scala language provider correctly parses JVM-style code
+ * with class/trait/object definitions, method extraction, and cross-file calls.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'path';
+import {
+  FIXTURES,
+  getRelationships,
+  getNodesByLabel,
+  runPipelineFromRepo,
+  type PipelineResult,
+} from './helpers.js';
+import { isLanguageAvailable } from '../../../src/core/tree-sitter/parser-loader.js';
+import { SupportedLanguages } from '../../../src/config/supported-languages.js';
+
+const scalaAvailable = isLanguageAvailable(SupportedLanguages.Scala);
+
+describe.skipIf(!scalaAvailable)('Scala pipeline integration', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'scala-app'), () => {});
+  }, 60000);
+
+  it('detects Scala files', () => {
+    const files = getNodesByLabel(result, 'File');
+    expect(files).toContain('Main.scala');
+    expect(files).toContain('User.scala');
+    expect(files).toContain('UserService.scala');
+  });
+
+  it('extracts classes, traits, and objects', () => {
+    const classes = getNodesByLabel(result, 'Class');
+    const interfaces = getNodesByLabel(result, 'Interface');
+    expect(classes).toContain('User');
+    expect(classes).toContain('UserService');
+    expect(classes).toContain('Main');
+    expect(interfaces).toContain('Greeter');
+  });
+
+  it('extracts methods', () => {
+    const methods = getNodesByLabel(result, 'Method');
+    expect(methods).toContain('greet');
+    expect(methods).toContain('getEmail');
+    expect(methods).toContain('create');
+    expect(methods).toContain('createUser');
+    expect(methods).toContain('process');
+    expect(methods).toContain('main');
+  });
+
+  it('extracts call edges', () => {
+    const calls = getRelationships(result, 'CALLS');
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const callNames = calls.map((c) => c.target);
+    expect(callNames).toContain('create');
+  });
+
+  it('extracts cross-file calls', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const callNames = calls.map((c) => c.target);
+    expect(callNames).toContain('createUser');
+    expect(callNames).toContain('process');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Scala as a supported language with full ingestion pipeline support
- Uses `tree-sitter-scala` v0.24.0 (ABI 14, N-API — works directly)
- Includes all extractors: call, class, field, heritage, import, method, variable, type
- Integration test with multi-file fixture

### Depends on

- #1279 (scaffolding: consolidate per-language patterns into LanguageProvider)

### Key Scala traits

- `importSemantics: 'named'` — explicit per-symbol imports
- `mroStrategy: 'implements-split'` — traits use IMPLEMENTS edges
- Entry-point pattern: `main` function

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] Integration test: definitions, imports, call graph resolution
- [ ] Full CI suite